### PR TITLE
Add table column helper for resources

### DIFF
--- a/src/components/environments/view/list.tsx
+++ b/src/components/environments/view/list.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react"
-import { ColumnDef, createColumnHelper } from "@tanstack/react-table"
 
+import { createResourceColumnHelper } from "@/lib/tables"
 import { Environment } from "@/types/environments"
 
 import { useListEnvironments } from "@/queries/environments"
@@ -17,20 +17,18 @@ export default function EnvironmentsList({
 }: EnvironmentsListProps) {
   const { data: environments = [], isLoading } = useListEnvironments()
 
-  const column = createColumnHelper<Environment>()
-  const columns = useMemo<ColumnDef<Environment, any>[]>(
+  const column = createResourceColumnHelper<Environment>()
+  const columns = useMemo(
     () => [
-      column.accessor((row) => row.attributes.name, {
+      column.id( { header: "ID" }),
+      column.attr("name", {
         header: "Name",
-        id: "attributes.name",
       }),
-      column.accessor((row) => row.attributes.code, {
+      column.attr("code", {
         header: "Code",
-        id: "attributes.code",
       }),
-      column.accessor((row) => row.attributes.isolationStrategy, {
+      column.attr("isolationStrategy", {
         header: "Isolation Strategy",
-        id: "attributes.isolationStrategy",
       }),
     ],
     [],

--- a/src/components/environments/view/list.tsx
+++ b/src/components/environments/view/list.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react"
 
-import { createResourceColumnHelper } from "@/lib/tables"
+import { createTableColumnHelper } from "@/lib/tables"
 import { Environment } from "@/types/environments"
 
 import { useListEnvironments } from "@/queries/environments"
@@ -17,7 +17,7 @@ export default function EnvironmentsList({
 }: EnvironmentsListProps) {
   const { data: environments = [], isLoading } = useListEnvironments()
 
-  const column = createResourceColumnHelper<Environment>()
+  const column = createTableColumnHelper<Environment>()
   const columns = useMemo(
     () => [
       column.id( { header: "ID" }),

--- a/src/components/environments/view/list.tsx
+++ b/src/components/environments/view/list.tsx
@@ -20,7 +20,7 @@ export default function EnvironmentsList({
   const column = createTableColumnHelper<Environment>()
   const columns = useMemo(
     () => [
-      column.id( { header: "ID" }),
+      column.id({ header: "ID" }),
       column.attr("name", {
         header: "Name",
       }),

--- a/src/lib/tables.ts
+++ b/src/lib/tables.ts
@@ -1,0 +1,33 @@
+
+import { ColumnDef, createColumnHelper } from "@tanstack/react-table"
+import { Resource } from "@/types/api"
+
+export function createResourceColumnHelper<T extends Resource<any, any, any>>() {
+  const helper = createColumnHelper<T>()
+
+  return {
+    id(
+      def: Omit<ColumnDef<T, T["id"]>, "accessorKey" | "accessorFn"> = {},
+    ): ColumnDef<T, T["id"]> {
+      return helper.accessor(row => row.id, { id: "id", ...def })
+    },
+    attr<K extends keyof T["attributes"]>(
+      key: K,
+      def: Omit<ColumnDef<T, T["attributes"][K]>, "accessorKey" | "accessorFn"> = {},
+    ): ColumnDef<T, T["attributes"][K]> {
+      return helper.accessor(row => row.attributes[key], {
+        id: `attributes.${String(key)}`,
+        ...def,
+      })
+    },
+    rel<K extends keyof T["relationships"]>(
+      key: K,
+      def: Omit<ColumnDef<T, T["relationships"][K]>, "accessorKey" | "accessorFn"> = {},
+    ): ColumnDef<T, T["relationships"][K]> {
+      return helper.accessor(row => row.relationships[key], {
+        id: `relationships.${String(key)}`,
+        ...def,
+      })
+    },
+  }
+}

--- a/src/lib/tables.ts
+++ b/src/lib/tables.ts
@@ -13,22 +13,28 @@ export function createTableColumnHelper<T extends TableResource>() {
     id(
       def: Omit<ColumnDef<T, T["id"]>, "accessorKey" | "accessorFn"> = {},
     ): ColumnDef<T, T["id"]> {
-      return helper.accessor(row => row.id, { id: "id", ...def })
+      return helper.accessor((row) => row.id, { id: "id", ...def })
     },
     attr<K extends PropertyKey & keyof T["attributes"]>(
       key: K,
-      def: Omit<ColumnDef<T, T["attributes"][K]>, "accessorKey" | "accessorFn"> = {},
+      def: Omit<
+        ColumnDef<T, T["attributes"][K]>,
+        "accessorKey" | "accessorFn"
+      > = {},
     ): ColumnDef<T, T["attributes"][K]> {
-      return helper.accessor(row => row.attributes[key], {
+      return helper.accessor((row) => row.attributes[key], {
         id: `attributes.${String(key)}`,
         ...def,
       })
     },
     rel<K extends PropertyKey & keyof T["relationships"]>(
       key: K,
-      def: Omit<ColumnDef<T, T["relationships"][K]>, "accessorKey" | "accessorFn"> = {},
+      def: Omit<
+        ColumnDef<T, T["relationships"][K]>,
+        "accessorKey" | "accessorFn"
+      > = {},
     ): ColumnDef<T, T["relationships"][K]> {
-      return helper.accessor(row => row.relationships[key], {
+      return helper.accessor((row) => row.relationships[key], {
         id: `relationships.${String(key)}`,
         ...def,
       })

--- a/src/lib/tables.ts
+++ b/src/lib/tables.ts
@@ -1,8 +1,12 @@
-
 import { ColumnDef, createColumnHelper } from "@tanstack/react-table"
-import { Resource } from "@/types/api"
 
-export function createResourceColumnHelper<T extends Resource<any, any, any>>() {
+interface TableResource {
+  id: string
+  attributes: Record<string, unknown>
+  relationships: Record<string, unknown>
+}
+
+export function createResourceColumnHelper<T extends TableResource>() {
   const helper = createColumnHelper<T>()
 
   return {
@@ -11,7 +15,7 @@ export function createResourceColumnHelper<T extends Resource<any, any, any>>() 
     ): ColumnDef<T, T["id"]> {
       return helper.accessor(row => row.id, { id: "id", ...def })
     },
-    attr<K extends keyof T["attributes"]>(
+    attr<K extends string & keyof T["attributes"]>(
       key: K,
       def: Omit<ColumnDef<T, T["attributes"][K]>, "accessorKey" | "accessorFn"> = {},
     ): ColumnDef<T, T["attributes"][K]> {
@@ -20,7 +24,7 @@ export function createResourceColumnHelper<T extends Resource<any, any, any>>() 
         ...def,
       })
     },
-    rel<K extends keyof T["relationships"]>(
+    rel<K extends string & keyof T["relationships"]>(
       key: K,
       def: Omit<ColumnDef<T, T["relationships"][K]>, "accessorKey" | "accessorFn"> = {},
     ): ColumnDef<T, T["relationships"][K]> {

--- a/src/lib/tables.ts
+++ b/src/lib/tables.ts
@@ -6,7 +6,7 @@ interface TableResource {
   relationships: Record<string, unknown>
 }
 
-export function createResourceColumnHelper<T extends TableResource>() {
+export function createTableColumnHelper<T extends TableResource>() {
   const helper = createColumnHelper<T>()
 
   return {

--- a/src/lib/tables.ts
+++ b/src/lib/tables.ts
@@ -2,8 +2,8 @@ import { ColumnDef, createColumnHelper } from "@tanstack/react-table"
 
 interface TableResource {
   id: string
-  attributes: Record<string, unknown>
-  relationships: Record<string, unknown>
+  attributes: Record<PropertyKey, unknown>
+  relationships: Record<PropertyKey, unknown>
 }
 
 export function createTableColumnHelper<T extends TableResource>() {
@@ -15,7 +15,7 @@ export function createTableColumnHelper<T extends TableResource>() {
     ): ColumnDef<T, T["id"]> {
       return helper.accessor(row => row.id, { id: "id", ...def })
     },
-    attr<K extends string & keyof T["attributes"]>(
+    attr<K extends PropertyKey & keyof T["attributes"]>(
       key: K,
       def: Omit<ColumnDef<T, T["attributes"][K]>, "accessorKey" | "accessorFn"> = {},
     ): ColumnDef<T, T["attributes"][K]> {
@@ -24,7 +24,7 @@ export function createTableColumnHelper<T extends TableResource>() {
         ...def,
       })
     },
-    rel<K extends string & keyof T["relationships"]>(
+    rel<K extends PropertyKey & keyof T["relationships"]>(
       key: K,
       def: Omit<ColumnDef<T, T["relationships"][K]>, "accessorKey" | "accessorFn"> = {},
     ): ColumnDef<T, T["relationships"][K]> {

--- a/src/pages/app/entitlement/list.tsx
+++ b/src/pages/app/entitlement/list.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
-import { ColumnDef, createColumnHelper } from "@tanstack/react-table"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
 
+import { createResourceColumnHelper } from "@/lib/tables"
 import { Entitlement } from "@/types/entitlements"
 
 import { useListEntitlements } from "@/queries/entitlements"
@@ -24,33 +24,28 @@ export default function PoliciesList() {
 
   const [open, setOpen] = useState(false)
 
-  const column = createColumnHelper<Entitlement>()
-  const columns = useMemo<ColumnDef<Entitlement, any>[]>(
+  const column = createResourceColumnHelper<Entitlement>()
+  const columns = useMemo(
     () => [
-      column.accessor((row) => row.id, {
-        id: "attributes.id",
+      column.id({
         header: "ID",
         cell: (info) => <ClipboardButton value={info.getValue()} />,
       }),
-      column.accessor((row) => row.attributes.name, {
+      column.attr("name", {
         header: "Name",
-        id: "attributes.name",
       }),
-      column.accessor((row) => row.attributes.code, {
+      column.attr("code", {
         header: "Code",
-        id: "attributes.code",
       }),
-      column.accessor((row) => row.attributes.created, {
-        id: "attributes.created",
+      column.attr("created", {
+        sortingFn: "datetime",
         header: "Created",
         cell: (info) => new Date(info.getValue()).toLocaleDateString(),
-        sortingFn: "datetime",
       }),
-      column.accessor((row) => row.attributes.updated, {
-        id: "attributes.updated",
+      column.attr("updated", {
+        sortingFn: "datetime",
         header: "Updated",
         cell: (info) => new Date(info.getValue()).toLocaleDateString(),
-        sortingFn: "datetime",
       }),
     ],
     [],

--- a/src/pages/app/entitlement/list.tsx
+++ b/src/pages/app/entitlement/list.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "@tanstack/react-router"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
 
-import { createResourceColumnHelper } from "@/lib/tables"
+import { createTableColumnHelper } from "@/lib/tables"
 import { Entitlement } from "@/types/entitlements"
 
 import { useListEntitlements } from "@/queries/entitlements"
@@ -24,7 +24,8 @@ export default function PoliciesList() {
 
   const [open, setOpen] = useState(false)
 
-  const column = createResourceColumnHelper<Entitlement>()
+  // TODO(ezekg) extract all this out into e.g. useEntitlementTableColumns so it can be used elsewhere?
+  const column = createTableColumnHelper<Entitlement>()
   const columns = useMemo(
     () => [
       column.id({

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
-import { ColumnDef, createColumnHelper } from "@tanstack/react-table"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
 
+import { createResourceColumnHelper } from "@/lib/tables"
 import { Policy, MockPolicies } from "@/types/policies"
 
 // import { useListPolicies } from "@/queries/policies"
@@ -31,44 +31,36 @@ export default function PoliciesList() {
     return map
   }, [products])
 
-  const column = createColumnHelper<Policy>()
-  const columns = useMemo<ColumnDef<Policy, any>[]>(
+  const column = createResourceColumnHelper<Policy>()
+  const columns = useMemo(
     () => [
-      column.accessor((row) => row.id, {
-        id: "attributes.id",
+      column.id({
         header: "ID",
         cell: (info) => <ClipboardButton value={info.getValue()} />,
       }),
-      column.accessor((row) => row.attributes.name, {
+      column.attr("name", {
         header: "Name",
-        id: "attributes.name",
       }),
-      column.accessor(
-        (row) => {
-          const productId = row.relationships.product?.data?.id ?? ""
-          return productNameById.get(productId) ?? ""
+      column.rel("product", {
+        sortingFn: "alphanumeric",
+        header: "Product",
+        cell: (info) => {
+          const productId = info.getValue()?.data?.id ?? ""
+
+          return productNameById.get(productId) ?? (
+            <span className="text-muted-foreground">--</span>
+          )
         },
-        {
-          id: "relationships.product",
-          header: "Product",
-          cell: (info) =>
-            info.getValue() || (
-              <span className="text-muted-foreground">--</span>
-            ),
-          sortingFn: "alphanumeric",
-        },
-      ),
-      column.accessor((row) => row.attributes.created, {
-        id: "attributes.created",
+      }),
+      column.attr("created", {
+        sortingFn: "datetime",
         header: "Created",
         cell: (info) => new Date(info.getValue()).toLocaleDateString(),
-        sortingFn: "datetime",
       }),
-      column.accessor((row) => row.attributes.updated, {
-        id: "attributes.updated",
+      column.attr("updated", {
+        sortingFn: "datetime",
         header: "Updated",
         cell: (info) => new Date(info.getValue()).toLocaleDateString(),
-        sortingFn: "datetime",
       }),
     ],
     [productNameById],

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -47,8 +47,10 @@ export default function PoliciesList() {
         cell: (info) => {
           const productId = info.getValue()?.data?.id ?? ""
 
-          return productNameById.get(productId) ?? (
-            <span className="text-muted-foreground">--</span>
+          return (
+            productNameById.get(productId) ?? (
+              <span className="text-muted-foreground">--</span>
+            )
           )
         },
       }),

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "@tanstack/react-router"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
 
-import { createResourceColumnHelper } from "@/lib/tables"
+import { createTableColumnHelper } from "@/lib/tables"
 import { Policy, MockPolicies } from "@/types/policies"
 
 // import { useListPolicies } from "@/queries/policies"
@@ -31,7 +31,7 @@ export default function PoliciesList() {
     return map
   }, [products])
 
-  const column = createResourceColumnHelper<Policy>()
+  const column = createTableColumnHelper<Policy>()
   const columns = useMemo(
     () => [
       column.id({

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "@tanstack/react-router"
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
 
-import { createResourceColumnHelper } from "@/lib/tables"
+import { createTableColumnHelper } from "@/lib/tables"
 import { Product, } from "@/types/products"
 
 import { useListProducts } from "@/queries/products"
@@ -22,7 +22,7 @@ export default function ProductsList() {
 
   const [open, setOpen] = useState(false)
 
-  const column = createResourceColumnHelper<Product>()
+  const column = createTableColumnHelper<Product>()
   const columns = useMemo(
     () => [
       column.id({

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
 
 import { createTableColumnHelper } from "@/lib/tables"
-import { Product, } from "@/types/products"
+import { Product } from "@/types/products"
 
 import { useListProducts } from "@/queries/products"
 

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
-import { ColumnDef, createColumnHelper } from "@tanstack/react-table"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
 
-import { Product } from "@/types/products"
+import { createResourceColumnHelper } from "@/lib/tables"
+import { Product, } from "@/types/products"
 
 import { useListProducts } from "@/queries/products"
 
@@ -22,24 +22,20 @@ export default function ProductsList() {
 
   const [open, setOpen] = useState(false)
 
-  const column = createColumnHelper<Product>()
-  const columns = useMemo<ColumnDef<Product, any>[]>(
+  const column = createResourceColumnHelper<Product>()
+  const columns = useMemo(
     () => [
-      column.accessor((row) => row.id, {
-        id: "attributes.id",
+      column.id({
         header: "ID",
         cell: (info) => <ClipboardButton value={info.getValue()} />,
       }),
-      column.accessor((row) => row.attributes.name, {
+      column.attr("name", {
         header: "Name",
-        id: "attributes.name",
       }),
-      column.accessor((row) => row.attributes.code, {
+      column.attr("code", {
         header: "Code",
-        id: "attributes.code",
       }),
-      column.accessor((row) => row.attributes.url, {
-        id: "attributes.url",
+      column.attr("url", {
         header: "URL",
         cell: (info) => (
           <a
@@ -52,14 +48,12 @@ export default function ProductsList() {
           </a>
         ),
       }),
-      column.accessor((row) => row.attributes.created, {
-        id: "attributes.created",
+      column.attr("created", {
         header: "Created",
         cell: (info) => new Date(info.getValue()).toLocaleDateString(),
         sortingFn: "datetime",
       }),
-      column.accessor((row) => row.attributes.updated, {
-        id: "attributes.updated",
+      column.attr("updated", {
         header: "Updated",
         cell: (info) => new Date(info.getValue()).toLocaleDateString(),
         sortingFn: "datetime",

--- a/src/types/entitlements.ts
+++ b/src/types/entitlements.ts
@@ -24,7 +24,7 @@ export enum EntitlementView {
   DETAILS = "details",
 }
 
-export interface EntitlementAttributes {
+export type EntitlementAttributes = {
   name: string
   code: string
   metadata: Record<string, unknown>

--- a/src/types/entitlements.ts
+++ b/src/types/entitlements.ts
@@ -27,7 +27,7 @@ export enum EntitlementView {
 export interface EntitlementAttributes {
   name: string
   code: string
-  metadata: Record<string, any>
+  metadata: Record<string, unknown>
   created: string
   updated: string
 }

--- a/src/types/environments.ts
+++ b/src/types/environments.ts
@@ -49,3 +49,4 @@ export type EnvironmentsListResponse = APIResponse<Environment[]>
 
 export type CreateEnvironmentPayload = Writable<EnvironmentAttributes>
 export type UpdateEnvironmentPayload = Partial<Writable<EnvironmentAttributes>>
+

--- a/src/types/environments.ts
+++ b/src/types/environments.ts
@@ -26,7 +26,7 @@ export enum IsolationStrategy {
   SHARED = "SHARED",
 }
 
-export interface EnvironmentAttributes {
+export type EnvironmentAttributes = {
   name: string
   code: string
   isolationStrategy: IsolationStrategy

--- a/src/types/policies.ts
+++ b/src/types/policies.ts
@@ -162,7 +162,7 @@ export interface PolicyAttributes {
   processLeasingStrategy: ProcessLeasingStrategy
   overageStrategy: OverageStrategy
 
-  metadata: Record<string, any>
+  metadata: Record<string, unknown>
   created: string
   updated: string
 }
@@ -217,7 +217,7 @@ export interface PolicyInput {
 
   authenticationStrategy?: AuthenticationStrategy | null
 
-  metadata?: Record<string, any>
+  metadata?: Record<string, unknown>
 }
 
 export enum TimingTemplates {

--- a/src/types/policies.ts
+++ b/src/types/policies.ts
@@ -111,7 +111,7 @@ export enum TransferStrategy {
   RESET_EXPIRY = "RESET_EXPIRY",
 }
 
-export interface PolicyAttributes {
+export type PolicyAttributes = {
   name: string
   duration: number | null
   strict: boolean

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -28,7 +28,7 @@ export enum DistributionStrategy {
   CLOSED = "CLOSED",
 }
 
-export interface ProductAttributes {
+export type ProductAttributes = {
   name: string
   code: string
   distributionStrategy: DistributionStrategy

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -35,7 +35,7 @@ export interface ProductAttributes {
   url: string
   platforms: string[]
   permissions: string[]
-  metadata: Record<string, any>
+  metadata: Record<string, unknown>
   created: string
   updated: string
 }


### PR DESCRIPTION
Fixes the `any` type lint errors in our Tanstack Table usage via introducing a resource-aware column helper, i.e. `helper.id()` for accessing the ID, `helper.attr()` for accessing attributes, and `helper.rel()` for accessing relationships. This new helper correctly infers types according to the accessed resource field.