### PR TITLE
Add machines interface for CRUD actions

### DIFF
--- a/src/components/attribute/value.tsx
+++ b/src/components/attribute/value.tsx
@@ -87,9 +87,7 @@ export default function AttributeValue({
         : truncateKey(String(raw), { maxLength: isMobile ? 16 : 24 })
       break
     case "date":
-      value = isUnset
-        ? emptyLabel
-        : formatDate(new Date(String(raw)), "PPp")
+      value = isUnset ? emptyLabel : formatDate(new Date(String(raw)), "PPp")
       break
     case "code":
     case "number":

--- a/src/components/attribute/value.tsx
+++ b/src/components/attribute/value.tsx
@@ -1,4 +1,4 @@
-import { formatDuration } from "date-fns"
+import { formatDuration, formatDate } from "date-fns"
 
 import TooltipBadge from "@/components/tooltip-badge"
 
@@ -16,6 +16,7 @@ export type AttributeType =
   | "json"
   | "enum"
   | "license-key"
+  | "date"
 
 type AttributeValueProps = {
   type: AttributeType
@@ -84,6 +85,11 @@ export default function AttributeValue({
       value = isUnset
         ? emptyLabel
         : truncateKey(String(raw), { maxLength: isMobile ? 16 : 24 })
+      break
+    case "date":
+      value = isUnset
+        ? emptyLabel
+        : formatDate(new Date(String(raw)), "PPp")
       break
     case "code":
     case "number":

--- a/src/components/clipboard-button.tsx
+++ b/src/components/clipboard-button.tsx
@@ -1,73 +1,14 @@
 import { forwardRef, useMemo } from "react"
 import { Copy } from "lucide-react"
-import { copyToClipboard } from "@/lib/clipboard"
 
-type TruncateStyle = "clip" | "start" | "middle" | "end"
-type TruncateOptions = {
-  maxLength: number
-}
+import { copyToClipboard } from "@/lib/clipboard"
+import { truncator, TruncateStyle } from "@/lib/truncate"
 
 interface ClipboardButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   value: string
   truncate?: boolean
   truncateStyle?: TruncateStyle
   maxLength?: number
-}
-
-function truncateStart(
-  value: string,
-  { maxLength = 64 }: TruncateOptions,
-): string {
-  if (value.length <= maxLength) return value
-
-  const tail = value.slice(-maxLength)
-
-  return `…${tail}`
-}
-
-function truncateMiddle(
-  value: string,
-  { maxLength = 64 }: TruncateOptions,
-): string {
-  if (value.length <= maxLength) return value
-
-  const head = value.slice(0, Math.ceil(maxLength / 2))
-  const tail = value.slice(-Math.floor(maxLength / 2))
-
-  return `${head}…${tail}`
-}
-
-function truncateEnd(
-  value: string,
-  { maxLength = 64 }: TruncateOptions,
-): string {
-  if (value.length <= maxLength) return value
-
-  const head = value.slice(0, maxLength)
-
-  return `${head}…`
-}
-
-function truncateClip(
-  value: string,
-  { maxLength = 64 }: TruncateOptions,
-): string {
-  if (value.length <= maxLength) return value
-
-  return value.slice(0, maxLength)
-}
-
-function truncator(style: TruncateStyle, options: TruncateOptions) {
-  switch (style) {
-    case "clip":
-      return (v: string) => truncateClip(v, options)
-    case "start":
-      return (v: string) => truncateStart(v, options)
-    case "middle":
-      return (v: string) => truncateMiddle(v, options)
-    case "end":
-      return (v: string) => truncateEnd(v, options)
-  }
 }
 
 const ClipboardButton = forwardRef<HTMLDivElement, ClipboardButtonProps>(

--- a/src/components/environments/view/modal.tsx
+++ b/src/components/environments/view/modal.tsx
@@ -137,7 +137,7 @@ export default function EnvironmentsViewModal({
       <DialogFooter className="border-t border-accent p-4">
         {view === EnvironmentView.List && (
           <Button onClick={() => onChangeMode(EnvironmentMode.Create)}>
-            Create Environment
+            New Environment
           </Button>
         )}
         {view === EnvironmentView.Details && selectedEnvironment && (

--- a/src/components/go-to-button.tsx
+++ b/src/components/go-to-button.tsx
@@ -11,6 +11,7 @@ interface GoToProps {
   path: string
   params?: Record<string, string>
   label: string
+  disabled?: boolean
   className?: string
 }
 
@@ -18,6 +19,7 @@ export default function GoToButton({
   path,
   params,
   label,
+  disabled = false,
   className,
 }: GoToProps): React.ReactElement {
   const navigate = useNavigate()
@@ -27,12 +29,19 @@ export default function GoToButton({
   }
 
   return (
-    <div className={cn("group flex h-6 w-fit gap-1", className)}>
+    <div
+      className={cn(
+        "group flex h-6 w-fit gap-1",
+        disabled && "pointer-events-none",
+        className,
+      )}
+    >
       <Button
         type="button"
         variant="link"
         size="link"
         onClick={handleClick}
+        disabled={disabled}
         className="text-primary group-hover:text-primary/80"
         aria-label={label}
       >

--- a/src/components/inspect-resource.tsx
+++ b/src/components/inspect-resource.tsx
@@ -5,6 +5,7 @@ import { Copy } from "lucide-react"
 
 import { Group } from "@/types/groups"
 import { Policy } from "@/types/policies"
+import { Machine } from "@/types/machines"
 import { Product } from "@/types/products"
 import { License } from "@/types/licenses"
 import { Entitlement } from "@/types/entitlements"
@@ -13,7 +14,7 @@ import { cn } from "@/lib/utils"
 import { copyToClipboard } from "@/lib/clipboard"
 
 interface InspectResourceProps {
-  resource: Policy | Product | License | Entitlement | Group
+  resource: Policy | Product | License | Entitlement | Group | Machine
   className?: string
 }
 

--- a/src/components/licenses/create/modal.tsx
+++ b/src/components/licenses/create/modal.tsx
@@ -164,6 +164,9 @@ export default function LicensesCreateModal({
         return
       }
 
+      const policy = policies.find((p) => p.id === values.policyId)
+      const productId = policy?.relationships?.product?.data?.id
+
       setLoading(true)
 
       setTimeout(() => {
@@ -204,10 +207,7 @@ export default function LicensesCreateModal({
             },
             product: {
               links: { related: null },
-              data: {
-                type: "products",
-                id: "80dca7f1-e939-4927-8e47-8a4c84c8ac71",
-              },
+              data: productId ? { type: "products", id: productId } : undefined,
             },
             policy: {
               links: { related: null },
@@ -240,7 +240,7 @@ export default function LicensesCreateModal({
         onClose()
       }, 500)
     },
-    [onSelectLicense, onClose],
+    [policies, onSelectLicense, onClose],
   )
 
   return (

--- a/src/components/licenses/fields/additional.tsx
+++ b/src/components/licenses/fields/additional.tsx
@@ -42,7 +42,7 @@ function CreateLayout({
   title,
   className,
 }: Omit<OptionsFieldsProps, "layout">): React.ReactElement {
-  const form = useFormContext<Forms.Licenses.BaseValues>()
+  const form = useFormContext<Forms.Licenses.CreateValues>()
 
   return (
     <div className={cn("m-4 md:mb-0", className)}>

--- a/src/components/licenses/fields/general.tsx
+++ b/src/components/licenses/fields/general.tsx
@@ -55,7 +55,7 @@ function CreateLayout({
   title,
   className,
 }: Omit<GeneralFieldsProps, "layout">): React.ReactElement {
-  const form = useFormContext<Forms.Licenses.BaseValues>()
+  const form = useFormContext<Forms.Licenses.CreateValues>()
 
   const { data: policies = [], isLoading: policiesLoading } = useListPolicies()
   const { data: products = [], isLoading: productsLoading } = useListProducts()

--- a/src/components/licenses/fields/limits.tsx
+++ b/src/components/licenses/fields/limits.tsx
@@ -54,7 +54,7 @@ function CreateLayout({
   className,
   selectedPolicy,
 }: Omit<LimitsFieldsProps, "layout">): React.ReactElement {
-  const form = useFormContext<Forms.Licenses.BaseValues>()
+  const form = useFormContext<Forms.Licenses.CreateValues>()
 
   return (
     <div className={cn("m-4 md:mb-0", className)}>

--- a/src/components/machines/advanced-dialog.tsx
+++ b/src/components/machines/advanced-dialog.tsx
@@ -1,0 +1,117 @@
+import { useState, useEffect } from "react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent } from "@/components/ui/tabs"
+import {
+  Dialog,
+  DialogHeader,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+
+import { Text, CurlyBraces } from "lucide-react"
+
+import { MockMachines } from "@/types/machines"
+
+import * as Machines from "@/components/machines"
+import Metadata from "@/components/metadata"
+import TabsSwitch from "@/components/tabs-switch"
+import InspectResource from "@/components/inspect-resource"
+import CollapsibleCard from "@/components/collapsible-card"
+
+interface AdvancedDialogProps {
+  id: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export default function AdvancedDialog({
+  id,
+  open,
+  onOpenChange,
+}: AdvancedDialogProps) {
+  const machine = MockMachines.find((m) => m.id === id)
+  const machineLoading = false
+  const machineFetching = false
+  const machineError = !machine
+
+  const [tab, setTab] = useState<"attributes" | "inspect">("attributes")
+
+  useEffect(() => {
+    if (machineError && !machineFetching) {
+      onOpenChange(false)
+    }
+  }, [machineError, machineFetching, onOpenChange])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[calc(100dvh-2rem)] w-full flex-col overflow-hidden p-0 md:min-w-4xl">
+        <DialogHeader className="flex items-start border-b border-accent p-4 pt-3">
+          <DialogTitle className="text-base">Advanced</DialogTitle>
+          <DialogDescription className="sr-only">Advanced</DialogDescription>
+        </DialogHeader>
+        <div className="flex min-h-0 flex-1 flex-col">
+          {!machine || machineLoading ? (
+            <div className="space-y-4 p-4">
+              <div className="flex items-center gap-4">
+                <Skeleton className="h-8 w-48" />
+                <Skeleton className="h-8 w-32" />
+              </div>
+
+              <div className="space-y-4">
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            </div>
+          ) : (
+            <Tabs
+              value={tab}
+              onValueChange={(value) => setTab(value as typeof tab)}
+              className="flex min-h-0 min-w-0 flex-1 flex-col gap-0"
+            >
+              <TabsSwitch
+                className="pt-8 pb-0"
+                options={[
+                  {
+                    value: "attributes",
+                    label: "Other attributes",
+                    icon: Text,
+                  },
+                  {
+                    value: "inspect",
+                    label: "Inspect machine",
+                    icon: CurlyBraces,
+                  },
+                ]}
+              />
+              <TabsContent
+                value="attributes"
+                className="flex min-h-0 min-w-0 flex-1 flex-col"
+              >
+                <ScrollArea className="min-h-0 w-full min-w-0">
+                  <div className="flex min-w-0 flex-col gap-2 p-2">
+                    <Machines.AllAttributes machine={machine} />
+
+                    <CollapsibleCard title="Metadata" contentClass="p-0">
+                      <Metadata resource={machine} className="p-2" />
+                    </CollapsibleCard>
+                  </div>
+                </ScrollArea>
+              </TabsContent>
+
+              <TabsContent
+                value="inspect"
+                className="flex min-h-0 min-w-0 flex-1 p-0"
+              >
+                <InspectResource resource={machine} />
+              </TabsContent>
+            </Tabs>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/machines/all-attributes.tsx
+++ b/src/components/machines/all-attributes.tsx
@@ -1,0 +1,31 @@
+import { humanize } from "@/lib/utils"
+import { machineAttributeTypeSchema } from "@/lib/machines"
+
+import { Machine } from "@/types/machines"
+
+import AttributeGroup from "@/components/machines/attribute-group"
+
+type Key = keyof typeof machineAttributeTypeSchema
+
+interface AllAttributesProps {
+  machine: Machine
+  className?: string
+}
+
+export default function AllAttributes({
+  machine,
+  className,
+}: AllAttributesProps): React.ReactElement {
+  const keys = (Object.keys(machineAttributeTypeSchema) as Key[]).sort((a, b) =>
+    humanize(a).localeCompare(humanize(b)),
+  )
+
+  return (
+    <AttributeGroup
+      machine={machine}
+      title="Attributes"
+      keys={keys}
+      className={className}
+    />
+  )
+}

--- a/src/components/machines/attribute-group.tsx
+++ b/src/components/machines/attribute-group.tsx
@@ -1,0 +1,56 @@
+import { humanize } from "@/lib/utils"
+import { machineAttributeTypeSchema } from "@/lib/machines"
+import { Machine, MachineAttributeDescriptions } from "@/types/machines"
+import * as Attribute from "@/components/attribute"
+import CollapsibleCard from "@/components/collapsible-card"
+
+type Key = keyof typeof machineAttributeTypeSchema
+
+type AttributeGroupProps = {
+  machine: Machine
+  title: string
+  keys: readonly Key[]
+  when?: (machine: Machine) => boolean
+  className?: string
+}
+
+export default function AttributeGroup({
+  machine,
+  title,
+  keys,
+  when,
+  className,
+}: AttributeGroupProps): React.ReactElement | null {
+  if (when && !when(machine)) return null
+  if (keys.length === 0) return null
+
+  const middle = Math.ceil(keys.length / 2)
+  const left = keys.slice(0, middle)
+  const right = keys.slice(middle)
+
+  const row = (k: Key) => (
+    <Attribute.Field
+      key={k}
+      label={humanize(k)}
+      variant="none"
+      value={
+        <Attribute.Value
+          type={machineAttributeTypeSchema[k]}
+          value={machine.attributes[k]}
+          tooltip={
+            (MachineAttributeDescriptions as Record<Key, string | undefined>)[k]
+          }
+        />
+      }
+    />
+  )
+
+  return (
+    <CollapsibleCard title={title} contentClass={className}>
+      <div className="md:grid md:grid-cols-2 md:gap-x-6 md:divide-x md:divide-dashed">
+        <div className="space-y-4 md:pr-3">{left.map(row)}</div>
+        <div className="mt-4 space-y-4 md:mt-0 md:pl-3">{right.map(row)}</div>
+      </div>
+    </CollapsibleCard>
+  )
+}

--- a/src/components/machines/create/index.ts
+++ b/src/components/machines/create/index.ts
@@ -1,0 +1,1 @@
+export { default as Modal } from "./modal"

--- a/src/components/machines/create/modal.tsx
+++ b/src/components/machines/create/modal.tsx
@@ -1,0 +1,302 @@
+import { useMemo, useCallback, useState } from "react"
+import { useForm, FieldPath } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+
+import { Form } from "@/components/ui/form"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog"
+
+import * as Forms from "@/forms"
+
+import { Machine, HeartbeatStatus, MockMachines } from "@/types/machines"
+import { MockLicenses } from "@/types/licenses"
+
+import { toast } from "@/lib/toast"
+
+import { useSlide } from "@/hooks/use-slide"
+import { useMobile } from "@/hooks/use-mobile"
+
+import * as Motion from "@/components/motion"
+import * as Machines from "@/components/machines"
+import * as Loading from "@/components/loading"
+import StepProgress from "@/components/step-progress"
+import DocumentationLink from "@/components/documentation-link"
+import CollapsedBreadcrumb from "@/components/collapsed-breadcrumb"
+
+enum Steps {
+  General = "general",
+  Attributes = "attributes",
+  Additional = "additional",
+}
+
+type StepKey = (typeof Steps)[keyof typeof Steps]
+
+type Step = {
+  key: StepKey
+  title: string
+  fields?: FieldPath<Forms.Machines.CreateValues>[]
+  render: () => React.ReactElement
+}
+
+interface MachinesCreateModalProps {
+  onSelectMachine: (machine: Machine | null) => void
+  onClose: () => void
+}
+
+export default function MachinesCreateModal({
+  onSelectMachine,
+  onClose,
+}: MachinesCreateModalProps) {
+  const isMobile = useMobile()
+
+  const [loading, setLoading] = useState(false)
+  const [completedStep, setCompletedStep] = useState<Set<string>>(new Set())
+
+  const form = useForm<Forms.Machines.CreateValues>({
+    resolver: zodResolver(Forms.Machines.CreateSchema),
+    mode: "onChange",
+    defaultValues: {
+      fingerprint: "",
+      name: null,
+      licenseId: "",
+      groupId: null,
+      ownerId: null,
+      ip: null,
+      hostname: null,
+      platform: null,
+      cores: null,
+      memory: null,
+      disk: null,
+      metadata: {},
+    },
+  })
+
+  const steps: Step[] = useMemo(
+    () => [
+      {
+        key: Steps.General,
+        title: "General configuration",
+        fields: ["fingerprint", "licenseId"],
+        render: () => <Machines.Fields.General />,
+      },
+      {
+        key: Steps.Attributes,
+        title: "Machine attributes",
+        fields: ["ip", "hostname", "platform", "cores", "memory", "disk"],
+        render: () => <Machines.Fields.Attributes />,
+      },
+      {
+        key: Steps.Additional,
+        title: "Additional configuration",
+        fields: ["groupId", "ownerId", "metadata"],
+        render: () => <Machines.Fields.Additional />,
+      },
+    ],
+    [],
+  )
+
+  const [step, direction, goTo] = useSlide(steps.map((_, i) => i))
+
+  const current = steps[step]
+  const last = step === steps.length - 1
+
+  const next = useCallback(async () => {
+    if (current.fields?.length) {
+      const ok = await form.trigger(current.fields)
+
+      if (!ok) return
+    }
+
+    if (step < steps.length - 1) {
+      setCompletedStep((prev) => {
+        const next = new Set(prev)
+        next.add(steps[step].key)
+
+        return next
+      })
+
+      goTo(step + 1)
+    }
+  }, [current, step, steps, goTo, form])
+
+  const back = useCallback(() => {
+    if (step > 0) goTo(step - 1)
+  }, [step, goTo])
+
+  const handleCreateMachine = useCallback(
+    (values: Forms.Machines.CreateValues) => {
+      if (!values.licenseId) {
+        toast({
+          message: "Failed to create machine",
+          description: "License is required.",
+          variant: "error",
+        })
+        return
+      }
+
+      const license = MockLicenses.find((l) => l.id === values.licenseId)
+      const productId = license?.relationships?.product?.data?.id
+
+      setLoading(true)
+
+      setTimeout(() => {
+        const newMachine: Machine = {
+          id: crypto.randomUUID(),
+          type: "machines",
+          links: {
+            self: `/v1/accounts/{ACCOUNT}/machines/${crypto.randomUUID()}`,
+          },
+          attributes: {
+            fingerprint: values.fingerprint,
+            name: values.name ?? null,
+            ip: values.ip ?? null,
+            hostname: values.hostname ?? null,
+            platform: values.platform ?? null,
+            cores: values.cores ?? null,
+            memory: values.memory ?? null,
+            disk: values.disk ?? null,
+            requireHeartbeat: false,
+            heartbeatStatus: HeartbeatStatus.NotStarted,
+            heartbeatDuration: null,
+            lastHeartbeat: null,
+            nextHeartbeat: null,
+            lastCheckOut: null,
+            maxProcesses: null,
+            metadata: values.metadata ?? {},
+            created: new Date().toISOString(),
+            updated: new Date().toISOString(),
+          },
+          relationships: {
+            account: {
+              links: { related: "/v1/accounts/{ACCOUNT}" },
+              data: { type: "accounts", id: "{ACCOUNT}" },
+            },
+            environment: {
+              links: { related: null },
+              data: null,
+            },
+            product: {
+              links: { related: null },
+              data: productId ? { type: "products", id: productId } : undefined,
+            },
+            license: {
+              links: { related: null },
+              data: { type: "licenses", id: values.licenseId },
+            },
+            owner: {
+              links: { related: null },
+              data: values.ownerId
+                ? { type: "users", id: values.ownerId }
+                : null,
+            },
+            group: {
+              links: { related: null },
+              data: values.groupId
+                ? { type: "groups", id: values.groupId }
+                : null,
+            },
+            components: {
+              links: { related: null },
+              data: [],
+            },
+            processes: {
+              links: { related: null },
+              data: [],
+            },
+          },
+        }
+
+        MockMachines.push(newMachine)
+        setLoading(false)
+        toast({ message: "Machine created", variant: "success" })
+        onSelectMachine(newMachine)
+        onClose()
+      }, 500)
+    },
+    [onSelectMachine, onClose],
+  )
+
+  return (
+    <DialogContent className="min-w-fit">
+      <DialogHeader className="h-fit items-start border-b border-accent p-2">
+        <DialogDescription className="text-xs">
+          Activating a new machine
+        </DialogDescription>
+        <DialogTitle className="w-full">
+          {!isMobile && (
+            <CollapsedBreadcrumb
+              crumb={steps}
+              step={step}
+              goTo={goTo}
+              className="mt-1"
+              visibleSteps={3}
+            />
+          )}
+          {isMobile && (
+            <div className="mt-2 w-full px-2">
+              <StepProgress
+                steps={steps.map((step) => ({
+                  key: step.key,
+                  label: step.title,
+                }))}
+                currentIndex={step}
+                completedSteps={completedStep}
+                orientation="horizontal"
+              />
+            </div>
+          )}
+        </DialogTitle>
+      </DialogHeader>
+
+      <Form {...form}>
+        <form onSubmit={(e) => e.preventDefault()}>
+          <Motion.Slide direction={direction}>
+            <ScrollArea
+              key={current?.key ?? Steps.General}
+              className="flex h-[calc(100vh-11rem)] flex-col justify-between md:h-[50vh] md:w-4xl"
+            >
+              {current && <current.render />}
+
+              <DocumentationLink page="machines" />
+            </ScrollArea>
+          </Motion.Slide>
+
+          <DialogFooter className="flex flex-row gap-4 border-t border-accent p-4">
+            <Button
+              variant="outline"
+              type="button"
+              onClick={step === 0 ? onClose : back}
+              disabled={loading}
+              className="max-w-48 flex-1 basis-1/2"
+            >
+              {step === 0 ? "Cancel" : "Back"}
+            </Button>
+
+            <Button
+              key={last ? "create" : "next"}
+              type="button"
+              onClick={last ? form.handleSubmit(handleCreateMachine) : next}
+              disabled={loading}
+              className="max-w-48 flex-1 basis-1/2"
+            >
+              {loading ? (
+                <Loading.Dots className="bg-background" />
+              ) : last ? (
+                "Create"
+              ) : (
+                "Next step"
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </Form>
+    </DialogContent>
+  )
+}

--- a/src/components/machines/edit/edit-form.tsx
+++ b/src/components/machines/edit/edit-form.tsx
@@ -1,0 +1,89 @@
+import { useCallback } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+
+import { Form } from "@/components/ui/form"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { DialogFooter } from "@/components/ui/dialog"
+
+import * as Forms from "@/forms"
+import { Machine } from "@/types/machines"
+
+import * as Machines from "@/components/machines"
+import * as Loading from "@/components/loading"
+import DocumentationLink from "@/components/documentation-link"
+
+interface EditFormProps {
+  machine: Machine
+  loading?: boolean
+  onUpdate: (values: Forms.Machines.UpdateValues) => Promise<void> | void
+  onCancel: () => void
+}
+
+export default function EditForm({
+  machine,
+  loading,
+  onUpdate,
+  onCancel,
+}: EditFormProps) {
+  const form = useForm<Forms.Machines.UpdateValues>({
+    resolver: zodResolver(Forms.Machines.UpdateSchema),
+    mode: "onChange",
+    defaultValues: {
+      name: machine.attributes.name ?? null,
+      ip: machine.attributes.ip ?? null,
+      hostname: machine.attributes.hostname ?? null,
+      platform: machine.attributes.platform ?? null,
+      cores: machine.attributes.cores ?? null,
+      memory: machine.attributes.memory ?? null,
+      disk: machine.attributes.disk ?? null,
+      metadata: machine.attributes.metadata ?? {},
+      groupId: machine.relationships.group?.data?.id ?? null,
+      ownerId: machine.relationships.owner?.data?.id ?? null,
+    },
+  })
+
+  const update = useCallback(
+    async (values: Forms.Machines.UpdateValues) => {
+      await onUpdate(values)
+    },
+    [onUpdate],
+  )
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault()
+          await form.handleSubmit(update)()
+        }}
+      >
+        <ScrollArea type="always" className="h-[calc(100dvh-8rem)]">
+          <Machines.Fields.All />
+
+          <DocumentationLink page="machines" />
+        </ScrollArea>
+
+        <DialogFooter className="flex flex-row gap-4 border-t border-accent p-4">
+          <Button
+            variant="outline"
+            type="button"
+            onClick={onCancel}
+            disabled={loading}
+            className="max-w-48 flex-1 basis-1/2"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            disabled={loading}
+            className="max-w-48 flex-1 basis-1/2"
+          >
+            {loading ? <Loading.Dots className="bg-background" /> : "Update"}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
+  )
+}

--- a/src/components/machines/edit/index.ts
+++ b/src/components/machines/edit/index.ts
@@ -1,0 +1,1 @@
+export { default as Modal } from "./modal"

--- a/src/components/machines/edit/modal.tsx
+++ b/src/components/machines/edit/modal.tsx
@@ -1,0 +1,132 @@
+import { useCallback, useState } from "react"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+
+import { toast } from "@/lib/toast"
+
+import * as Forms from "@/forms"
+import { Machine, MockMachines } from "@/types/machines"
+
+import EditForm from "./edit-form"
+
+import * as Loading from "@/components/loading"
+
+interface MachinesEditModalProps {
+  open: boolean
+  onClose: () => void
+  machine: Machine | null
+}
+
+export default function MachinesEditModal({
+  open,
+  onClose,
+  machine,
+}: MachinesEditModalProps) {
+  const [loading, setLoading] = useState(false)
+
+  const handleUpdateMachine = useCallback(
+    (values: Forms.Machines.UpdateValues) => {
+      if (!machine) return
+
+      setLoading(true)
+
+      // Mock update
+      setTimeout(() => {
+        const index = MockMachines.findIndex((m) => m.id === machine.id)
+        if (index === -1) {
+          toast({ message: "Machine not found", variant: "error" })
+          setLoading(false)
+          return
+        }
+
+        const updated: Machine = {
+          ...machine,
+          attributes: {
+            ...machine.attributes,
+            name:
+              values.name !== undefined ? values.name : machine.attributes.name,
+            ip: values.ip !== undefined ? values.ip : machine.attributes.ip,
+            hostname:
+              values.hostname !== undefined
+                ? values.hostname
+                : machine.attributes.hostname,
+            platform:
+              values.platform !== undefined
+                ? values.platform
+                : machine.attributes.platform,
+            cores:
+              values.cores !== undefined
+                ? values.cores
+                : machine.attributes.cores,
+            memory:
+              values.memory !== undefined
+                ? values.memory
+                : machine.attributes.memory,
+            disk:
+              values.disk !== undefined ? values.disk : machine.attributes.disk,
+            metadata: values.metadata ?? machine.attributes.metadata,
+            updated: new Date().toISOString(),
+          },
+          relationships: {
+            ...machine.relationships,
+            group:
+              values.groupId !== undefined
+                ? values.groupId
+                  ? { data: { type: "groups", id: values.groupId } }
+                  : null
+                : machine.relationships.group,
+            owner:
+              values.ownerId !== undefined
+                ? values.ownerId
+                  ? { data: { type: "users", id: values.ownerId } }
+                  : null
+                : machine.relationships.owner,
+          },
+        }
+
+        MockMachines[index] = updated
+        setLoading(false)
+        toast({ message: "Machine updated", variant: "success" })
+        onClose()
+      }, 500)
+    },
+    [machine, onClose],
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+        className="min-h-screen min-w-screen rounded-none border-none"
+      >
+        <DialogHeader className="h-fit border-b border-accent p-2">
+          <DialogDescription className="flex h-8 items-center space-x-1 text-xs">
+            Updating an existing machine
+          </DialogDescription>
+          <DialogTitle className="sr-only" />
+        </DialogHeader>
+        {!machine ? (
+          <div className="flex w-full justify-center">
+            <Loading.Dots />
+          </div>
+        ) : (
+          open && (
+            <EditForm
+              machine={machine}
+              loading={loading}
+              onUpdate={handleUpdateMachine}
+              onCancel={onClose}
+            />
+          )
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/machines/fields/additional.tsx
+++ b/src/components/machines/fields/additional.tsx
@@ -1,0 +1,106 @@
+import { useFormContext } from "react-hook-form"
+
+import { Separator } from "@/components/ui/separator"
+import {
+  FormField,
+  FormItem,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form"
+
+import { cn } from "@/lib/utils"
+
+import * as Forms from "@/forms"
+
+import { MockGroups } from "@/types/groups"
+import { MachineFormFieldDescriptions } from "@/types/machines"
+
+import * as Field from "@/components/field"
+import SectionCard from "@/components/section-card"
+import KeyValueInput from "@/components/key-value-input"
+import SearchSelect from "@/components/search-select"
+
+interface AdditionalFieldsProps {
+  title?: string
+  className?: string
+}
+
+export default function AdditionalFields({
+  title,
+  className,
+}: AdditionalFieldsProps): React.ReactElement {
+  const form = useFormContext<Forms.Machines.CreateValues>()
+
+  return (
+    <div className={cn("m-4 md:mb-0", className)}>
+      <SectionCard title={title ?? "Additional configuration"}>
+        <div className="flex flex-col gap-4 md:flex-row">
+          <div className="flex-1 space-y-4">
+            <FormField
+              control={form.control}
+              name="groupId"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <Field.Header label="Group" variant="stacking" optional>
+                    <SearchSelect
+                      resource="group"
+                      value={field.value}
+                      onChange={(value) => field.onChange(value)}
+                      options={MockGroups}
+                      invalid={!!fieldState.error}
+                    />
+                  </Field.Header>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="ownerId"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <Field.Header label="Owner" variant="stacking" optional>
+                    <SearchSelect
+                      resource="user"
+                      value={field.value}
+                      onChange={(value) => field.onChange(value)}
+                      options={[]}
+                      invalid={!!fieldState.error}
+                    />
+                  </Field.Header>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <div className="mx-4 hidden md:block">
+            <Separator orientation="vertical" dashed={true} />
+          </div>
+
+          <div className="flex-1 space-y-4">
+            <FormField
+              control={form.control}
+              name="metadata"
+              render={() => (
+                <FormItem>
+                  <Field.Header
+                    label="Metadata"
+                    variant="stacking"
+                    tooltip={MachineFormFieldDescriptions.metadata}
+                    optional
+                  >
+                    <FormControl>
+                      <KeyValueInput<Forms.Machines.CreateValues> name="metadata" />
+                    </FormControl>
+                  </Field.Header>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </div>
+      </SectionCard>
+    </div>
+  )
+}

--- a/src/components/machines/fields/all.tsx
+++ b/src/components/machines/fields/all.tsx
@@ -1,0 +1,299 @@
+import { useFormContext } from "react-hook-form"
+
+import { Input } from "@/components/ui/input"
+import { Separator } from "@/components/ui/separator"
+import {
+  FormField,
+  FormItem,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form"
+
+import { cn } from "@/lib/utils"
+
+import * as Forms from "@/forms"
+
+import { MockGroups } from "@/types/groups"
+import { MachineFormFieldDescriptions } from "@/types/machines"
+
+import * as Field from "@/components/field"
+import SearchSelect from "@/components/search-select"
+import KeyValueInput from "@/components/key-value-input"
+
+interface AllFieldsProps {
+  className?: string
+}
+
+export default function AllFields({
+  className,
+}: AllFieldsProps): React.ReactElement {
+  const form = useFormContext<Forms.Machines.UpdateValues>()
+
+  return (
+    <div className={cn("p-4", className)}>
+      <h2 className="text-content-loud/90">Attributes</h2>
+      <section className="mt-4 flex flex-col md:flex-row">
+        <div className="w-full space-y-6">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <Field.Header
+                  label="Machine name"
+                  variant="stacking"
+                  tooltip={MachineFormFieldDescriptions.name}
+                  optional
+                >
+                  <FormControl>
+                    <Input
+                      {...field}
+                      value={field.value || ""}
+                      placeholder="Enter machine name..."
+                      autoComplete="off"
+                    />
+                  </FormControl>
+                </Field.Header>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="platform"
+            render={({ field }) => (
+              <FormItem>
+                <Field.Header
+                  label="Platform"
+                  variant="stacking"
+                  tooltip={MachineFormFieldDescriptions.platform}
+                  optional
+                >
+                  <FormControl>
+                    <Input
+                      {...field}
+                      value={field.value || ""}
+                      placeholder="Enter platform..."
+                    />
+                  </FormControl>
+                </Field.Header>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="hostname"
+            render={({ field }) => (
+              <FormItem>
+                <Field.Header
+                  label="Hostname"
+                  variant="stacking"
+                  tooltip={MachineFormFieldDescriptions.hostname}
+                  optional
+                >
+                  <FormControl>
+                    <Input
+                      {...field}
+                      value={field.value || ""}
+                      placeholder="Enter hostname..."
+                    />
+                  </FormControl>
+                </Field.Header>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="ip"
+            render={({ field }) => (
+              <FormItem>
+                <Field.Header
+                  label="IP address"
+                  variant="stacking"
+                  tooltip={MachineFormFieldDescriptions.ip}
+                  optional
+                >
+                  <FormControl>
+                    <Input
+                      {...field}
+                      value={field.value || ""}
+                      placeholder="Enter IP address..."
+                    />
+                  </FormControl>
+                </Field.Header>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="mx-8 hidden md:block">
+          <Separator orientation="vertical" dashed />
+        </div>
+
+        <div className="mt-4 w-full space-y-6 md:mt-0">
+          <FormField
+            control={form.control}
+            name="cores"
+            render={({ field }) => (
+              <FormItem>
+                <Field.Header
+                  label="Cores"
+                  variant="stacking"
+                  tooltip={MachineFormFieldDescriptions.cores}
+                  optional
+                >
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={1}
+                      placeholder="e.g. 4"
+                      {...field}
+                      value={field.value ?? ""}
+                      onChange={(e) => {
+                        const value = e.target.value
+                        field.onChange(value === "" ? null : Number(value))
+                      }}
+                    />
+                  </FormControl>
+                </Field.Header>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="memory"
+            render={({ field }) => (
+              <FormItem>
+                <Field.Header
+                  label="Memory"
+                  variant="stacking"
+                  tooltip={MachineFormFieldDescriptions.memory}
+                  optional
+                >
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={1}
+                      placeholder="e.g. 8"
+                      {...field}
+                      value={field.value ?? ""}
+                      onChange={(e) => {
+                        const value = e.target.value
+                        field.onChange(value === "" ? null : Number(value))
+                      }}
+                    />
+                  </FormControl>
+                </Field.Header>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="disk"
+            render={({ field }) => (
+              <FormItem>
+                <Field.Header
+                  label="Disk"
+                  variant="stacking"
+                  tooltip={MachineFormFieldDescriptions.disk}
+                  optional
+                >
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={1}
+                      placeholder="e.g. 256"
+                      {...field}
+                      value={field.value ?? ""}
+                      onChange={(e) => {
+                        const value = e.target.value
+                        field.onChange(value === "" ? null : Number(value))
+                      }}
+                    />
+                  </FormControl>
+                </Field.Header>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="metadata"
+            render={() => (
+              <FormItem>
+                <Field.Header
+                  label="Metadata"
+                  variant="stacking"
+                  tooltip={MachineFormFieldDescriptions.metadata}
+                >
+                  <FormControl>
+                    <KeyValueInput<Forms.Machines.UpdateValues> name="metadata" />
+                  </FormControl>
+                </Field.Header>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      </section>
+
+      <Separator className="my-6" />
+
+      <h2 className="text-content-loud/90">Relationships</h2>
+      <section className="mt-4 flex flex-col md:flex-row">
+        <div className="w-full space-y-6">
+          <FormField
+            control={form.control}
+            name="groupId"
+            render={({ field, fieldState }) => (
+              <FormItem>
+                <Field.Header label="Group" variant="stacking" optional>
+                  <SearchSelect
+                    resource="group"
+                    value={field.value}
+                    onChange={(value) => field.onChange(value)}
+                    options={MockGroups}
+                    invalid={!!fieldState.error}
+                  />
+                </Field.Header>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="mx-8 hidden md:block">
+          <Separator orientation="vertical" dashed />
+        </div>
+
+        <div className="mt-4 w-full space-y-6 md:mt-0">
+          <FormField
+            control={form.control}
+            name="ownerId"
+            render={({ field, fieldState }) => (
+              <FormItem>
+                <Field.Header label="Owner" variant="stacking" optional>
+                  <SearchSelect
+                    resource="user"
+                    value={field.value}
+                    onChange={(value) => field.onChange(value)}
+                    options={[]}
+                    invalid={!!fieldState.error}
+                  />
+                </Field.Header>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/machines/fields/attributes.tsx
+++ b/src/components/machines/fields/attributes.tsx
@@ -1,0 +1,211 @@
+import { useFormContext } from "react-hook-form"
+
+import { Input } from "@/components/ui/input"
+import { Separator } from "@/components/ui/separator"
+import {
+  FormField,
+  FormItem,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form"
+
+import { cn } from "@/lib/utils"
+
+import * as Forms from "@/forms"
+
+import { MachineFormFieldDescriptions } from "@/types/machines"
+
+import * as Field from "@/components/field"
+import SectionCard from "@/components/section-card"
+
+interface AttributesFieldsProps {
+  title?: string
+  className?: string
+}
+
+export default function AttributesFields({
+  title,
+  className,
+}: AttributesFieldsProps): React.ReactElement {
+  const form = useFormContext<Forms.Machines.CreateValues>()
+
+  return (
+    <div className={cn("m-4 md:mb-0", className)}>
+      <SectionCard title={title ?? "Machine attributes"}>
+        <div className="flex flex-col gap-4 md:flex-row">
+          <div className="flex-1 space-y-4">
+            <FormField
+              control={form.control}
+              name="hostname"
+              render={({ field }) => (
+                <FormItem>
+                  <Field.Header
+                    label="Hostname"
+                    variant="stacking"
+                    tooltip={MachineFormFieldDescriptions.hostname}
+                    optional
+                  >
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder="Enter hostname..."
+                        value={field.value ?? ""}
+                        onChange={(e) => field.onChange(e.target.value || null)}
+                      />
+                    </FormControl>
+                  </Field.Header>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="ip"
+              render={({ field }) => (
+                <FormItem>
+                  <Field.Header
+                    label="IP Address"
+                    variant="stacking"
+                    tooltip={MachineFormFieldDescriptions.ip}
+                    optional
+                  >
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder="Enter IP address..."
+                        value={field.value ?? ""}
+                        onChange={(e) => field.onChange(e.target.value || null)}
+                      />
+                    </FormControl>
+                  </Field.Header>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="platform"
+              render={({ field }) => (
+                <FormItem>
+                  <Field.Header
+                    label="Platform"
+                    variant="stacking"
+                    tooltip={MachineFormFieldDescriptions.platform}
+                    optional
+                  >
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder="e.g., macOS, Windows, Linux"
+                        value={field.value ?? ""}
+                        onChange={(e) => field.onChange(e.target.value || null)}
+                      />
+                    </FormControl>
+                  </Field.Header>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <div className="mx-4 hidden md:block">
+            <Separator orientation="vertical" dashed={true} />
+          </div>
+
+          <div className="flex-1 space-y-4">
+            <FormField
+              control={form.control}
+              name="cores"
+              render={({ field }) => (
+                <FormItem>
+                  <Field.Header
+                    label="CPU Cores"
+                    variant="stacking"
+                    tooltip={MachineFormFieldDescriptions.cores}
+                    optional
+                  >
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="number"
+                        min={1}
+                        placeholder="Enter CPU cores..."
+                        value={field.value ?? ""}
+                        onChange={(e) =>
+                          field.onChange(
+                            e.target.value ? parseInt(e.target.value) : null,
+                          )
+                        }
+                      />
+                    </FormControl>
+                  </Field.Header>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="memory"
+              render={({ field }) => (
+                <FormItem>
+                  <Field.Header
+                    label="Memory"
+                    variant="stacking"
+                    tooltip={MachineFormFieldDescriptions.memory}
+                    optional
+                  >
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="number"
+                        min={1}
+                        placeholder="Enter memory in bytes..."
+                        value={field.value ?? ""}
+                        onChange={(e) =>
+                          field.onChange(
+                            e.target.value ? parseInt(e.target.value) : null,
+                          )
+                        }
+                      />
+                    </FormControl>
+                  </Field.Header>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="disk"
+              render={({ field }) => (
+                <FormItem>
+                  <Field.Header
+                    label="Disk"
+                    variant="stacking"
+                    tooltip={MachineFormFieldDescriptions.disk}
+                    optional
+                  >
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="number"
+                        min={1}
+                        placeholder="Enter disk space in bytes..."
+                        value={field.value ?? ""}
+                        onChange={(e) =>
+                          field.onChange(
+                            e.target.value ? parseInt(e.target.value) : null,
+                          )
+                        }
+                      />
+                    </FormControl>
+                  </Field.Header>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </div>
+      </SectionCard>
+    </div>
+  )
+}

--- a/src/components/machines/fields/general.tsx
+++ b/src/components/machines/fields/general.tsx
@@ -1,0 +1,114 @@
+import { useFormContext } from "react-hook-form"
+
+import { Input } from "@/components/ui/input"
+import { Separator } from "@/components/ui/separator"
+import {
+  FormField,
+  FormItem,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form"
+
+import { cn } from "@/lib/utils"
+
+import * as Forms from "@/forms"
+
+import { MockLicenses } from "@/types/licenses"
+import { MachineFormFieldDescriptions } from "@/types/machines"
+
+import * as Field from "@/components/field"
+import SectionCard from "@/components/section-card"
+import SearchSelect from "@/components/search-select"
+
+interface GeneralFieldsProps {
+  title?: string
+  className?: string
+}
+
+export default function GeneralFields({
+  title,
+  className,
+}: GeneralFieldsProps): React.ReactElement {
+  const form = useFormContext<Forms.Machines.CreateValues>()
+
+  return (
+    <div className={cn("m-4 md:mb-0", className)}>
+      <FormField
+        control={form.control}
+        name="name"
+        render={({ field }) => (
+          <FormItem className="m-4 md:my-6">
+            <FormControl>
+              <Input
+                {...field}
+                value={field.value || ""}
+                variant="title"
+                placeholder="Enter machine name..."
+                className="border-none text-xl placeholder:text-content-subdued! md:text-2xl"
+                autoFocus={!field.value}
+                autoComplete="off"
+              />
+            </FormControl>
+            <FormMessage className="ml-2" />
+          </FormItem>
+        )}
+      />
+
+      <SectionCard title={title ?? "General machine configuration"}>
+        <div className="flex flex-col gap-4 md:flex-row">
+          <div className="flex-1 space-y-4">
+            <FormField
+              control={form.control}
+              name="fingerprint"
+              render={({ field }) => (
+                <FormItem>
+                  <Field.Header
+                    label="Fingerprint"
+                    variant="stacking"
+                    tooltip={MachineFormFieldDescriptions.fingerprint}
+                  >
+                    <FormControl>
+                      <Input
+                        {...field}
+                        value={field.value || ""}
+                        placeholder="Enter machine fingerprint..."
+                      />
+                    </FormControl>
+                  </Field.Header>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <div className="mx-4 hidden md:block">
+            <Separator orientation="vertical" dashed={true} />
+          </div>
+
+          <div className="flex-1 space-y-4">
+            <FormField
+              control={form.control}
+              name="licenseId"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <Field.Header label="License Relationship" variant="stacking">
+                    <SearchSelect
+                      resource="license"
+                      value={field.value}
+                      onChange={(value) => field.onChange(value)}
+                      options={MockLicenses}
+                      allowClear={false}
+                      invalid={!!fieldState.error}
+                      truncate="middle"
+                    />
+                  </Field.Header>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </div>
+      </SectionCard>
+    </div>
+  )
+}

--- a/src/components/machines/fields/index.ts
+++ b/src/components/machines/fields/index.ts
@@ -1,0 +1,4 @@
+export { default as All } from "./all"
+export { default as General } from "./general"
+export { default as Attributes } from "./attributes"
+export { default as Additional } from "./additional"

--- a/src/components/machines/index.ts
+++ b/src/components/machines/index.ts
@@ -6,3 +6,7 @@ export { Edit }
 
 import * as Fields from "./fields"
 export { Fields }
+
+export { default as AttributeGroup } from "./attribute-group"
+export { default as AllAttributes } from "./all-attributes"
+export { default as AdvancedDialog } from "./advanced-dialog"

--- a/src/components/machines/index.ts
+++ b/src/components/machines/index.ts
@@ -1,2 +1,8 @@
+import * as Create from "./create"
+export { Create }
+
+import * as Edit from "./edit"
+export { Edit }
+
 import * as Fields from "./fields"
 export { Fields }

--- a/src/components/machines/index.ts
+++ b/src/components/machines/index.ts
@@ -1,0 +1,2 @@
+import * as Fields from "./fields"
+export { Fields }

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -182,7 +182,9 @@ export default function MultiSelect({
               ))}
             </ScrollArea>
 
-            <CommandEmpty>No results.</CommandEmpty>
+            <CommandEmpty className="p-2 text-sm text-content-normal">
+              No results found
+            </CommandEmpty>
           </CommandList>
         </Command>
       </PopoverContent>

--- a/src/components/search-select.tsx
+++ b/src/components/search-select.tsx
@@ -1,0 +1,260 @@
+import { useState, useRef, useMemo } from "react"
+
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Command, CommandList, CommandItem } from "@/components/ui/command"
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover"
+
+import { ChevronsUpDown } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { getGroupLabel } from "@/lib/groups"
+import { getLicenseLabel } from "@/lib/licenses"
+import { truncator, TruncateStyle } from "@/lib/truncate"
+
+import * as keygen from "@/keygen"
+
+import GoToButton from "@/components/go-to-button"
+
+type BaseOption = { id: string }
+type NamedOption = BaseOption & { attributes: { name: string } }
+
+type ResourceType = "license" | "group" | "user"
+
+interface ResourceConfig {
+  getLabel: (option: BaseOption) => string
+  placeholder: string
+  searchPlaceholder: string
+  emptyMessage: React.ReactElement
+}
+
+const resourceConfigs: Record<ResourceType, ResourceConfig> = {
+  license: {
+    getLabel: getLicenseLabel as (option: BaseOption) => string,
+    placeholder: "Select a license...",
+    searchPlaceholder: "Search by ID or name...",
+    emptyMessage: (
+      <span className="flex items-center gap-2">
+        No licenses found.
+        <GoToButton
+          path="/$id/app/licenses"
+          params={{ id: keygen.config.id }}
+          label="View licenses"
+        />
+      </span>
+    ),
+  },
+  group: {
+    getLabel: getGroupLabel as (option: BaseOption) => string,
+    placeholder: "Select a group...",
+    searchPlaceholder: "Search by ID or name...",
+    emptyMessage: (
+      <span className="flex items-center gap-2">
+        No groups found.
+        <GoToButton
+          path="/$id/app/groups"
+          params={{ id: keygen.config.id }}
+          label="View groups"
+        />
+      </span>
+    ),
+  },
+  user: {
+    // TODO(cazden) Update when Users resource is available
+    getLabel: (option: BaseOption) => option.id,
+    placeholder: "Select an owner...",
+    searchPlaceholder: "Search by ID or email...",
+    emptyMessage: (
+      <span className="flex items-center gap-2">
+        No users found.
+        {/* <GoToButton
+          path="/$id/app/users"
+          params={{ id: keygen.config.id }}
+          label="View users"
+        /> */}
+      </span>
+    ),
+  },
+}
+
+function getDefaultLabel<T extends BaseOption>(option: T): string {
+  if (
+    "attributes" in option &&
+    typeof (option as NamedOption).attributes?.name === "string"
+  ) {
+    return (option as NamedOption).attributes.name
+  }
+  return option.id
+}
+
+interface SearchSelectProps<T extends BaseOption> {
+  value: string | null | undefined
+  onChange: (value: string | null) => void
+  options: T[]
+  resource?: ResourceType
+  placeholder?: string
+  searchPlaceholder?: string
+  emptyMessage?: string | React.ReactElement
+  allowClear?: boolean
+  clearLabel?: string
+  invalid?: boolean
+  truncate?: TruncateStyle
+  truncateLength?: number
+  className?: string
+}
+
+export default function SearchSelect<T extends BaseOption>({
+  value,
+  onChange,
+  options,
+  resource,
+  placeholder,
+  searchPlaceholder,
+  emptyMessage,
+  allowClear = true,
+  clearLabel = "Clear",
+  invalid = false,
+  truncate,
+  truncateLength = 36,
+  className,
+}: SearchSelectProps<T>) {
+  const config = resource ? resourceConfigs[resource] : null
+
+  const getLabel = config?.getLabel ?? getDefaultLabel
+
+  const resolvedPlaceholder =
+    placeholder ?? config?.placeholder ?? "Select one..."
+  const resolvedSearchPlaceholder =
+    searchPlaceholder ?? config?.searchPlaceholder ?? "Search by ID or name..."
+  const resolvedEmptyMessage =
+    emptyMessage ?? config?.emptyMessage ?? "No results found"
+
+  const [query, setQuery] = useState("")
+  const [open, setOpen] = useState(false)
+
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const format = useMemo(
+    () =>
+      truncate ? truncator(truncate, { maxLength: truncateLength }) : null,
+    [truncate, truncateLength],
+  )
+
+  const labelMap = useMemo(
+    () => new Map(options.map((o) => [o.id, getLabel(o)])),
+    [options, getLabel],
+  )
+
+  const visibleOptions = useMemo(() => {
+    const lowerQuery = query.toLowerCase()
+    return options.filter(
+      (option) =>
+        getLabel(option).toLowerCase().includes(lowerQuery) ||
+        option.id.toLowerCase().includes(lowerQuery),
+    )
+  }, [query, options, getLabel])
+
+  const selectedLabel = value ? labelMap.get(value) : null
+  const displayLabel = selectedLabel
+    ? format
+      ? format(selectedLabel)
+      : selectedLabel
+    : null
+
+  const handleSelect = (id: string | null) => {
+    onChange(id)
+    setQuery("")
+    setOpen(false)
+  }
+
+  const trigger = (
+    <Button
+      variant="outline"
+      role="combobox"
+      aria-expanded={open}
+      className={cn(
+        "w-full justify-between font-normal",
+        !displayLabel && "text-content-subdued",
+        invalid && "border-destructive!",
+        className,
+      )}
+    >
+      <span className="truncate">{displayLabel ?? resolvedPlaceholder}</span>
+      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+    </Button>
+  )
+
+  return (
+    <Popover modal open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+
+      <PopoverContent
+        align="start"
+        className="w-(--radix-popover-trigger-width) p-0"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault()
+          inputRef.current?.focus()
+        }}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
+        <Command shouldFilter={false}>
+          <div className="border-b border-accent p-2">
+            <Input
+              ref={inputRef}
+              value={query}
+              placeholder={resolvedSearchPlaceholder}
+              fieldSize="sm"
+              className="h-8"
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  setOpen(false)
+                  setQuery("")
+                }
+              }}
+            />
+          </div>
+
+          <CommandList className="p-1">
+            <ScrollArea className={cn(visibleOptions.length > 5 && "h-48")}>
+              {allowClear && visibleOptions.length > 0 && !query && (
+                <CommandItem
+                  onSelect={() => handleSelect(null)}
+                  className="cursor-pointer text-content-subdued"
+                >
+                  {clearLabel}
+                </CommandItem>
+              )}
+
+              {visibleOptions.length > 0 ? (
+                visibleOptions.map((option) => {
+                  const label = getLabel(option)
+                  const displayOptionLabel = format ? format(label) : label
+
+                  return (
+                    <CommandItem
+                      key={option.id}
+                      onSelect={() => handleSelect(option.id)}
+                      className="cursor-pointer"
+                    >
+                      {displayOptionLabel}
+                    </CommandItem>
+                  )
+                })
+              ) : (
+                <div className="px-2 py-1 text-sm text-content-normal">
+                  {resolvedEmptyMessage}
+                </div>
+              )}
+            </ScrollArea>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/sidebar/panel.tsx
+++ b/src/components/sidebar/panel.tsx
@@ -118,6 +118,11 @@ const licensingOptions = linkOptions([
     params: { id: keygen.config.id },
   },
   {
+    to: "/$id/app/machines",
+    label: "Machines",
+    params: { id: keygen.config.id },
+  },
+  {
     to: "/$id/app/groups",
     label: "Groups",
     params: { id: keygen.config.id },

--- a/src/components/tables/index.ts
+++ b/src/components/tables/index.ts
@@ -1,1 +1,3 @@
+export { default as LicenseCell } from "./license-cell"
+export { default as PolicyCell } from "./policy-cell"
 export { default as ProductCell } from "./product-cell"

--- a/src/components/tables/license-cell.tsx
+++ b/src/components/tables/license-cell.tsx
@@ -1,0 +1,29 @@
+// TODO(cazden) Add licenses query
+// import { useGetLicense } from "@/queries/licenses"
+
+import ResourceCell from "./resource-cell"
+
+interface LicenseCellProps {
+  id: string | undefined
+}
+
+export default function LicenseCell({
+  id,
+}: LicenseCellProps): React.ReactElement {
+  if (!id) return <ResourceCell isEmpty />
+  return <LicenseCellContent id={id} />
+}
+
+function LicenseCellContent({ id }: { id: string }): React.ReactElement {
+  // const { data, isLoading: licenseLoading } = useGetLicense(id)
+
+  void id
+  const data = { attributes: { name: "--" } }
+  const licenseLoading = false
+
+  return (
+    <ResourceCell isEmpty={!data} isLoading={licenseLoading}>
+      {data?.attributes.name}
+    </ResourceCell>
+  )
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -16,7 +16,7 @@ const inputVariants = cva(
   {
     variants: {
       variant: {
-        default: "",
+        default: "placeholder:text-content-subdued!",
         destructive:
           "text-destructive border-brand-destructive ring-2 ring-destructive/20 focus-visible:ring-destructive/40",
         outline: "bg-background",

--- a/src/forms/index.ts
+++ b/src/forms/index.ts
@@ -13,5 +13,8 @@ export { Policies }
 import * as Licenses from "./licenses"
 export { Licenses }
 
+import * as Machines from "./machines"
+export { Machines }
+
 import * as Groups from "./groups"
 export { Groups }

--- a/src/forms/machines.ts
+++ b/src/forms/machines.ts
@@ -1,0 +1,63 @@
+import { z } from "zod"
+
+import { Writable } from "@/types/api"
+import { MachineAttributes } from "@/types/machines"
+
+export type BaseValues = Writable<
+  Partial<
+    Pick<
+      MachineAttributes,
+      | "name"
+      | "ip"
+      | "hostname"
+      | "platform"
+      | "cores"
+      | "memory"
+      | "disk"
+      | "metadata"
+    >
+  >
+> & {
+  groupId?: string | null
+  ownerId?: string | null
+}
+
+export type CreateValues = BaseValues & {
+  fingerprint: string
+  licenseId: string
+}
+
+export type UpdateValues = Partial<BaseValues>
+
+const BaseShape = z.object({
+  name: z.string().trim().nullable().optional(),
+  ip: z.string().trim().nullable().optional(),
+  hostname: z.string().trim().nullable().optional(),
+  platform: z.string().trim().nullable().optional(),
+  cores: z.number().int().positive().nullable().optional(),
+  memory: z.number().int().positive().nullable().optional(),
+  disk: z.number().int().positive().nullable().optional(),
+  metadata: z.record(z.unknown()).default({}),
+  groupId: z.string().nullable().optional(),
+  ownerId: z.string().nullable().optional(),
+})
+
+const FingerprintShape = z.object({
+  fingerprint: z.string().trim().min(1, "Fingerprint is required"),
+})
+
+const LicenseRelationshipShape = z.object({
+  licenseId: z.string().min(1, "License is required"),
+})
+
+const BaseRules = (schema: z.ZodType<BaseValues>): z.ZodType<BaseValues> => {
+  // Custom rules can be added here in the future, e.g.
+  // schema.refine(...)
+  return schema
+}
+
+export const BaseSchema: z.ZodType<BaseValues> = BaseRules(BaseShape)
+export const CreateSchema: z.ZodType<CreateValues> = BaseRules(
+  BaseShape.merge(FingerprintShape).merge(LicenseRelationshipShape),
+) as z.ZodType<CreateValues>
+export const UpdateSchema: z.ZodType<UpdateValues> = BaseSchema

--- a/src/hooks/use-license-table-columns.tsx
+++ b/src/hooks/use-license-table-columns.tsx
@@ -10,8 +10,7 @@ import {
 
 import { createTableColumnHelper } from "@/lib/tables"
 
-import PolicyCell from "@/components/tables/policy-cell"
-import ProductCell from "@/components/tables/product-cell"
+import * as Tables from "@/components/tables"
 import ClipboardButton from "@/components/clipboard-button"
 
 const column = createTableColumnHelper<License>()
@@ -52,12 +51,12 @@ export function useLicenseTableColumns() {
       column.rel("policy", {
         sortingFn: "alphanumeric",
         header: "Policy",
-        cell: (info) => <PolicyCell id={info.getValue()?.data?.id} />,
+        cell: (info) => <Tables.PolicyCell id={info.getValue()?.data?.id} />,
       }),
       column.rel("product", {
         sortingFn: "alphanumeric",
         header: "Product",
-        cell: (info) => <ProductCell id={info.getValue()?.data?.id} />,
+        cell: (info) => <Tables.ProductCell id={info.getValue()?.data?.id} />,
       }),
       column.attr("expiry", {
         sortingFn: "datetime",

--- a/src/hooks/use-machine-table-columns.tsx
+++ b/src/hooks/use-machine-table-columns.tsx
@@ -1,0 +1,54 @@
+import { useMemo } from "react"
+
+import { Machine } from "@/types/machines"
+
+import { createTableColumnHelper } from "@/lib/tables"
+
+import * as Tables from "@/components/tables"
+import ClipboardButton from "@/components/clipboard-button"
+
+const column = createTableColumnHelper<Machine>()
+
+export function useMachineTableColumns() {
+  const columns = useMemo(
+    () => [
+      column.id({
+        header: "ID",
+        cell: (info) => <ClipboardButton value={info.getValue()} />,
+      }),
+      column.attr("fingerprint", {
+        header: "Fingerprint",
+        cell: (info) =>
+          info.getValue() || <span className="text-content-muted">--</span>,
+      }),
+      column.attr("name", {
+        header: "Name",
+        cell: (info) =>
+          info.getValue() || <span className="text-content-muted">--</span>,
+      }),
+      column.rel("license", {
+        sortingFn: "alphanumeric",
+        header: "License",
+        cell: (info) => <Tables.LicenseCell id={info.getValue()?.data?.id} />,
+      }),
+      column.rel("product", {
+        sortingFn: "alphanumeric",
+        header: "Product",
+        cell: (info) => <Tables.ProductCell id={info.getValue()?.data?.id} />,
+      }),
+      column.attr("created", {
+        sortingFn: "datetime",
+        header: "Created",
+        cell: (info) => new Date(info.getValue()).toLocaleDateString(),
+      }),
+      column.attr("updated", {
+        sortingFn: "datetime",
+        header: "Updated",
+        cell: (info) => new Date(info.getValue()).toLocaleDateString(),
+      }),
+    ],
+    [],
+  )
+
+  return columns
+}

--- a/src/hooks/use-policy-table-columns.tsx
+++ b/src/hooks/use-policy-table-columns.tsx
@@ -4,8 +4,8 @@ import { Policy } from "@/types/policies"
 
 import { createTableColumnHelper } from "@/lib/tables"
 
+import * as Tables from "@/components/tables"
 import ClipboardButton from "@/components/clipboard-button"
-import ProductCell from "@/components/tables/product-cell"
 
 const column = createTableColumnHelper<Policy>()
 
@@ -22,7 +22,7 @@ export function usePolicyTableColumns() {
       column.rel("product", {
         sortingFn: "alphanumeric",
         header: "Product",
-        cell: (info) => <ProductCell id={info.getValue()?.data?.id} />,
+        cell: (info) => <Tables.ProductCell id={info.getValue()?.data?.id} />,
       }),
       column.attr("created", {
         sortingFn: "datetime",

--- a/src/lib/groups.ts
+++ b/src/lib/groups.ts
@@ -11,3 +11,7 @@ export const groupAttributeTypeSchema: Record<
   maxLicenses: "number",
   maxMachines: "number",
 }
+
+export function getGroupLabel(group: Group) {
+  return group.attributes.name
+}

--- a/src/lib/licenses.ts
+++ b/src/lib/licenses.ts
@@ -9,7 +9,7 @@ export const licenseAttributeTypeSchema: Record<
 > = {
   name: "string",
   key: "license-key",
-  expiry: "datetime",
+  expiry: "date",
   status: "enum",
   uses: "number",
   suspended: "boolean",
@@ -22,10 +22,10 @@ export const licenseAttributeTypeSchema: Record<
   maxUses: "number",
   requireHeartbeat: "boolean",
   requireCheckIn: "boolean",
-  lastValidated: "datetime",
-  lastCheckOut: "datetime",
-  lastCheckIn: "datetime",
-  nextCheckIn: "datetime",
+  lastValidated: "date",
+  lastCheckOut: "date",
+  lastCheckIn: "date",
+  nextCheckIn: "date",
 }
 
 export function getLimit(

--- a/src/lib/licenses.ts
+++ b/src/lib/licenses.ts
@@ -134,3 +134,7 @@ export function truncateKey(
 
   return `${head}${ellipsis}${tail}`
 }
+
+export function getLicenseLabel(license: License) {
+  return license.attributes.name || license.attributes.key
+}

--- a/src/lib/machines.ts
+++ b/src/lib/machines.ts
@@ -1,0 +1,38 @@
+import { AttributeType } from "@/components/attribute/value"
+
+import { Machine, HeartbeatStatus } from "@/types/machines"
+
+export const machineAttributeTypeSchema: Record<
+  keyof Omit<Machine["attributes"], "metadata" | "created" | "updated">,
+  AttributeType
+> = {
+  fingerprint: "string",
+  name: "string",
+  ip: "string",
+  hostname: "string",
+  platform: "string",
+  cores: "number",
+  memory: "number",
+  disk: "number",
+  requireHeartbeat: "boolean",
+  heartbeatStatus: "string",
+  heartbeatDuration: "number",
+  lastHeartbeat: "date",
+  nextHeartbeat: "date",
+  lastCheckOut: "date",
+  maxProcesses: "number",
+}
+
+export const getHeartbeatStatusVariant = (
+  status: HeartbeatStatus,
+): "default" | "success" | "disabled" => {
+  switch (status) {
+    case HeartbeatStatus.Alive:
+    case HeartbeatStatus.Resurrected:
+      return "success"
+    case HeartbeatStatus.Dead:
+      return "disabled"
+    default:
+      return "default"
+  }
+}

--- a/src/lib/truncate.ts
+++ b/src/lib/truncate.ts
@@ -1,0 +1,64 @@
+export type TruncateStyle = "clip" | "start" | "middle" | "end"
+
+type TruncateOptions = {
+  maxLength?: number
+}
+
+function truncateStart(
+  value: string,
+  { maxLength = 64 }: TruncateOptions = {},
+): string {
+  if (value.length <= maxLength) return value
+
+  const tail = value.slice(-maxLength)
+
+  return `…${tail}`
+}
+
+function truncateMiddle(
+  value: string,
+  { maxLength = 64 }: TruncateOptions = {},
+): string {
+  if (value.length <= maxLength) return value
+
+  const head = value.slice(0, Math.ceil(maxLength / 2))
+  const tail = value.slice(-Math.floor(maxLength / 2))
+
+  return `${head}…${tail}`
+}
+
+function truncateEnd(
+  value: string,
+  { maxLength = 64 }: TruncateOptions = {},
+): string {
+  if (value.length <= maxLength) return value
+
+  const head = value.slice(0, maxLength)
+
+  return `${head}…`
+}
+
+function truncateClip(
+  value: string,
+  { maxLength = 64 }: TruncateOptions = {},
+): string {
+  if (value.length <= maxLength) return value
+
+  return value.slice(0, maxLength)
+}
+
+export function truncator(
+  style: TruncateStyle,
+  options: TruncateOptions = {},
+): (value: string) => string {
+  switch (style) {
+    case "clip":
+      return (v: string) => truncateClip(v, options)
+    case "start":
+      return (v: string) => truncateStart(v, options)
+    case "middle":
+      return (v: string) => truncateMiddle(v, options)
+    case "end":
+      return (v: string) => truncateEnd(v, options)
+  }
+}

--- a/src/pages/app/entitlement/list.tsx
+++ b/src/pages/app/entitlement/list.tsx
@@ -40,7 +40,7 @@ export default function EntitlementsList() {
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogTrigger asChild>
             <Button size="sm" disabled={entitlementsLoading}>
-              Create Entitlement
+              New Entitlement
             </Button>
           </DialogTrigger>
 

--- a/src/pages/app/group/list.tsx
+++ b/src/pages/app/group/list.tsx
@@ -43,7 +43,7 @@ export default function GroupsList() {
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogTrigger asChild>
             <Button size="sm" disabled={groupsLoading}>
-              Create Group
+              New Group
             </Button>
           </DialogTrigger>
 

--- a/src/pages/app/index.ts
+++ b/src/pages/app/index.ts
@@ -3,6 +3,7 @@ export { default as Products } from "./products"
 export { default as Policies } from "./policies"
 export { default as Entitlements } from "./entitlements"
 export { default as Licenses } from "./licenses"
+export { default as Machines } from "./machines"
 export { default as Groups } from "./groups"
 
 import * as Product from "./product"
@@ -16,6 +17,9 @@ export { Entitlement }
 
 import * as License from "./license"
 export { License }
+
+import * as Machine from "./machine"
+export { Machine }
 
 import * as Group from "./group"
 export { Group }

--- a/src/pages/app/license/list.tsx
+++ b/src/pages/app/license/list.tsx
@@ -43,7 +43,7 @@ export default function LicensesList() {
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogTrigger asChild>
             <Button size="sm" disabled={licensesLoading}>
-              Create License
+              New License
             </Button>
           </DialogTrigger>
 

--- a/src/pages/app/machine/details.tsx
+++ b/src/pages/app/machine/details.tsx
@@ -1,0 +1,659 @@
+import { useState, useEffect } from "react"
+import { useNavigate, useParams } from "@tanstack/react-router"
+import { formatDate } from "date-fns"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Separator } from "@/components/ui/separator"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent } from "@/components/ui/tabs"
+import {
+  Sidebar,
+  SidebarHeader,
+  SidebarContent,
+  SidebarFooter,
+} from "@/components/ui/sidebar"
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu"
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbPage,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+
+import {
+  Copy,
+  Logs,
+  Menu,
+  GitFork,
+  SquarePen,
+  SquarePlus,
+  EllipsisVertical,
+} from "lucide-react"
+
+import { MockGroups } from "@/types/groups"
+import { MockLicenses } from "@/types/licenses"
+import { MockMachines, MachineAttributeDescriptions } from "@/types/machines"
+
+import { useGetProduct } from "@/queries/products"
+
+import { useMobile } from "@/hooks/use-mobile"
+
+import { truncateKey } from "@/lib/licenses"
+import { copyToClipboard } from "@/lib/clipboard"
+import { getHeartbeatStatusVariant } from "@/lib/machines"
+
+import * as keygen from "@/keygen"
+import * as Machines from "@/components/machines"
+import * as Property from "@/components/property"
+import * as Attribute from "@/components/attribute"
+import Metadata from "@/components/metadata"
+import PageHeader from "@/components/page-header"
+import TabsSwitch from "@/components/tabs-switch"
+import BackButton from "@/components/back-button"
+import GoToButton from "@/components/go-to-button"
+import DeleteModal from "@/components/delete-modal"
+import CollapsibleMenu from "@/components/collapsible-menu"
+import CollapsibleCard from "@/components/collapsible-card"
+
+export default function MachineDetails() {
+  const { machineId } = useParams({ from: "/$id/app/machines/$machineId" })
+
+  const machine = MockMachines.find((m) => m.id === machineId)
+  const [machineLoading, setMachineLoading] = useState(true)
+  const machineError = false
+
+  const licenseId = machine?.relationships.license?.data?.id || ""
+  const license = MockLicenses.find((l) => l.id === licenseId)
+  const [licenseLoading, setLicenseLoading] = useState(true)
+  const licenseError = false
+
+  const groupId = machine?.relationships.group?.data?.id || ""
+  const group = MockGroups.find((g) => g.id === groupId)
+  const [groupLoading, setGroupLoading] = useState(true)
+  const groupError = false
+
+  const productId = machine?.relationships.product?.data?.id || ""
+  const {
+    data: product,
+    isLoading: productLoading,
+    isError: productError,
+  } = useGetProduct(productId)
+
+  const navigate = useNavigate()
+
+  const isMobile = useMobile()
+  const [open, setOpen] = useState({
+    edit: false,
+    delete: false,
+    attributes: false,
+  })
+
+  useEffect(() => {
+    ;(async () => {
+      if (machineError) {
+        await navigate({ to: ".." })
+      }
+    })()
+  }, [machineError, navigate])
+
+  useEffect(() => {
+    setTimeout(() => {
+      setMachineLoading(false)
+      setLicenseLoading(false)
+      setGroupLoading(false)
+    }, 300)
+  }, [])
+
+  const toggleOpen = (key: keyof typeof open, value: boolean) => {
+    setOpen((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const handleDeleteMachine = () => {
+    console.log("Machine deleted.")
+    // TODO(cazden) Implement API call to delete machine
+  }
+
+  return (
+    <section className="flex h-screen w-full">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <PageHeader>
+          <Breadcrumb className="flex-1">
+            <BreadcrumbList className="text-base">
+              <BreadcrumbItem>
+                <BreadcrumbLink
+                  className="cursor-pointer"
+                  onClick={() => navigate({ to: `..` })}
+                >
+                  Machines
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                {machine ? (
+                  <BreadcrumbPage className="w-40 truncate md:w-auto">
+                    {machine?.attributes.name ||
+                      machine?.attributes.fingerprint}
+                  </BreadcrumbPage>
+                ) : (
+                  <Skeleton className="h-6 w-32" />
+                )}
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+
+          {isMobile ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  disabled={machineLoading}
+                  className="text-content-muted"
+                >
+                  <EllipsisVertical className="size-5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="mr-4 p-0">
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    toggleOpen("edit", true)
+                    e.currentTarget.blur()
+                  }}
+                  className="pb-2 text-base"
+                >
+                  Edit
+                </DropdownMenuItem>
+                <Separator />
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    toggleOpen("delete", true)
+                    e.currentTarget.blur()
+                  }}
+                  className="pb-2 text-base"
+                >
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <div className="flex items-center space-x-2">
+              <Button
+                variant="outline"
+                disabled={machineLoading}
+                onClick={() => toggleOpen("edit", true)}
+              >
+                Edit
+              </Button>
+              <Button
+                variant="outline"
+                disabled={machineLoading}
+                onClick={() => toggleOpen("delete", true)}
+              >
+                Delete
+              </Button>
+            </div>
+          )}
+        </PageHeader>
+
+        {machine ? (
+          <ScrollArea className="min-h-0 flex-1 overflow-y-auto">
+            <div className="px-4 py-6 md:px-10 md:py-8">
+              <BackButton path=".." className="mb-8" />
+
+              <div className="flex flex-col gap-3 md:flex-row md:items-center">
+                <h1 className="font-owners-wide text-2xl font-medium">
+                  {machine?.attributes.name || machine?.attributes.fingerprint}
+                </h1>
+                <Button
+                  variant="clipboard"
+                  size="clipboard"
+                  onClick={() => copyToClipboard(machine.id)}
+                  className="w-fit pb-0.5"
+                >
+                  {machine.id}
+                  <Copy className="size-4 pt-0.5 md:size-3" />
+                </Button>
+              </div>
+
+              <div className="mt-6 space-y-6 md:mt-8">
+                <CollapsibleCard title="Attributes">
+                  <div className="flex flex-col space-y-4 md:flex-row md:space-y-0">
+                    <div className="flex-1 space-y-4">
+                      <Attribute.Field
+                        label="Fingerprint"
+                        variant="none"
+                        value={
+                          <Attribute.Value
+                            type="string"
+                            value={machine.attributes.fingerprint}
+                            tooltip={MachineAttributeDescriptions.fingerprint}
+                          />
+                        }
+                      />
+                      <Attribute.Field
+                        label="Hostname"
+                        variant="none"
+                        value={
+                          <Attribute.Value
+                            type="string"
+                            value={machine.attributes.hostname}
+                            tooltip={MachineAttributeDescriptions.hostname}
+                          />
+                        }
+                      />
+                      <Attribute.Field
+                        label="IP Address"
+                        variant="none"
+                        value={
+                          <Attribute.Value
+                            type="string"
+                            value={machine.attributes.ip}
+                            tooltip={MachineAttributeDescriptions.ip}
+                          />
+                        }
+                      />
+                    </div>
+
+                    <div className="mx-4 hidden md:block">
+                      <Separator orientation="vertical" dashed={true} />
+                    </div>
+
+                    <div className="flex-1 space-y-4">
+                      <Attribute.Field
+                        label="Platform"
+                        variant="none"
+                        value={
+                          <Attribute.Value
+                            type="string"
+                            value={machine.attributes.platform}
+                            tooltip={MachineAttributeDescriptions.platform}
+                          />
+                        }
+                      />
+                      <Attribute.Field
+                        label="CPU Cores"
+                        variant="none"
+                        value={
+                          <Attribute.Value
+                            type="number"
+                            value={machine.attributes.cores}
+                            tooltip={MachineAttributeDescriptions.cores}
+                          />
+                        }
+                      />
+                      <Attribute.Field
+                        label="Memory"
+                        variant="none"
+                        value={
+                          <Attribute.Value
+                            type="number"
+                            value={machine.attributes.memory}
+                            tooltip={MachineAttributeDescriptions.memory}
+                          />
+                        }
+                      />
+                    </div>
+                  </div>
+                </CollapsibleCard>
+
+                <CollapsibleCard title="Heartbeat monitor">
+                  <div className="flex flex-col space-y-4 md:flex-row md:space-y-0">
+                    <div className="flex-1 space-y-4">
+                      <Attribute.Field
+                        label="Require Heartbeat"
+                        variant="none"
+                        value={
+                          <Attribute.Value
+                            type="boolean"
+                            value={machine.attributes.requireHeartbeat}
+                            tooltip={
+                              MachineAttributeDescriptions.requireHeartbeat
+                            }
+                          />
+                        }
+                      />
+                      <Attribute.Field
+                        label="Heartbeat Status"
+                        variant="none"
+                        value={
+                          <Attribute.Value
+                            type="enum"
+                            value={machine.attributes.heartbeatStatus}
+                            tooltip={
+                              MachineAttributeDescriptions.heartbeatStatus
+                            }
+                            forceDisabled={
+                              getHeartbeatStatusVariant(
+                                machine.attributes.heartbeatStatus,
+                              ) === "disabled"
+                            }
+                          />
+                        }
+                      />
+                      <Attribute.Field
+                        label="Heartbeat Duration"
+                        variant="none"
+                        value={
+                          <Attribute.Value
+                            type="duration"
+                            value={machine.attributes.heartbeatDuration}
+                            tooltip={
+                              MachineAttributeDescriptions.heartbeatDuration
+                            }
+                          />
+                        }
+                      />
+                    </div>
+
+                    <div className="mx-4 hidden md:block">
+                      <Separator orientation="vertical" dashed={true} />
+                    </div>
+
+                    <div className="flex-1 space-y-4">
+                      <Attribute.Field
+                        label="Last Heartbeat"
+                        variant="none"
+                        value={
+                          <Attribute.Value
+                            type="date"
+                            value={machine.attributes.lastHeartbeat}
+                            tooltip={MachineAttributeDescriptions.lastHeartbeat}
+                          />
+                        }
+                      />
+                      <Attribute.Field
+                        label="Next Heartbeat"
+                        variant="none"
+                        value={
+                          <Attribute.Value
+                            type="date"
+                            value={machine.attributes.nextHeartbeat}
+                            tooltip={MachineAttributeDescriptions.nextHeartbeat}
+                          />
+                        }
+                      />
+                    </div>
+                  </div>
+                </CollapsibleCard>
+
+                <CollapsibleCard title="Relationships">
+                  <Attribute.Field
+                    variant="text"
+                    label="License"
+                    value={
+                      licenseError ? (
+                        <Badge variant="destructive">ERROR</Badge>
+                      ) : licenseLoading ? (
+                        <Skeleton className="h-5 w-32 rounded-sm" />
+                      ) : license ? (
+                        <GoToButton
+                          path="/$id/app/license/$licenseId"
+                          params={{
+                            id: keygen.config.id,
+                            licenseId: license.id,
+                          }}
+                          label={
+                            license.attributes.name ||
+                            truncateKey(license.attributes.key, {
+                              maxLength: isMobile ? 24 : 64,
+                            })
+                          }
+                        />
+                      ) : (
+                        <GoToButton
+                          path="/$id/app/licenses"
+                          params={{ id: keygen.config.id }}
+                          label="View all"
+                        />
+                      )
+                    }
+                  />
+
+                  <Attribute.Field
+                    variant="text"
+                    label="Product"
+                    value={
+                      productError ? (
+                        <Badge variant="destructive">ERROR</Badge>
+                      ) : productLoading ? (
+                        <Skeleton className="h-5 w-32 rounded-sm" />
+                      ) : product ? (
+                        <GoToButton
+                          path="/$id/app/product/$productId"
+                          params={{
+                            id: keygen.config.id,
+                            productId: product.id,
+                          }}
+                          label={product.attributes.name}
+                        />
+                      ) : (
+                        <GoToButton
+                          path="/$id/app/products"
+                          params={{ id: keygen.config.id }}
+                          label="View all"
+                        />
+                      )
+                    }
+                  />
+
+                  {/* TODO(cazden) Implement owner relationship */}
+                  <Attribute.Field variant="text" label="Owner" value="--" />
+
+                  <Attribute.Field
+                    variant="text"
+                    label="Group"
+                    value={
+                      groupError ? (
+                        <Badge variant="destructive">ERROR</Badge>
+                      ) : groupLoading ? (
+                        <Skeleton className="h-5 w-32 rounded-sm" />
+                      ) : group ? (
+                        <GoToButton
+                          path="/$id/app/groups/$groupId"
+                          params={{
+                            id: keygen.config.id,
+                            groupId: group.id,
+                          }}
+                          label={group.attributes.name}
+                        />
+                      ) : (
+                        "--"
+                      )
+                    }
+                  />
+
+                  <Attribute.Field
+                    variant="text"
+                    label="Components"
+                    value={
+                      <GoToButton
+                        path="/$id/app/components"
+                        params={{ id: keygen.config.id }}
+                        label="View all"
+                        disabled // TODO(cazden) Enable when components are implemented
+                      />
+                    }
+                  />
+                  <Attribute.Field
+                    variant="text"
+                    label="Processes"
+                    value={
+                      <GoToButton
+                        path="/$id/app/processes"
+                        params={{ id: keygen.config.id }}
+                        label="View all"
+                        disabled // TODO(cazden) Enable when processes are implemented
+                      />
+                    }
+                  />
+                </CollapsibleCard>
+
+                <CollapsibleCard title="Metadata" contentClass="p-0">
+                  <Metadata resource={machine} />
+                </CollapsibleCard>
+
+                {isMobile && (
+                  <CollapsibleCard
+                    title="Other attributes"
+                    contentClass="space-y-2"
+                  >
+                    {machine ? (
+                      <CollapsibleMenu title="Properties" className="space-y-2">
+                        <Attribute.Field
+                          label="Created at"
+                          value={formatDate(
+                            new Date(String(machine.attributes.created)),
+                            "PP",
+                          )}
+                        />
+                        <Attribute.Field
+                          label="Updated at"
+                          value={formatDate(
+                            new Date(String(machine.attributes.updated)),
+                            "PP",
+                          )}
+                        />
+                      </CollapsibleMenu>
+                    ) : (
+                      <div className="flex flex-col space-y-2">
+                        <Skeleton className="h-4 w-3/4" />
+                        <Skeleton className="h-4 w-1/2" />
+                        <Skeleton className="h-4 w-1/3" />
+                      </div>
+                    )}
+                  </CollapsibleCard>
+                )}
+
+                {isMobile && (
+                  <CollapsibleCard title="Events">
+                    <p className="text-sm text-content-subdued">
+                      Nothing here yet.
+                    </p>
+                  </CollapsibleCard>
+                )}
+
+                {isMobile && (
+                  <Button
+                    variant="outline"
+                    onClick={() => toggleOpen("attributes", true)}
+                    className="w-full text-content-muted"
+                  >
+                    <Logs className="mt-0.5 size-4 text-content-normal" />
+                    View All Attributes
+                  </Button>
+                )}
+              </div>
+            </div>
+          </ScrollArea>
+        ) : (
+          <div className="space-y-4 p-4 md:px-10 md:py-8">
+            <Skeleton className="h-6 w-24" />
+            <Skeleton className="h-6 w-32" />
+            <div className="mb-8 flex items-center gap-4">
+              <Skeleton className="h-8 w-48" />
+              <Skeleton className="h-8 w-32" />
+            </div>
+
+            <div className="space-y-4">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {!isMobile && (
+        <Tabs defaultValue="overview">
+          <Sidebar className="w-64 shrink-0" side="right">
+            <SidebarHeader className="p-0 pt-4">
+              <TabsSwitch
+                options={[
+                  { value: "overview", label: "Overview", icon: Menu },
+                  { value: "events", label: "Events", icon: GitFork },
+                ]}
+              />
+            </SidebarHeader>
+            <SidebarContent>
+              <TabsContent value="overview">
+                {machine ? (
+                  <>
+                    <Property.Section title="Properties" className="p-4">
+                      <Property.Field
+                        icon={SquarePlus}
+                        label="Created at"
+                        value={formatDate(
+                          new Date(String(machine.attributes.created)),
+                          "PP",
+                        )}
+                      />
+                      <Property.Field
+                        icon={SquarePen}
+                        label="Updated at"
+                        value={formatDate(
+                          new Date(String(machine.attributes.updated)),
+                          "PP",
+                        )}
+                      />
+                    </Property.Section>
+
+                    <Separator />
+                  </>
+                ) : (
+                  <div className="flex flex-col space-y-2">
+                    <Skeleton className="h-4 w-3/4" />
+                    <Skeleton className="h-4 w-1/2" />
+                    <Skeleton className="h-4 w-1/3" />
+                  </div>
+                )}
+              </TabsContent>
+
+              <TabsContent value="events" className="p-4"></TabsContent>
+            </SidebarContent>
+            <SidebarFooter className="p-4">
+              <Button
+                variant="outline"
+                onClick={() => toggleOpen("attributes", true)}
+                className="w-full text-content-muted"
+              >
+                <Logs className="mt-0.5 size-4 text-content-normal" />
+                View All Attributes
+              </Button>
+            </SidebarFooter>
+          </Sidebar>
+        </Tabs>
+      )}
+
+      <Machines.Edit.Modal
+        open={open.edit}
+        onClose={() => toggleOpen("edit", false)}
+        machine={machine!}
+      />
+
+      <DeleteModal
+        title={`Delete ${machine?.attributes.name || machine?.attributes.fingerprint}`}
+        description="Are you sure you want to delete this machine? This action cannot be undone."
+        open={open.delete}
+        disabled={machineLoading}
+        onClose={() => toggleOpen("delete", false)}
+        onDelete={handleDeleteMachine}
+      />
+
+      {machine && (
+        <Machines.AdvancedDialog
+          id={machine.id}
+          open={open.attributes}
+          onOpenChange={() => toggleOpen("attributes", false)}
+        />
+      )}
+    </section>
+  )
+}

--- a/src/pages/app/machine/index.ts
+++ b/src/pages/app/machine/index.ts
@@ -1,0 +1,2 @@
+export { default as List } from "./list"
+export { default as Details } from "./details"

--- a/src/pages/app/machine/list.tsx
+++ b/src/pages/app/machine/list.tsx
@@ -1,0 +1,73 @@
+import { useState, useEffect } from "react"
+import { useNavigate } from "@tanstack/react-router"
+
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogTrigger } from "@/components/ui/dialog"
+
+import { useMachineTableColumns } from "@/hooks/use-machine-table-columns"
+import { Machine, MockMachines } from "@/types/machines"
+
+import * as keygen from "@/keygen"
+import * as Machines from "@/components/machines"
+import * as Skeletons from "@/components/skeletons"
+import DataTable from "@/components/data-table"
+import PageHeader from "@/components/page-header"
+
+export default function MachinesList() {
+  const [machinesLoading, setMachinesLoading] = useState(true)
+  const columns = useMachineTableColumns()
+
+  const navigate = useNavigate()
+
+  const [open, setOpen] = useState(false)
+
+  const handleSelectMachine = async (machine: Machine | null) => {
+    if (!machine) return
+
+    await navigate({
+      to: "/$id/app/machines/$machineId",
+      params: { id: keygen.config.id, machineId: machine.id },
+    })
+  }
+
+  useEffect(() => {
+    setTimeout(() => {
+      setMachinesLoading(false)
+    }, 300)
+  }, [])
+
+  return (
+    <section>
+      <PageHeader title="Machines">
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button size="sm" disabled={machinesLoading}>
+              New Machine
+            </Button>
+          </DialogTrigger>
+
+          <Machines.Create.Modal
+            onSelectMachine={(machine) => handleSelectMachine(machine)}
+            onClose={() => setOpen(false)}
+          />
+        </Dialog>
+      </PageHeader>
+
+      {machinesLoading ? (
+        <Skeletons.Table />
+      ) : (
+        <DataTable<Machine>
+          data={MockMachines}
+          columns={columns}
+          hideOnMobile={[
+            "relationships.license",
+            "relationships.product",
+            "attributes.created",
+            "attributes.updated",
+          ]}
+          onRowClick={(m) => handleSelectMachine(m)}
+        />
+      )}
+    </section>
+  )
+}

--- a/src/pages/app/machines.tsx
+++ b/src/pages/app/machines.tsx
@@ -1,0 +1,26 @@
+import { Outlet, useParams } from "@tanstack/react-router"
+
+import { MachineView } from "@/types/machines"
+
+import * as Motion from "@/components/motion"
+import * as Page from "@/pages"
+
+export default function Machines() {
+  const { machineId } = useParams({ strict: false })
+
+  const view = machineId ? MachineView.Details : MachineView.List
+
+  const direction: 1 | -1 = view === MachineView.Details ? 1 : -1
+
+  const key = view === MachineView.List ? "list" : `details-${machineId}`
+
+  return (
+    <Motion.Slide direction={direction}>
+      {view === MachineView.List ? (
+        <Page.App.Machine.List key={key} />
+      ) : (
+        <Outlet key={key} />
+      )}
+    </Motion.Slide>
+  )
+}

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -39,7 +39,7 @@ export default function PoliciesList() {
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogTrigger asChild>
             <Button size="sm" disabled={policiesLoading}>
-              Create Policy
+              New Policy
             </Button>
           </DialogTrigger>
 

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -40,7 +40,7 @@ export default function ProductsList() {
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogTrigger asChild>
             <Button size="sm" disabled={isLoading}>
-              Create Product
+              New Product
             </Button>
           </DialogTrigger>
 

--- a/src/routes/$id/app.machines.$machineId.tsx
+++ b/src/routes/$id/app.machines.$machineId.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import * as Page from "@/pages/index"
+
+export const Route = createFileRoute("/$id/app/machines/$machineId")({
+  component: () => <Page.App.Machine.Details />,
+})

--- a/src/routes/$id/app.machines.tsx
+++ b/src/routes/$id/app.machines.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import * as Page from "@/pages/index"
+
+export const Route = createFileRoute("/$id/app/machines")({
+  component: () => <Page.App.Machines />,
+})

--- a/src/types/machines.ts
+++ b/src/types/machines.ts
@@ -1,0 +1,110 @@
+import { APIResponse, Resource, Relationship, Linkage } from "@/types/api"
+
+export enum MachineMode {
+  View = "view",
+  Edit = "edit",
+  Create = "create",
+}
+
+export enum MachineView {
+  List = "list",
+  Details = "details",
+}
+
+export enum HeartbeatStatus {
+  NotStarted = "NOT_STARTED",
+  Alive = "ALIVE",
+  Dead = "DEAD",
+  Resurrected = "RESURRECTED",
+}
+
+export type MachineAttributes = {
+  fingerprint: string
+  name: string | null
+  ip: string | null
+  hostname: string | null
+  platform: string | null
+  cores: number | null
+  memory: number | null
+  disk: number | null
+  requireHeartbeat: boolean
+  heartbeatStatus: HeartbeatStatus
+  heartbeatDuration: number | null
+  lastHeartbeat: string | null
+  nextHeartbeat: string | null
+  lastCheckOut: string | null
+  maxProcesses: number | null
+  metadata: Record<string, unknown>
+  created: string
+  updated: string
+}
+
+export interface MachineInput {
+  fingerprint?: string
+  name?: string | null
+  ip?: string | null
+  hostname?: string | null
+  platform?: string | null
+  cores?: number | null
+  memory?: number | null
+  disk?: number | null
+  metadata?: Record<string, unknown>
+}
+
+export type MachineRelationships = {
+  account: Relationship<Linkage<"accounts">>
+  environment: Relationship<Linkage<"environments"> | null>
+  product: Relationship<Linkage<"products">>
+  license: Relationship<Linkage<"licenses">>
+  owner: Relationship<Linkage<"users"> | null>
+  group: Relationship<Linkage<"groups"> | null>
+  components: Relationship<Linkage<"components">[]>
+  processes: Relationship<Linkage<"processes">[]>
+}
+
+export type Machine = Resource<
+  "machines",
+  MachineAttributes,
+  MachineRelationships
+>
+
+export type MachineResponse = APIResponse<Machine>
+export type MachineListResponse = APIResponse<Machine[]>
+
+export const MachineAttributeDescriptions: Readonly<
+  Record<keyof Omit<MachineAttributes, "created" | "updated">, string>
+> = {
+  fingerprint: "The unique fingerprint of the machine.",
+  name: "The human-readable name of the machine.",
+  ip: "The IP of the machine.",
+  hostname: "The hostname of the machine.",
+  platform: "The platform of the machine.",
+  cores: "The number of CPU cores for the machine.",
+  memory: "The amount of memory for the machine.",
+  disk: "The amount of disk for the machine.",
+  requireHeartbeat:
+    "Whether or not the machine requires heartbeat pings, i.e. the policy requires heartbeats, or the machine has an active heartbeat monitor.",
+  heartbeatStatus: "The status of the machine's heartbeat.",
+  heartbeatDuration:
+    "The duration in seconds for the machine's heartbeat window. Inherited from the license's policy.",
+  lastHeartbeat:
+    "The time at which the machine last sent a heartbeat ping (UTC timezone).",
+  nextHeartbeat:
+    "The time at which the machine must send a heartbeat ping by to remain active (UTC timezone).",
+  lastCheckOut:
+    "The time at which the machine was last checked-out (UTC timezone).",
+  maxProcesses:
+    "The maximum number of processes the machine can have associated with it. Inherited from its license.",
+  metadata:
+    "Store arbitrary key/value data on the machine for book keeping purposes, entitlements, etc.",
+} as const
+
+export const MachineFormFieldDescriptions: Readonly<
+  Record<keyof Omit<MachineAttributes, "created" | "updated">, string>
+> = {
+  ...MachineAttributeDescriptions,
+  fingerprint:
+    "This can be an arbitrary string, but must be unique within the scope of the license it belongs to.",
+}
+
+export const MockMachines: Machine[] = []


### PR DESCRIPTION
Adds base interface for the Machines resource that includes list and details pages, CRUD dialogs/forms, and mobile styles. Also adds a new Search Select component for searching resources by ID/name or custom parameters per resource (e.g. licenses would be searchable by id or name, or key if name isn't set).