### PR TITLE
add duplicate policies interface

### DIFF
--- a/src/components/policies/duplicate/duplicate-form.tsx
+++ b/src/components/policies/duplicate/duplicate-form.tsx
@@ -1,0 +1,76 @@
+import { useMemo, useCallback } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+
+import { Form } from "@/components/ui/form"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { DialogFooter } from "@/components/ui/dialog"
+
+import { Policy, PolicyFormValues } from "@/types/policies"
+
+import * as Policies from "@/components/policies"
+import DocumentationLink from "@/components/documentation-link"
+import {
+  BaseSchema,
+  getFormValuesFromPolicy,
+} from "@/components/policies/schema"
+
+interface DuplicateFormProps {
+  policy: Policy
+  onSubmit: (values: PolicyFormValues) => void
+  onCancel: () => void
+}
+
+export default function DuplicateForm({
+  policy,
+  onSubmit,
+  onCancel,
+}: DuplicateFormProps) {
+  const defaultValues = useMemo(() => {
+    const values = getFormValuesFromPolicy(policy)
+    return {
+      ...values,
+      name: `${values.name} (dup)`,
+    }
+  }, [policy])
+
+  const form = useForm<PolicyFormValues>({
+    resolver: zodResolver(BaseSchema),
+    mode: "onBlur",
+    reValidateMode: "onChange",
+    defaultValues,
+    shouldUnregister: true,
+  })
+
+  const handleSubmit = useCallback(
+    (values: PolicyFormValues) => onSubmit(values),
+    [onSubmit],
+  )
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmit)}>
+        <ScrollArea type="always" className="h-[calc(100dvh-8rem)]">
+          <Policies.Fields.All />
+
+          <DocumentationLink page="policies" />
+        </ScrollArea>
+
+        <DialogFooter className="flex flex-row gap-4 border-t border-accent p-4">
+          <Button
+            variant="outline"
+            type="button"
+            onClick={onCancel}
+            className="max-w-[12rem] flex-1 basis-1/2"
+          >
+            Cancel
+          </Button>
+          <Button type="submit" className="max-w-[12rem] flex-1 basis-1/2">
+            Create
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
+  )
+}

--- a/src/components/policies/duplicate/index.ts
+++ b/src/components/policies/duplicate/index.ts
@@ -1,0 +1,1 @@
+export { default as Modal } from "./modal"

