### PR TITLE
Add disabled field tooltips

### DIFF
--- a/src/components/nullable-select.tsx
+++ b/src/components/nullable-select.tsx
@@ -5,6 +5,11 @@ import {
   SelectContent,
   SelectTrigger,
 } from "@/components/ui/select"
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip"
 
 import { cn } from "@/lib/utils"
 
@@ -18,6 +23,7 @@ type NullableSelectProps<T extends string> = {
   placeholder?: string
   className?: string
   disabled?: boolean
+  disabledTooltip?: string
   children: React.ReactNode
 }
 
@@ -29,21 +35,37 @@ export default function NullableSelect<T extends string>({
   placeholder = "Select one...",
   className,
   disabled = false,
+  disabledTooltip,
   children,
 }: NullableSelectProps<T>): React.ReactElement {
   const rendered = (value ?? "") as string
+
+  const trigger = (
+    <SelectTrigger
+      className={cn("w-full", invalid && "!border-destructive", className)}
+      disabled={disabled}
+    >
+      <SelectValue placeholder={placeholder} />
+    </SelectTrigger>
+  )
 
   return (
     <Select
       value={rendered}
       onValueChange={(v) => onChange(v === CLEAR || v === "" ? null : (v as T))}
     >
-      <SelectTrigger
-        className={cn("w-full", invalid && "!border-destructive", className)}
-        disabled={disabled}
-      >
-        <SelectValue placeholder={placeholder} />
-      </SelectTrigger>
+      {disabled && disabledTooltip ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span tabIndex={0}>{trigger}</span>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-64 bg-background-4 text-pretty text-content-muted">
+            {disabledTooltip}
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        trigger
+      )}
       <SelectContent>
         <SelectItem className="text-content-subdued" value={CLEAR}>
           {clearLabel}

--- a/src/components/policies/fields/all.tsx
+++ b/src/components/policies/fields/all.tsx
@@ -20,6 +20,11 @@ import {
   FormControl,
   FormMessage,
 } from "@/components/ui/form"
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip"
 
 import { X } from "lucide-react"
 
@@ -351,15 +356,35 @@ export default function AllFields({
                   tooltip={PolicyAttributeDescriptions.checkInIntervalCount}
                 >
                   <FormControl>
-                    <Input
-                      type="number"
-                      min={1}
-                      max={365}
-                      placeholder="1 - 365"
-                      {...field}
-                      value={field.value ?? ""}
-                      disabled={!checkInInterval}
-                    />
+                    {!checkInInterval ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span tabIndex={0}>
+                            <Input
+                              type="number"
+                              min={1}
+                              max={365}
+                              placeholder="1 - 365"
+                              {...field}
+                              value={field.value ?? ""}
+                              disabled
+                            />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-80 bg-background-4 text-pretty text-content-muted">
+                          Set a check-in interval to configure this field.
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <Input
+                        type="number"
+                        min={1}
+                        max={365}
+                        placeholder="1 - 365"
+                        {...field}
+                        value={field.value ?? ""}
+                      />
+                    )}
                   </FormControl>
                 </Field.Header>
                 <FormMessage />
@@ -471,6 +496,7 @@ export default function AllFields({
                     onChange={(value) => field.onChange(value)}
                     invalid={!!fieldState.error}
                     disabled={!duration}
+                    disabledTooltip="Set a duration to configure this field."
                   >
                     {Object.values(ExpirationBasis).map((basis) => (
                       <SelectItem key={basis} value={basis}>
@@ -498,6 +524,7 @@ export default function AllFields({
                     onChange={(value) => field.onChange(value)}
                     invalid={!!fieldState.error}
                     disabled={!duration}
+                    disabledTooltip="Set a duration to configure this field."
                   >
                     {Object.values(ExpirationStrategy).map((strategy) => (
                       <SelectItem key={strategy} value={strategy}>
@@ -547,6 +574,7 @@ export default function AllFields({
                     onChange={(value) => field.onChange(value)}
                     invalid={!!fieldState.error}
                     disabled={!requireHeartbeat}
+                    disabledTooltip="Enable heartbeat to configure this field."
                   >
                     {Object.values(HeartbeatBasis).map((basis) => (
                       <SelectItem key={basis} value={basis}>
@@ -575,6 +603,7 @@ export default function AllFields({
                     onChange={(value) => field.onChange(value)}
                     invalid={!!fieldState.error}
                     disabled={!requireHeartbeat}
+                    disabledTooltip="Enable heartbeat to configure this field."
                   >
                     {Object.values(HeartbeatCullStrategy).map((strategy) => (
                       <SelectItem key={strategy} value={strategy}>
@@ -628,6 +657,7 @@ export default function AllFields({
                     onChange={(value) => field.onChange(value)}
                     invalid={!!fieldState.error}
                     disabled={!requireHeartbeat}
+                    disabledTooltip="Enable heartbeat to configure this field."
                   >
                     {Object.values(HeartbeatResurrectionStrategy).map(
                       (strategy) => (

--- a/src/components/policies/fields/lease-based.tsx
+++ b/src/components/policies/fields/lease-based.tsx
@@ -167,6 +167,7 @@ function DefaultLayout({
                 onChange={(value) => field.onChange(value)}
                 invalid={!!fieldState.error}
                 disabled={!requireHeartbeat}
+                disabledTooltip="Enable heartbeat to configure this field."
               >
                 {Object.values(HeartbeatCullStrategy).map((strategy) => (
                   <SelectItem key={strategy} value={strategy}>
@@ -195,6 +196,7 @@ function DefaultLayout({
                 onChange={(value) => field.onChange(value)}
                 invalid={!!fieldState.error}
                 disabled={!requireHeartbeat}
+                disabledTooltip="Enable heartbeat to configure this field."
               >
                 {Object.values(HeartbeatBasis).map((basis) => (
                   <SelectItem key={basis} value={basis}>
@@ -226,6 +228,7 @@ function DefaultLayout({
                 onChange={(value) => field.onChange(value)}
                 invalid={!!fieldState.error}
                 disabled={!requireHeartbeat}
+                disabledTooltip="Enable heartbeat to configure this field."
               >
                 {Object.values(HeartbeatResurrectionStrategy).map(
                   (strategy) => (

--- a/src/components/policies/fields/timed.tsx
+++ b/src/components/policies/fields/timed.tsx
@@ -120,6 +120,7 @@ function DefaultLayout({
                 onChange={(value) => field.onChange(value)}
                 invalid={!!fieldState.error}
                 disabled={!duration}
+                disabledTooltip="Set a duration to configure this field."
               >
                 {Object.values(ExpirationStrategy).map((strategy) => (
                   <SelectItem key={strategy} value={strategy}>
@@ -148,6 +149,7 @@ function DefaultLayout({
                 onChange={(value) => field.onChange(value)}
                 invalid={!!fieldState.error}
                 disabled={!duration}
+                disabledTooltip="Set a duration to configure this field."
               >
                 {Object.values(ExpirationBasis).map((basis) => (
                   <SelectItem key={basis} value={basis}>
@@ -176,6 +178,7 @@ function DefaultLayout({
                 onChange={(value) => field.onChange(value)}
                 invalid={!!fieldState.error}
                 disabled={!duration}
+                disabledTooltip="Set a duration to configure this field."
               >
                 {Object.values(RenewalBasis).map((basis) => (
                   <SelectItem key={basis} value={basis}>
@@ -204,6 +207,7 @@ function DefaultLayout({
                 onChange={(value) => field.onChange(value)}
                 invalid={!!fieldState.error}
                 disabled={!duration}
+                disabledTooltip="Set a duration to configure this field."
               >
                 {Object.values(TransferStrategy).map((strategy) => (
                   <SelectItem key={strategy} value={strategy}>


### PR DESCRIPTION
Dependent fields were disabled without any indicators. As discussed on discord, now there's a tooltip when hovering over any disabled field:

<img width="800" alt="image" src="https://github.com/user-attachments/assets/67f3432f-85b3-4a0a-b097-2ecd2e566a2a" />
