### PR TITLE
Refactor older forms with field headers

### DIFF
--- a/src/components/entitlements/create/attributes-form.tsx
+++ b/src/components/entitlements/create/attributes-form.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/form"
 
 import * as Forms from "@/forms"
+import { EntitlementAttributeDescriptions } from "@/types/entitlements"
 
 import * as Field from "@/components/field"
 import * as Loading from "@/components/loading"
@@ -92,7 +93,7 @@ export default function AttributesForm({
                       <FormItem>
                         <Field.Header
                           label="Code"
-                          tooltip="This can be used to lookup the entitlement by a human-readable identifier."
+                          tooltip={EntitlementAttributeDescriptions.code}
                         >
                           <FormControl>
                             <Input
@@ -125,9 +126,7 @@ export default function AttributesForm({
                           label="Metadata"
                           variant="stacking"
                           optional
-                          tooltip="Store arbitrary key/value data on the
-                                  entitlement for book keeping purposes,
-                                  supplemental entitlement data, etc."
+                          tooltip={EntitlementAttributeDescriptions.metadata}
                         >
                           <FormControl>
                             <KeyValueInput<Forms.Entitlements.BaseValues> name="metadata" />

--- a/src/components/entitlements/edit/edit-form.tsx
+++ b/src/components/entitlements/edit/edit-form.tsx
@@ -16,7 +16,10 @@ import {
 } from "@/components/ui/form"
 
 import * as Forms from "@/forms"
-import { Entitlement } from "@/types/entitlements"
+import {
+  Entitlement,
+  EntitlementAttributeDescriptions,
+} from "@/types/entitlements"
 
 import * as Field from "@/components/field"
 import * as Loading from "@/components/loading"
@@ -94,7 +97,7 @@ export default function EditForm({
                       <FormItem>
                         <Field.Header
                           label="Code"
-                          tooltip="This can be used to lookup the entitlement by a human-readable identifier."
+                          tooltip={EntitlementAttributeDescriptions.code}
                         >
                           <FormControl>
                             <Input
@@ -127,9 +130,7 @@ export default function EditForm({
                           label="Metadata"
                           variant="stacking"
                           optional
-                          tooltip="Store arbitrary key/value data on the
-								  entitlement for book keeping purposes,
-								  supplemental entitlement data, etc."
+                          tooltip={EntitlementAttributeDescriptions.metadata}
                         >
                           <FormControl>
                             <KeyValueInput<Forms.Entitlements.BaseValues> name="metadata" />

--- a/src/components/environments/create/attributes-form.tsx
+++ b/src/components/environments/create/attributes-form.tsx
@@ -10,28 +10,17 @@ import {
   Form,
   FormField,
   FormItem,
-  FormLabel,
   FormControl,
   FormMessage,
 } from "@/components/ui/form"
-import {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-} from "@/components/ui/tooltip"
-import {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-} from "@/components/ui/popover"
-
-import { Info } from "lucide-react"
 
 import * as Forms from "@/forms"
-import { IsolationStrategy } from "@/types/environments"
+import {
+  IsolationStrategy,
+  EnvironmentAttributeDescriptions,
+} from "@/types/environments"
 
-import { useMobile } from "@/hooks/use-mobile"
-
+import * as Field from "@/components/field"
 import * as Loading from "@/components/loading"
 import SectionCard from "@/components/section-card"
 import DocumentationLink from "@/components/documentation-link"
@@ -51,8 +40,6 @@ export default function AttributesForm({
   onSubmit,
   onCancel,
 }: AttributesFormProps) {
-  const isMobile = useMobile()
-
   const form = useForm<Forms.Environments.AttributesValues>({
     resolver: zodResolver(Forms.Environments.AttributesSchema),
     mode: "onChange",
@@ -104,40 +91,22 @@ export default function AttributesForm({
                 name="code"
                 render={({ field }) => (
                   <FormItem>
-                    <div className="flex items-center gap-2">
-                      <FormLabel>Code</FormLabel>
-                      {isMobile ? (
-                        <Popover>
-                          <PopoverTrigger onClick={(e) => e.stopPropagation()}>
-                            <Info className="size-5 text-content-subdued" />
-                          </PopoverTrigger>
-                          <PopoverContent className="ml-2 max-w-64 bg-background-4 text-content-muted">
-                            The unique code for the environment. The code cannot
-                            collide with any environments that already exist.
-                          </PopoverContent>
-                        </Popover>
-                      ) : (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Info className="size-4 pt-0.5 text-content-subdued" />
-                          </TooltipTrigger>
-                          <TooltipContent className="max-w-80 bg-background-4 text-content-muted">
-                            The unique code for the environment. The code cannot
-                            collide with any environments that already exist.
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
-                    </div>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        placeholder="e.g. sandbox"
-                        disabled={loading}
-                        onChange={(e) => {
-                          field.onChange(e)
-                        }}
-                      />
-                    </FormControl>
+                    <Field.Header
+                      label="Code"
+                      tooltip={EnvironmentAttributeDescriptions.code}
+                      variant="stacking"
+                    >
+                      <FormControl>
+                        <Input
+                          {...field}
+                          placeholder="e.g. sandbox"
+                          disabled={loading}
+                          onChange={(e) => {
+                            field.onChange(e)
+                          }}
+                        />
+                      </FormControl>
+                    </Field.Header>
                     <FormMessage>{error || ""}</FormMessage>
                   </FormItem>
                 )}

--- a/src/components/environments/create/strategy-form.tsx
+++ b/src/components/environments/create/strategy-form.tsx
@@ -22,7 +22,11 @@ import { GlobeLock, Globe, Info } from "lucide-react"
 import { useMobile } from "@/hooks/use-mobile"
 
 import * as Forms from "@/forms"
-import { IsolationStrategy } from "@/types/environments"
+import {
+  EnvironmentAttributeDescriptions,
+  IsolationStrategy,
+  IsolationStrategyDescriptions,
+} from "@/types/environments"
 
 import { CardSelector, CardOption } from "@/components/card-selector"
 import DocumentationLink from "@/components/documentation-link"
@@ -54,15 +58,13 @@ export default function StrategyForm({
       value: IsolationStrategy.Isolated,
       label: "Isolated",
       icon: <GlobeLock className="size-6 text-content-subdued md:size-5" />,
-      tooltip:
-        "The environment will be isolated from all other resources in other environments.",
+      tooltip: IsolationStrategyDescriptions[IsolationStrategy.Isolated],
     },
     {
       value: IsolationStrategy.Shared,
       label: "Shared",
       icon: <Globe className="size-6 text-content-subdued md:size-5" />,
-      tooltip:
-        "The environment will be shared with the global environment. Resources in the global environment will be available as read-only resources.",
+      tooltip: IsolationStrategyDescriptions[IsolationStrategy.Shared],
     },
   ]
 
@@ -88,8 +90,7 @@ export default function StrategyForm({
                     <Info className="size-5 text-content-subdued" />
                   </PopoverTrigger>
                   <PopoverContent className="mr-2 max-w-60 bg-background-4 text-content-muted">
-                    The strategy used for isolating the environment from other
-                    environments.
+                    {EnvironmentAttributeDescriptions.isolationStrategy}
                   </PopoverContent>
                 </Popover>
               ) : (
@@ -98,8 +99,7 @@ export default function StrategyForm({
                     <Info className="size-4 pt-0.5 text-content-subdued" />
                   </TooltipTrigger>
                   <TooltipContent className="max-w-60 bg-background-4 text-content-muted">
-                    The strategy used for isolating the environment from other
-                    environments.
+                    {EnvironmentAttributeDescriptions.isolationStrategy}
                   </TooltipContent>
                 </Tooltip>
               )}

--- a/src/components/environments/edit/edit-form.tsx
+++ b/src/components/environments/edit/edit-form.tsx
@@ -14,7 +14,6 @@ import {
   FormItem,
   FormControl,
   FormMessage,
-  FormLabel,
 } from "@/components/ui/form"
 import {
   Tooltip,
@@ -27,13 +26,17 @@ import {
   PopoverContent,
 } from "@/components/ui/popover"
 
-import { Info, TriangleAlert } from "lucide-react"
+import { TriangleAlert } from "lucide-react"
 
 import * as Forms from "@/forms"
-import { Environment } from "@/types/environments"
+import {
+  Environment,
+  EnvironmentAttributeDescriptions,
+} from "@/types/environments"
 
 import { useMobile } from "@/hooks/use-mobile"
 
+import * as Field from "@/components/field"
 import * as Loading from "@/components/loading"
 import DocumentationLink from "@/components/documentation-link"
 
@@ -109,94 +112,71 @@ export default function EnvironmentEditForm({
                   name="code"
                   render={({ field }) => (
                     <FormItem>
-                      <div className="flex items-center gap-2">
-                        <FormLabel className="">Code</FormLabel>
-                        {isMobile ? (
-                          <Popover>
-                            <PopoverTrigger
-                              onClick={(e) => e.stopPropagation()}
-                            >
-                              <Info className="size-5 text-content-subdued" />
-                            </PopoverTrigger>
-                            <PopoverContent className="ml-2 max-w-64 bg-background-4 text-content-muted">
-                              The unique code for the environment. The code
-                              cannot collide with any environments that already
-                              exist.
-                            </PopoverContent>
-                          </Popover>
-                        ) : (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Info className="size-4 text-content-subdued" />
-                            </TooltipTrigger>
-                            <TooltipContent className="max-w-80 bg-background-4 text-content-muted">
-                              The unique code for the environment. The code
-                              cannot collide with any environments that already
-                              exist.
-                            </TooltipContent>
-                          </Tooltip>
-                        )}
-                      </div>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          placeholder="e.g. qa"
-                          disabled={loading}
-                          onChange={(e) => {
-                            field.onChange(e)
-                          }}
-                        />
-                      </FormControl>
+                      <Field.Header
+                        label="Code"
+                        tooltip={EnvironmentAttributeDescriptions.code}
+                        variant="stacking"
+                      >
+                        <FormControl>
+                          <Input
+                            {...field}
+                            placeholder="e.g. sandbox"
+                            disabled={loading}
+                            onChange={(e) => {
+                              field.onChange(e)
+                            }}
+                          />
+                        </FormControl>
+                      </Field.Header>
                       <FormMessage>{error || ""}</FormMessage>
-                      {isMobile ? (
-                        <Popover>
-                          <PopoverTrigger
-                            type="button"
-                            className="flex items-center gap-1 text-sm text-brand-amber"
-                          >
-                            <TriangleAlert className="size-5 flex-none pt-0.5" />
-
-                            <span className="text-brand-amber underline">
-                              Note on updating environment codes
-                            </span>
-                          </PopoverTrigger>
-                          <PopoverContent className="max-w-88 bg-background-4 text-content-muted">
-                            <span>
-                              Renaming an environment code that is already in
-                              use may cause requests using the old environment
-                              code to fail.
-                            </span>
-                            <Separator className="my-2 bg-content-subdued" />
-                            <span>
-                              We suggest making sure the existing code is no
-                              longer in use before changing it, to prevent
-                              unintended request failures.
-                            </span>
-                          </PopoverContent>
-                        </Popover>
-                      ) : (
-                        <Tooltip>
-                          <TooltipTrigger
-                            type="button"
-                            className="flex items-center gap-1 text-xs text-brand-amber"
-                          >
-                            <TriangleAlert className="size-3 flex-none" />
-                            <p>
-                              Renaming an environment code that is already in
-                              use may cause requests using the old environment
-                              code to fail.
-                            </p>
-                          </TooltipTrigger>
-                          <TooltipContent className="max-w-88 bg-background-4 text-content-muted">
-                            We suggest making sure the existing code is no
-                            longer in use before changing it, to prevent
-                            unintended request failures.
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
                     </FormItem>
                   )}
                 />
+
+                {isMobile ? (
+                  <Popover>
+                    <PopoverTrigger
+                      type="button"
+                      className="flex items-center gap-1 text-sm text-brand-amber"
+                    >
+                      <TriangleAlert className="size-5 flex-none pt-0.5" />
+
+                      <span className="text-brand-amber underline">
+                        Note on updating environment codes
+                      </span>
+                    </PopoverTrigger>
+                    <PopoverContent className="max-w-88 bg-background-4 text-content-muted">
+                      <span>
+                        Renaming an environment code that is already in use may
+                        cause requests using the old environment code to fail.
+                      </span>
+                      <Separator className="my-2 bg-content-subdued" />
+                      <span>
+                        We suggest making sure the existing code is no longer in
+                        use before changing it, to prevent unintended request
+                        failures.
+                      </span>
+                    </PopoverContent>
+                  </Popover>
+                ) : (
+                  <Tooltip>
+                    <TooltipTrigger
+                      type="button"
+                      className="flex items-center gap-1 text-xs text-brand-amber"
+                    >
+                      <TriangleAlert className="size-3 flex-none" />
+                      <p>
+                        Renaming an environment code that is already in use may
+                        cause requests using the old environment code to fail.
+                      </p>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-88 bg-background-4 text-content-muted">
+                      We suggest making sure the existing code is no longer in
+                      use before changing it, to prevent unintended request
+                      failures.
+                    </TooltipContent>
+                  </Tooltip>
+                )}
               </CardContent>
             </Card>
           </div>

--- a/src/components/products/create/attributes-form.tsx
+++ b/src/components/products/create/attributes-form.tsx
@@ -11,28 +11,18 @@ import {
   Form,
   FormField,
   FormItem,
-  FormLabel,
   FormControl,
   FormMessage,
 } from "@/components/ui/form"
-import {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-} from "@/components/ui/tooltip"
-import {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-} from "@/components/ui/popover"
-
-import { Info } from "lucide-react"
 
 import * as Forms from "@/forms"
-import { KnownPlatforms, Permissions } from "@/types/products"
+import {
+  KnownPlatforms,
+  Permissions,
+  ProductAttributeDescriptions,
+} from "@/types/products"
 
-import { useMobile } from "@/hooks/use-mobile"
-
+import * as Field from "@/components/field"
 import * as Loading from "@/components/loading"
 import TagInput from "@/components/tag-input"
 import MultiSelect from "@/components/multi-select"
@@ -53,8 +43,6 @@ export default function AttributesForm({
   onSubmit,
   onCancel,
 }: AttributesFormProps) {
-  const isMobile = useMobile()
-
   const form = useForm<Forms.Products.AttributesValues>({
     resolver: zodResolver(Forms.Products.AttributesSchema),
     mode: "onChange",
@@ -112,48 +100,22 @@ export default function AttributesForm({
                     name="code"
                     render={({ field }) => (
                       <FormItem>
-                        <div className="flex items-center justify-between gap-2">
-                          <div className="flex items-center gap-2">
-                            <FormLabel>Code</FormLabel>
-
-                            {isMobile ? (
-                              <Popover>
-                                <PopoverTrigger
-                                  onClick={(e) => e.stopPropagation()}
-                                >
-                                  <Info className="size-5 text-content-subdued" />
-                                </PopoverTrigger>
-                                <PopoverContent className="ml-2 max-w-64 bg-background-4 text-content-muted">
-                                  This can be used to lookup the product by a
-                                  human-readable identifier.
-                                </PopoverContent>
-                              </Popover>
-                            ) : (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Info className="size-4 pt-0.5 text-content-subdued" />
-                                </TooltipTrigger>
-                                <TooltipContent className="max-w-80 bg-background-4 text-content-muted">
-                                  This can be used to lookup the product by a
-                                  human-readable identifier.
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
-                          </div>
-                          <span className="text-xs text-content-subdued">
-                            Optional
-                          </span>
-                        </div>
-                        <FormControl>
-                          <Input
-                            {...field}
-                            placeholder="example"
-                            disabled={loading}
-                            onChange={(e) => {
-                              field.onChange(e)
-                            }}
-                          />
-                        </FormControl>
+                        <Field.Header
+                          label="Code"
+                          tooltip={ProductAttributeDescriptions.code}
+                          variant="stacking"
+                        >
+                          <FormControl>
+                            <Input
+                              {...field}
+                              placeholder="example"
+                              disabled={loading}
+                              onChange={(e) => {
+                                field.onChange(e)
+                              }}
+                            />
+                          </FormControl>
+                        </Field.Header>
                         <FormMessage>{error || ""}</FormMessage>
                       </FormItem>
                     )}
@@ -164,22 +126,23 @@ export default function AttributesForm({
                     name="url"
                     render={({ field }) => (
                       <FormItem>
-                        <div className="flex items-center justify-between gap-2">
-                          <FormLabel>URL</FormLabel>
-                          <span className="text-xs text-content-subdued">
-                            Optional
-                          </span>
-                        </div>
-                        <FormControl>
-                          <Input
-                            {...field}
-                            placeholder="https://example.com"
-                            disabled={loading}
-                            onChange={(e) => {
-                              field.onChange(e)
-                            }}
-                          />
-                        </FormControl>
+                        <Field.Header
+                          label="URL"
+                          tooltip={ProductAttributeDescriptions.url}
+                          variant="stacking"
+                          optional
+                        >
+                          <FormControl>
+                            <Input
+                              {...field}
+                              placeholder="https://example.com"
+                              disabled={loading}
+                              onChange={(e) => {
+                                field.onChange(e)
+                              }}
+                            />
+                          </FormControl>
+                        </Field.Header>
                         <FormMessage>{error || ""}</FormMessage>
                       </FormItem>
                     )}
@@ -190,18 +153,19 @@ export default function AttributesForm({
                     name="platforms"
                     render={() => (
                       <FormItem>
-                        <div className="flex items-center justify-between gap-2">
-                          <FormLabel>Platforms</FormLabel>
-                          <span className="text-xs text-content-subdued">
-                            Optional
-                          </span>
-                        </div>
-                        <TagInput
-                          name="platforms"
-                          placeholder=""
-                          options={KnownPlatforms}
-                          disabled={loading}
-                        />
+                        <Field.Header
+                          label="Platforms"
+                          tooltip={ProductAttributeDescriptions.platforms}
+                          variant="stacking"
+                          optional
+                        >
+                          <TagInput
+                            name="platforms"
+                            placeholder=""
+                            options={KnownPlatforms}
+                            disabled={loading}
+                          />
+                        </Field.Header>
                         <FormMessage>{error || ""}</FormMessage>
                       </FormItem>
                     )}
@@ -216,43 +180,24 @@ export default function AttributesForm({
                     name="permissions"
                     render={({ field }) => (
                       <FormItem>
-                        <div className="flex items-center gap-2">
-                          <FormLabel>Permissions</FormLabel>
-                          {isMobile ? (
-                            <Popover>
-                              <PopoverTrigger
-                                onClick={(e) => e.stopPropagation()}
-                              >
-                                <Info className="size-5 text-content-subdued" />
-                              </PopoverTrigger>
-                              <PopoverContent className="ml-2 max-w-72 bg-background-4 text-content-muted">
-                                The permissions for the product. Leave blank to
-                                use defaults.
-                              </PopoverContent>
-                            </Popover>
-                          ) : (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Info className="size-4 pt-0.5 text-content-subdued" />
-                              </TooltipTrigger>
-                              <TooltipContent className="max-w-52 bg-background-4 text-content-muted">
-                                The permissions for the product. Leave blank to
-                                use defaults.
-                              </TooltipContent>
-                            </Tooltip>
-                          )}
-                        </div>
-                        <MultiSelect
-                          value={field.value ?? []}
-                          onChange={field.onChange}
-                          options={Permissions.map((p) => ({
-                            label: p === "*" ? "*" : p,
-                            value: p,
-                          }))}
-                          wildcard="*"
-                          placeholder=""
-                          disabled={loading}
-                        />
+                        <Field.Header
+                          label="Permissions"
+                          tooltip={ProductAttributeDescriptions.permissions}
+                          variant="stacking"
+                        >
+                          <MultiSelect
+                            value={field.value ?? []}
+                            onChange={field.onChange}
+                            options={Permissions.map((p) => ({
+                              label: p === "*" ? "*" : p,
+                              value: p,
+                            }))}
+                            wildcard="*"
+                            placeholder=""
+                            disabled={loading}
+                          />
+                        </Field.Header>
+
                         <FormMessage>{error || ""}</FormMessage>
                       </FormItem>
                     )}
@@ -263,46 +208,19 @@ export default function AttributesForm({
                     name="metadata"
                     render={() => (
                       <FormItem>
-                        <div className="flex items-center justify-between gap-2">
-                          <div className="flex items-center gap-2">
-                            <FormLabel>Metadata</FormLabel>
-
-                            {isMobile ? (
-                              <Popover>
-                                <PopoverTrigger
-                                  onClick={(e) => e.stopPropagation()}
-                                >
-                                  <Info className="size-5 text-content-subdued" />
-                                </PopoverTrigger>
-                                <PopoverContent className="ml-2 max-w-64 bg-background-4 text-content-muted">
-                                  Store arbitrary key/value data on the product
-                                  for book keeping purposes, additional product
-                                  info, etc.
-                                </PopoverContent>
-                              </Popover>
-                            ) : (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Info className="size-4 pt-0.5 text-content-subdued" />
-                                </TooltipTrigger>
-                                <TooltipContent className="max-w-80 bg-background-4 text-content-muted">
-                                  Store arbitrary key/value data on the product
-                                  for book keeping purposes, additional product
-                                  info, etc.
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
-                          </div>
-                          <span className="text-xs text-content-subdued">
-                            Optional
-                          </span>
-                        </div>
-                        <FormControl>
-                          <KeyValueInput<Forms.Products.AttributesValues>
-                            name="metadata"
-                            disabled={loading}
-                          />
-                        </FormControl>
+                        <Field.Header
+                          label="Metadata"
+                          tooltip={ProductAttributeDescriptions.metadata}
+                          variant="stacking"
+                          optional
+                        >
+                          <FormControl>
+                            <KeyValueInput<Forms.Products.AttributesValues>
+                              name="metadata"
+                              disabled={loading}
+                            />
+                          </FormControl>
+                        </Field.Header>
                         <FormMessage>{error || ""}</FormMessage>
                       </FormItem>
                     )}

--- a/src/components/products/create/strategy-form.tsx
+++ b/src/components/products/create/strategy-form.tsx
@@ -22,7 +22,11 @@ import { Award, Unlock, Lock, Info } from "lucide-react"
 import { useMobile } from "@/hooks/use-mobile"
 
 import * as Forms from "@/forms"
-import { DistributionStrategy } from "@/types/products"
+import {
+  DistributionStrategy,
+  DistributionStrategyDescriptions,
+  ProductAttributeDescriptions,
+} from "@/types/products"
 
 import DocumentationLink from "@/components/documentation-link"
 import { CardSelector, CardOption } from "@/components/card-selector"
@@ -54,22 +58,19 @@ export default function StrategyForm({
       value: DistributionStrategy.Licensed,
       label: "Licensed",
       icon: <Award className="size-6 text-content-subdued md:size-5" />,
-      tooltip:
-        "Only licensed users, with a valid license, can access releases and release artifacts. API authentication is required.",
+      tooltip: DistributionStrategyDescriptions[DistributionStrategy.Licensed],
     },
     {
       value: DistributionStrategy.Open,
       label: "Open",
       icon: <Unlock className="size-6 text-content-subdued md:size-5" />,
-      tooltip:
-        "Anybody can access releases. No API authentication required, so this is a great option for public downloads, open-source projects, or freemium products.",
+      tooltip: DistributionStrategyDescriptions[DistributionStrategy.Open],
     },
     {
       value: DistributionStrategy.Closed,
       label: "Closed",
       icon: <Lock className="size-6 text-content-subdued md:size-5" />,
-      tooltip:
-        "Only admins can access releases. Download links must be generated server-side. API authentication is required.",
+      tooltip: DistributionStrategyDescriptions[DistributionStrategy.Closed],
     },
   ]
 
@@ -95,7 +96,7 @@ export default function StrategyForm({
                     <Info className="size-5 text-content-subdued" />
                   </PopoverTrigger>
                   <PopoverContent className="mr-2 max-w-60 bg-background-4 text-content-muted">
-                    The distribution strategy for releases.
+                    {ProductAttributeDescriptions.distributionStrategy}
                   </PopoverContent>
                 </Popover>
               ) : (
@@ -104,7 +105,7 @@ export default function StrategyForm({
                     <Info className="size-4 pt-0.5 text-content-subdued" />
                   </TooltipTrigger>
                   <TooltipContent className="max-w-60 bg-background-4 text-content-muted">
-                    The distribution strategy for releases.
+                    {ProductAttributeDescriptions.distributionStrategy}
                   </TooltipContent>
                 </Tooltip>
               )}

--- a/src/components/products/edit/edit-form.tsx
+++ b/src/components/products/edit/edit-form.tsx
@@ -16,20 +16,9 @@ import {
   Form,
   FormField,
   FormItem,
-  FormLabel,
   FormControl,
   FormMessage,
 } from "@/components/ui/form"
-import {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-} from "@/components/ui/tooltip"
-import {
-  Popover,
-  PopoverTrigger,
-  PopoverContent,
-} from "@/components/ui/popover"
 import {
   Select,
   SelectTrigger,
@@ -44,7 +33,7 @@ import {
   BreadcrumbPage,
 } from "@/components/ui/breadcrumb"
 
-import { Info, Award, Lock, Unlock } from "lucide-react"
+import { Award, Lock, Unlock } from "lucide-react"
 
 import * as Forms from "@/forms"
 import {
@@ -52,10 +41,10 @@ import {
   KnownPlatforms,
   Permissions,
   DistributionStrategy,
+  ProductAttributeDescriptions,
 } from "@/types/products"
 
-import { useMobile } from "@/hooks/use-mobile"
-
+import * as Field from "@/components/field"
 import * as Loading from "@/components/loading"
 import TagInput from "@/components/tag-input"
 import MultiSelect from "@/components/multi-select"
@@ -77,8 +66,6 @@ export default function EditForm({
   onSubmit,
   onCancel,
 }: EditFormProps) {
-  const isMobile = useMobile()
-
   const form = useForm<Forms.Products.BaseValues>({
     resolver: zodResolver(Forms.Products.BaseSchema),
     mode: "onBlur",
@@ -176,42 +163,22 @@ export default function EditForm({
                       name="code"
                       render={({ field }) => (
                         <FormItem>
-                          <div className="flex items-center gap-2">
-                            <FormLabel>Code</FormLabel>
-                            {isMobile ? (
-                              <Popover>
-                                <PopoverTrigger
-                                  onClick={(e) => e.stopPropagation()}
-                                >
-                                  <Info className="size-5 text-content-subdued" />
-                                </PopoverTrigger>
-                                <PopoverContent className="ml-2 max-w-64 bg-background-4 text-content-muted">
-                                  This can be used to lookup the product by a
-                                  human-readable identifier.
-                                </PopoverContent>
-                              </Popover>
-                            ) : (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Info className="size-4 pt-0.5 text-content-subdued" />
-                                </TooltipTrigger>
-                                <TooltipContent className="max-w-80 bg-background-4 text-content-muted">
-                                  This can be used to lookup the product by a
-                                  human-readable identifier.
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
-                          </div>
-                          <FormControl>
-                            <Input
-                              {...field}
-                              placeholder="example"
-                              disabled={loading}
-                              onChange={(e) => {
-                                field.onChange(e)
-                              }}
-                            />
-                          </FormControl>
+                          <Field.Header
+                            label="Code"
+                            tooltip={ProductAttributeDescriptions.code}
+                            variant="stacking"
+                          >
+                            <FormControl>
+                              <Input
+                                {...field}
+                                placeholder="example"
+                                disabled={loading}
+                                onChange={(e) => {
+                                  field.onChange(e)
+                                }}
+                              />
+                            </FormControl>
+                          </Field.Header>
                           <FormMessage />
                         </FormItem>
                       )}
@@ -222,22 +189,23 @@ export default function EditForm({
                       name="url"
                       render={({ field }) => (
                         <FormItem>
-                          <div className="flex items-center justify-between gap-2">
-                            <FormLabel>URL</FormLabel>
-                            <span className="text-xs text-content-subdued">
-                              Optional
-                            </span>
-                          </div>
-                          <FormControl>
-                            <Input
-                              {...field}
-                              placeholder="https://example.com"
-                              disabled={loading}
-                              onChange={(e) => {
-                                field.onChange(e)
-                              }}
-                            />
-                          </FormControl>
+                          <Field.Header
+                            label="URL"
+                            tooltip={ProductAttributeDescriptions.url}
+                            variant="stacking"
+                            optional
+                          >
+                            <FormControl>
+                              <Input
+                                {...field}
+                                placeholder="https://example.com"
+                                disabled={loading}
+                                onChange={(e) => {
+                                  field.onChange(e)
+                                }}
+                              />
+                            </FormControl>
+                          </Field.Header>
                           <FormMessage />
                         </FormItem>
                       )}
@@ -248,57 +216,41 @@ export default function EditForm({
                       name="distributionStrategy"
                       render={({ field }) => (
                         <FormItem>
-                          <div className="flex items-center gap-2">
-                            <FormLabel>Distribution Strategy</FormLabel>
-                            {isMobile ? (
-                              <Popover>
-                                <PopoverTrigger
-                                  onClick={(e) => e.stopPropagation()}
-                                >
-                                  <Info className="size-5 text-content-subdued" />
-                                </PopoverTrigger>
-                                <PopoverContent className="ml-2 max-w-64 bg-background-4 text-content-muted">
-                                  The distribution strategy for releases.
-                                </PopoverContent>
-                              </Popover>
-                            ) : (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Info className="size-4 pt-0.5 text-content-subdued" />
-                                </TooltipTrigger>
-                                <TooltipContent className="max-w-80 bg-background-4 text-content-muted">
-                                  The distribution strategy for releases.
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
-                          </div>
-
-                          <Select
-                            value={field.value}
-                            disabled={loading}
-                            onValueChange={(value) => {
-                              field.onChange(value as DistributionStrategy)
-                            }}
+                          <Field.Header
+                            label="Distribution Strategy"
+                            tooltip={
+                              ProductAttributeDescriptions.distributionStrategy
+                            }
+                            variant="stacking"
                           >
-                            <FormControl>
-                              <SelectTrigger className="w-full">
-                                <SelectValue />
-                              </SelectTrigger>
-                            </FormControl>
+                            <Select
+                              value={field.value}
+                              disabled={loading}
+                              onValueChange={(value) => {
+                                field.onChange(value as DistributionStrategy)
+                              }}
+                            >
+                              <FormControl>
+                                <SelectTrigger className="w-full">
+                                  <SelectValue />
+                                </SelectTrigger>
+                              </FormControl>
 
-                            <SelectContent>
-                              <SelectItem value={DistributionStrategy.Licensed}>
-                                Licensed
-                              </SelectItem>
-                              <SelectItem value={DistributionStrategy.Open}>
-                                Open
-                              </SelectItem>
-                              <SelectItem value={DistributionStrategy.Closed}>
-                                Closed
-                              </SelectItem>
-                            </SelectContent>
-                          </Select>
-
+                              <SelectContent>
+                                <SelectItem
+                                  value={DistributionStrategy.Licensed}
+                                >
+                                  Licensed
+                                </SelectItem>
+                                <SelectItem value={DistributionStrategy.Open}>
+                                  Open
+                                </SelectItem>
+                                <SelectItem value={DistributionStrategy.Closed}>
+                                  Closed
+                                </SelectItem>
+                              </SelectContent>
+                            </Select>
+                          </Field.Header>
                           <FormMessage />
                         </FormItem>
                       )}
@@ -309,17 +261,19 @@ export default function EditForm({
                       name="platforms"
                       render={() => (
                         <FormItem>
-                          <div className="flex items-center justify-between gap-2">
-                            <FormLabel>Platforms</FormLabel>
-                            <span className="text-xs text-content-subdued">
-                              Optional
-                            </span>
-                          </div>
-                          <TagInput
-                            name="platforms"
-                            placeholder=""
-                            options={KnownPlatforms}
-                          />
+                          <Field.Header
+                            label="Platforms"
+                            tooltip={ProductAttributeDescriptions.platforms}
+                            variant="stacking"
+                            optional
+                          >
+                            <TagInput
+                              name="platforms"
+                              placeholder=""
+                              options={KnownPlatforms}
+                              disabled={loading}
+                            />
+                          </Field.Header>
                           <FormMessage />
                         </FormItem>
                       )}
@@ -334,43 +288,24 @@ export default function EditForm({
                       name="permissions"
                       render={({ field }) => (
                         <FormItem>
-                          <div className="flex items-center gap-2">
-                            <FormLabel>Permissions</FormLabel>
-                            {isMobile ? (
-                              <Popover>
-                                <PopoverTrigger
-                                  onClick={(e) => e.stopPropagation()}
-                                >
-                                  <Info className="size-5 text-content-subdued" />
-                                </PopoverTrigger>
-                                <PopoverContent className="ml-2 max-w-72 bg-background-4 text-content-muted">
-                                  The permissions for the product. Leave blank
-                                  to use defaults.
-                                </PopoverContent>
-                              </Popover>
-                            ) : (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Info className="size-4 pt-0.5 text-content-subdued" />
-                                </TooltipTrigger>
-                                <TooltipContent className="max-w-52 bg-background-4 text-content-muted">
-                                  The permissions for the product. Leave blank
-                                  to use defaults.
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
-                          </div>
-                          <MultiSelect
-                            value={field.value ?? []}
-                            onChange={field.onChange}
-                            options={Permissions.map((p) => ({
-                              label: p === "*" ? "*" : p,
-                              value: p,
-                            }))}
-                            wildcard="*"
-                            placeholder=""
-                            disabled={loading}
-                          />
+                          <Field.Header
+                            label="Permissions"
+                            tooltip={ProductAttributeDescriptions.permissions}
+                            variant="stacking"
+                          >
+                            <MultiSelect
+                              value={field.value ?? []}
+                              onChange={field.onChange}
+                              options={Permissions.map((p) => ({
+                                label: p === "*" ? "*" : p,
+                                value: p,
+                              }))}
+                              wildcard="*"
+                              placeholder=""
+                              disabled={loading}
+                            />
+                          </Field.Header>
+
                           <FormMessage />
                         </FormItem>
                       )}
@@ -381,46 +316,19 @@ export default function EditForm({
                       name="metadata"
                       render={() => (
                         <FormItem>
-                          <div className="flex items-center justify-between gap-2">
-                            <div className="flex items-center gap-2">
-                              <FormLabel>Metadata</FormLabel>
-
-                              {isMobile ? (
-                                <Popover>
-                                  <PopoverTrigger
-                                    onClick={(e) => e.stopPropagation()}
-                                  >
-                                    <Info className="size-5 text-content-subdued" />
-                                  </PopoverTrigger>
-                                  <PopoverContent className="ml-2 max-w-64 bg-background-4 text-content-muted">
-                                    Store arbitrary key/value data on the
-                                    product for book keeping purposes,
-                                    additional product info, etc.
-                                  </PopoverContent>
-                                </Popover>
-                              ) : (
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <Info className="size-4 pt-0.5 text-content-subdued" />
-                                  </TooltipTrigger>
-                                  <TooltipContent className="max-w-80 bg-background-4 text-content-muted">
-                                    Store arbitrary key/value data on the
-                                    product for book keeping purposes,
-                                    additional product info, etc.
-                                  </TooltipContent>
-                                </Tooltip>
-                              )}
-                            </div>
-                            <span className="text-xs text-content-subdued">
-                              Optional
-                            </span>
-                          </div>
-                          <FormControl>
-                            <KeyValueInput<Forms.Products.BaseValues>
-                              name="metadata"
-                              disabled={loading}
-                            />
-                          </FormControl>
+                          <Field.Header
+                            label="Metadata"
+                            tooltip={ProductAttributeDescriptions.metadata}
+                            variant="stacking"
+                            optional
+                          >
+                            <FormControl>
+                              <KeyValueInput<Forms.Products.AttributesValues>
+                                name="metadata"
+                                disabled={loading}
+                              />
+                            </FormControl>
+                          </Field.Header>
                           <FormMessage />
                         </FormItem>
                       )}

--- a/src/types/entitlements.ts
+++ b/src/types/entitlements.ts
@@ -35,3 +35,12 @@ export type Entitlement = Resource<
 
 export type EntitlementResponse = APIResponse<Entitlement>
 export type EntitlementListResponse = APIResponse<Entitlement[]>
+
+export const EntitlementAttributeDescriptions: Readonly<
+  Record<keyof Omit<EntitlementAttributes, "created" | "updated">, string>
+> = {
+  name: "Entitlement name.",
+  code: "This can be used to lookup the entitlement by a human-readable identifier.",
+  metadata:
+    "Store arbitrary key/value data on the entitlement for book keeping purposes, supplemental entitlement data, etc.",
+} as const

--- a/src/types/environments.ts
+++ b/src/types/environments.ts
@@ -40,3 +40,21 @@ export type Environment = Resource<
 
 export type EnvironmentResponse = APIResponse<Environment>
 export type EnvironmentsListResponse = APIResponse<Environment[]>
+
+export const EnvironmentAttributeDescriptions: Readonly<
+  Record<keyof Omit<EnvironmentAttributes, "created" | "updated">, string>
+> = {
+  name: "Environment name.",
+  code: "The unique code for the environment. The code cannot collide with any environments that already exist.",
+  isolationStrategy:
+    "The isolation strategy used for isolating the environment from other environments.",
+} as const
+
+export const IsolationStrategyDescriptions: Readonly<
+  Record<IsolationStrategy, string>
+> = {
+  [IsolationStrategy.Isolated]:
+    "The environment will be isolated from all other resources in other environments.",
+  [IsolationStrategy.Shared]:
+    "The environment will be shared with the global environment. Resources in the global environment will be available as read-only resources.",
+} as const

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -51,6 +51,30 @@ export type Product = Resource<
 export type ProductResponse = APIResponse<Product>
 export type ProductsListResponse = APIResponse<Product[]>
 
+export const ProductAttributeDescriptions: Readonly<
+  Record<keyof Omit<ProductAttributes, "created" | "updated">, string>
+> = {
+  name: "Product name.",
+  code: "This can be used to lookup the product by a human-readable identifier.",
+  distributionStrategy: "The distribution strategy for releases.",
+  url: "",
+  platforms: "",
+  permissions: "The permissions for the product. Leave blank to use defaults.",
+  metadata:
+    "Store arbitrary key/value data on the product for book keeping purposes, additional product info, etc.",
+} as const
+
+export const DistributionStrategyDescriptions: Readonly<
+  Record<DistributionStrategy, string>
+> = {
+  [DistributionStrategy.Licensed]:
+    "Only licensed users, with a valid license, can access releases and release artifacts. API authentication is required.",
+  [DistributionStrategy.Open]:
+    "Anybody can access releases. No API authentication required, so this is a great option for public downloads, open-source projects, or freemium products.",
+  [DistributionStrategy.Closed]:
+    "Only admins can access releases. Download links must be generated server-side. API authentication is required.",
+} as const
+
 export const Permissions = [
   "account.read",
   "arch.read",


### PR DESCRIPTION
Standardizes older fields in `products` and `environments` forms with `<Field.Header />` components as used in newer forms. Also refactors/standardizes form field descriptions for the aforementioned resources as well as `entitlements`.

This will also close #37.