### PR TITLE
Fix trademark wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ pnpm run test
 ## License
 
 Portal is licensed under the [Apache 2.0][alv2] license. "Keygen" and related
-marks are trademarks of Keygen LLC, and therefore, use of them is not allowed
-in forked repositories.
+marks are trademarks of Keygen LLC, and therefore, these marks may not be used
+in derivative forks intended for redistribution.
 
 ## Contributing
 


### PR DESCRIPTION
Adjusts wording to make it clear that use of the trademarks in "forks" is allowed under certain circumstances, e.g. to contribute or to mirror, but use of the trademarks in derivative works is never allowed.