### PR TITLE
Add class name props to components

### DIFF
--- a/src/components/attribute/value.tsx
+++ b/src/components/attribute/value.tsx
@@ -2,7 +2,7 @@ import { formatDuration } from "date-fns"
 
 import TooltipBadge from "@/components/tooltip-badge"
 
-import { secondsToParts, labelize } from "@/lib/utils"
+import { cn, secondsToParts, labelize } from "@/lib/utils"
 
 export type AttributeType =
   | "duration"
@@ -19,6 +19,7 @@ type AttributeValueProps = {
   tooltip?: string
   emptyLabel?: string
   forceDisabled?: boolean
+  className?: string
 }
 
 export default function AttributeValue({
@@ -27,6 +28,7 @@ export default function AttributeValue({
   tooltip,
   emptyLabel = "Not set",
   forceDisabled,
+  className,
 }: AttributeValueProps): React.ReactElement {
   const isUnset = raw === null || raw === ""
 
@@ -44,7 +46,12 @@ export default function AttributeValue({
     const formatted = JSON.stringify(raw, null, 2)
 
     return (
-      <pre className="max-h-64 overflow-auto rounded border p-3 font-mono text-xs whitespace-pre-wrap">
+      <pre
+        className={cn(
+          "max-h-64 overflow-auto rounded border p-3 font-mono text-xs whitespace-pre-wrap",
+          className,
+        )}
+      >
         {formatted}
       </pre>
     )
@@ -88,5 +95,12 @@ export default function AttributeValue({
         ? "disabled"
         : "default"
 
-  return <TooltipBadge value={value} variant={variant} tooltip={tooltip!} />
+  return (
+    <TooltipBadge
+      value={value}
+      variant={variant}
+      tooltip={tooltip!}
+      className={className}
+    />
+  )
 }

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -27,6 +27,8 @@ import {
   ChevronsUpDown,
 } from "lucide-react"
 
+import { cn } from "@/lib/utils"
+
 import { useMobile } from "@/hooks/use-mobile"
 
 import { TableColumns, TableResource } from "@/lib/tables"
@@ -38,6 +40,7 @@ export type DataTableProps<T extends TableResource> = {
   hideOnMobile?: string[]
   pageSize?: number
   includePagination?: boolean
+  className?: string
 }
 
 export default function DataTable<T extends TableResource>({
@@ -47,6 +50,7 @@ export default function DataTable<T extends TableResource>({
   hideOnMobile = [],
   pageSize = 10,
   includePagination = true,
+  className,
 }: DataTableProps<T>): React.ReactElement {
   const isMobile = useMobile()
   const [sorting, setSorting] = useState<SortingState>([])
@@ -73,7 +77,7 @@ export default function DataTable<T extends TableResource>({
   })
 
   return (
-    <div className="px-4">
+    <div className={cn("px-4", className)}>
       <Table>
         <TableHeader>
           {table.getHeaderGroups().map((group) => (

--- a/src/components/delete-modal.tsx
+++ b/src/components/delete-modal.tsx
@@ -18,6 +18,7 @@ interface DeleteModalProps {
   disabled?: boolean
   onClose: () => void
   onDelete: () => void
+  className?: string
 }
 
 export default function DeleteModal({
@@ -27,10 +28,11 @@ export default function DeleteModal({
   disabled,
   onClose,
   onDelete,
+  className,
 }: DeleteModalProps) {
   return (
     <AlertDialog open={open} onOpenChange={onClose}>
-      <AlertDialogContent>
+      <AlertDialogContent className={className}>
         <AlertDialogHeader className="text-start">
           <AlertDialogTitle>{title}</AlertDialogTitle>
           <AlertDialogDescription>{description}</AlertDialogDescription>

--- a/src/components/documentation-link.tsx
+++ b/src/components/documentation-link.tsx
@@ -1,5 +1,7 @@
 import { Button } from "@/components/ui/button"
 
+import { cn } from "@/lib/utils"
+
 type DocumentationPage =
   | ""
   | "environments"
@@ -17,6 +19,7 @@ interface DocumentationLinkProps {
   page?: DocumentationPage
   section?: string
   message?: string
+  className?: string
   children?: React.ReactNode
 }
 
@@ -24,10 +27,16 @@ export default function DocumentationLink({
   page = "",
   section = "",
   message = "",
+  className,
   children,
 }: DocumentationLinkProps): React.ReactElement {
   return (
-    <p className="mx-6 my-4 hidden flex-wrap items-center gap-1 text-sm text-content-subdued md:flex">
+    <p
+      className={cn(
+        "mx-6 my-4 hidden flex-wrap items-center gap-1 text-sm text-content-subdued md:flex",
+        className,
+      )}
+    >
       {message || `To learn more about ${page || "Keygen"}, see the `}
       <Button asChild variant="link" size="link">
         <a

--- a/src/components/key-value-input.tsx
+++ b/src/components/key-value-input.tsx
@@ -6,6 +6,8 @@ import { Button } from "@/components/ui/button"
 
 import { X } from "lucide-react"
 
+import { cn } from "@/lib/utils"
+
 type Pair = { id: string; key: string; value: string }
 
 interface KeyValueInputProps<TFormValues extends FieldValues> {
@@ -14,6 +16,7 @@ interface KeyValueInputProps<TFormValues extends FieldValues> {
   keyPlaceholder?: string
   valuePlaceholder?: string
   disabled?: boolean
+  className?: string
 }
 
 export default function KeyValueInput<
@@ -24,6 +27,7 @@ export default function KeyValueInput<
   keyPlaceholder = "Key",
   valuePlaceholder = "Value",
   disabled,
+  className,
 }: KeyValueInputProps<TFormValues>): React.ReactElement {
   const { field } = useController<TFormValues, FieldPath<TFormValues>>({ name })
 
@@ -98,7 +102,7 @@ export default function KeyValueInput<
   const canAdd = rows.every(({ key, value }) => key.trim() && value.trim())
 
   return (
-    <div className="space-y-2">
+    <div className={cn("space-y-2", className)}>
       {rows.length === 0 ? (
         <Button
           id="key-value-add"

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -27,6 +27,7 @@ interface MultiSelectProps {
   wildcard?: string
   placeholder?: string
   disabled?: boolean
+  className?: string
 }
 
 export default function MultiSelect({
@@ -36,6 +37,7 @@ export default function MultiSelect({
   wildcard,
   placeholder = "Choose...",
   disabled,
+  className,
 }: MultiSelectProps) {
   const selected = value ?? []
   const [query, setQuery] = useState("")
@@ -103,6 +105,7 @@ export default function MultiSelect({
           className={cn(
             "max-h-48 overflow-y-auto rounded-md border border-accent transition-colors duration-300 focus-within:border-content-subdued",
             "data-[state=open]:border-content-subdued [&_[data-radix-scroll-area-thumb]]:bg-content-muted",
+            className,
           )}
         >
           <div className="flex min-h-9 w-full flex-wrap items-center gap-x-2 gap-y-2 p-2 text-sm">

--- a/src/components/nullable-select.tsx
+++ b/src/components/nullable-select.tsx
@@ -7,7 +7,6 @@ import {
 } from "@/components/ui/select"
 
 import { cn } from "@/lib/utils"
-import React from "react"
 
 const CLEAR = "__CLEAR__" as const
 

--- a/src/components/tag-input.tsx
+++ b/src/components/tag-input.tsx
@@ -23,6 +23,7 @@ interface TagInputProps {
   placeholder?: string
   delimiters?: string[]
   disabled?: boolean
+  className?: string
 }
 
 export default function TagInput({
@@ -31,6 +32,7 @@ export default function TagInput({
   placeholder = "Add item...",
   delimiters = ["Enter", "Tab", ","],
   disabled,
+  className,
 }: TagInputProps) {
   const { watch, setValue } = useFormContext()
   const tags = useMemo(() => (watch(name) as string[]) ?? [], [watch, name])
@@ -93,6 +95,7 @@ export default function TagInput({
           className={cn(
             "flex min-h-9 w-full flex-wrap gap-x-2 gap-y-2 rounded-md border p-2 text-sm transition-colors duration-300 focus-within:border-content-subdued",
             "data-[state=open]:border-content-subdued [&_[data-radix-scroll-area-thumb]]:bg-content-muted",
+            className,
           )}
         >
           {tags.map((tag) => (


### PR DESCRIPTION
Adds/standardizes class names to all custom components across the code base. Some components were missing this.

Closes #40.