--- a/src/components/policies/duplicate/modal.tsx
+++ b/src/components/policies/duplicate/modal.tsx
@@ -1,0 +1,197 @@
+import { useState } from "react"
+import { useParams, useNavigate } from "@tanstack/react-router"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+import { toast } from "@/lib/toast"
+
+import { MockPolicies, Policy, PolicyFormValues } from "@/types/policies"
+import DuplicateForm from "./duplicate-form"
+import * as Loading from "@/components/loading"
+import * as keygen from "@/keygen"
+
+interface PoliciesDuplicateModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export default function PoliciesDuplicateModal({
+  open,
+  onOpenChange,
+}: PoliciesDuplicateModalProps) {
+  const { policyId } = useParams({ from: "/$id/app/policies/$policyId" })
+  const policy = MockPolicies.find((p) => p.id === policyId)
+  const [policyLoading] = useState(false)
+  const [policyFetching] = useState(false)
+  const policyError = false
+
+  const navigate = useNavigate()
+
+  const handleCreatePolicy = (values: PolicyFormValues) => {
+    if (!policy) return
+
+    onOpenChange(false)
+
+    const now = new Date().toISOString()
+    const newId = crypto.randomUUID()
+
+    const created: Policy = {
+      ...policy,
+      id: newId,
+      links: { self: `/v1/accounts/{ACCOUNT}/policies/${newId}` },
+      attributes: {
+        ...policy.attributes,
+        name: values.name ?? "",
+        created: now,
+        updated: now,
+        metadata: values.metadata ?? policy.attributes.metadata ?? {},
+        duration: values.duration ?? null,
+        expirationStrategy:
+          values.expirationStrategy ?? policy.attributes.expirationStrategy,
+        expirationBasis:
+          values.expirationBasis ?? policy.attributes.expirationBasis,
+        renewalBasis: values.renewalBasis ?? policy.attributes.renewalBasis,
+        transferStrategy:
+          values.transferStrategy ?? policy.attributes.transferStrategy,
+        strict: values.strict ?? policy.attributes.strict,
+        floating: values.floating ?? policy.attributes.floating,
+        protected: values.protected ?? policy.attributes.protected,
+        usePool: values.usePool ?? policy.attributes.usePool,
+        checkInInterval: values.checkInInterval ?? null,
+        checkInIntervalCount: values.checkInIntervalCount ?? null,
+        maxMachines: values.maxMachines ?? null,
+        maxProcesses: values.maxProcesses ?? null,
+        maxUsers: values.maxUsers ?? null,
+        maxUses: values.maxUses ?? null,
+        maxCores: values.maxCores ?? null,
+        requireCheckIn:
+          values.requireCheckIn ?? policy.attributes.requireCheckIn,
+        requireProductScope:
+          values.requireProductScope ?? policy.attributes.requireProductScope,
+        requirePolicyScope:
+          values.requirePolicyScope ?? policy.attributes.requirePolicyScope,
+        requireMachineScope:
+          values.requireMachineScope ?? policy.attributes.requireMachineScope,
+        requireFingerprintScope:
+          values.requireFingerprintScope ??
+          policy.attributes.requireFingerprintScope,
+        requireComponentsScope:
+          values.requireComponentsScope ??
+          policy.attributes.requireComponentsScope,
+        requireUserScope:
+          values.requireUserScope ?? policy.attributes.requireUserScope,
+        requireChecksumScope:
+          values.requireChecksumScope ?? policy.attributes.requireChecksumScope,
+        requireVersionScope:
+          values.requireVersionScope ?? policy.attributes.requireVersionScope,
+
+        machineUniquenessStrategy:
+          values.machineUniquenessStrategy ??
+          policy.attributes.machineUniquenessStrategy,
+        machineMatchingStrategy:
+          values.machineMatchingStrategy ??
+          policy.attributes.machineMatchingStrategy,
+        componentUniquenessStrategy:
+          values.componentUniquenessStrategy ??
+          policy.attributes.componentUniquenessStrategy,
+        componentMatchingStrategy:
+          values.componentMatchingStrategy ??
+          policy.attributes.componentMatchingStrategy,
+        overageStrategy:
+          values.overageStrategy ?? policy.attributes.overageStrategy,
+
+        requireHeartbeat:
+          values.requireHeartbeat ?? policy.attributes.requireHeartbeat,
+        heartbeatDuration: values.heartbeatDuration ?? null,
+        heartbeatBasis:
+          values.heartbeatBasis ?? policy.attributes.heartbeatBasis,
+        heartbeatCullStrategy:
+          values.heartbeatCullStrategy ??
+          policy.attributes.heartbeatCullStrategy,
+        heartbeatResurrectionStrategy:
+          values.heartbeatResurrectionStrategy ??
+          policy.attributes.heartbeatResurrectionStrategy,
+        machineLeasingStrategy:
+          values.machineLeasingStrategy ??
+          policy.attributes.machineLeasingStrategy,
+        processLeasingStrategy:
+          values.processLeasingStrategy ??
+          policy.attributes.processLeasingStrategy,
+
+        authenticationStrategy:
+          values.authenticationStrategy ??
+          policy.attributes.authenticationStrategy,
+        scheme: values.scheme ?? policy.attributes.scheme ?? null,
+        encrypted: values.encrypted ?? policy.attributes.encrypted,
+      },
+      relationships: {
+        ...policy.relationships,
+        product: {
+          ...policy.relationships.product,
+          data: {
+            type: "products",
+            id: values.product?.id ?? policy.relationships.product?.data?.id!,
+          },
+        },
+        entitlements: {
+          ...policy.relationships.entitlements,
+          data: (values.entitlements?.attach ?? []).map((eid) => ({
+            type: "entitlements",
+            id: eid,
+          })),
+        },
+      },
+    }
+
+    MockPolicies.push(created)
+
+    toast({ message: "Policy created", variant: "success" })
+
+    navigate({
+      to: "/$id/app/policies/$policyId",
+      params: {
+        id: keygen.config.id,
+        policyId: created.id,
+      },
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+        className="min-h-screen min-w-screen rounded-none border-none"
+      >
+        <DialogHeader className="h-fit border-b border-accent p-2">
+          <DialogDescription className="flex h-8 items-center space-x-1 text-xs">
+            Duplicating an existing policy
+          </DialogDescription>
+          <DialogTitle className="sr-only" />
+        </DialogHeader>
+
+        {policyLoading || policyFetching ? (
+          <div className="flex w-full justify-center">
+            <Loading.Dots />
+          </div>
+        ) : policyError ? (
+          <p className="text-center text-sm text-red-500">
+            Failed to load policy.
+          </p>
+        ) : (
+          open && (
+            <DuplicateForm
+              policy={policy!}
+              onSubmit={handleCreatePolicy}
+              onCancel={() => onOpenChange(false)}
+            />
+          )
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/policies/index.ts
+++ b/src/components/policies/index.ts
@@ -8,5 +8,8 @@ export { Create }
 import * as Edit from "./edit"
 export { Edit }
 
+import * as Duplicate from "./duplicate"
+export { Duplicate }
+
 import * as Fields from "./fields"
 export { Fields }

--- a/src/pages/app/policy/details.tsx
+++ b/src/pages/app/policy/details.tsx
@@ -107,6 +107,7 @@ export default function PolicyDetails() {
   const [open, setOpen] = useState({
     edit: false,
     delete: false,
+    duplicate: false,
     attributes: false,
   })
 
@@ -180,6 +181,15 @@ export default function PolicyDetails() {
               <DropdownMenuContent className="mr-4 p-0">
                 <DropdownMenuItem
                   onClick={(e) => {
+                    toggleOpen("duplicate", true)
+                    e.currentTarget.blur()
+                  }}
+                  className="pb-2 text-base"
+                >
+                  Duplicate
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={(e) => {
                     toggleOpen("edit", true)
                     e.currentTarget.blur()
                   }}
@@ -201,6 +211,13 @@ export default function PolicyDetails() {
             </DropdownMenu>
           ) : (
             <div className="flex items-center space-x-2">
+              <Button
+                variant="outline"
+                disabled={policyLoading}
+                onClick={() => toggleOpen("duplicate", true)}
+              >
+                Duplicate
+              </Button>
               <Button
                 variant="outline"
                 disabled={policyLoading}
@@ -717,6 +734,11 @@ export default function PolicyDetails() {
       <Policies.Edit.Modal
         open={open.edit}
         onOpenChange={(value) => toggleOpen("edit", value)}
+      />
+
+      <Policies.Duplicate.Modal
+        open={open.duplicate}
+        onOpenChange={(value) => toggleOpen("duplicate", value)}
       />
 
       <DeleteModal


### PR DESCRIPTION
Adds interface for duplicating policies that behaves similarly to the edit policy form, but with some logic changes to pre-fill fields, and create rather than update.