### PR TITLE
Add components interface for CRUD actions

### DIFF
--- a/src/components/components/advanced-dialog.tsx
+++ b/src/components/components/advanced-dialog.tsx
@@ -1,0 +1,117 @@
+import { useState, useEffect } from "react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent } from "@/components/ui/tabs"
+import {
+  Dialog,
+  DialogHeader,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+
+import { Text, CurlyBraces } from "lucide-react"
+
+import { MockComponents } from "@/types/components"
+
+import * as Components from "@/components/components"
+import Metadata from "@/components/metadata"
+import TabsSwitch from "@/components/tabs-switch"
+import InspectResource from "@/components/inspect-resource"
+import CollapsibleCard from "@/components/collapsible-card"
+
+interface AdvancedDialogProps {
+  id: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export default function AdvancedDialog({
+  id,
+  open,
+  onOpenChange,
+}: AdvancedDialogProps) {
+  const component = MockComponents.find((c) => c.id === id)
+  const componentLoading = false
+  const componentFetching = false
+  const componentError = !component
+
+  const [tab, setTab] = useState<"attributes" | "inspect">("attributes")
+
+  useEffect(() => {
+    if (componentError && !componentFetching) {
+      onOpenChange(false)
+    }
+  }, [componentError, componentFetching, onOpenChange])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[calc(100dvh-2rem)] w-full flex-col overflow-hidden p-0 md:min-w-4xl">
+        <DialogHeader className="flex items-start border-b border-accent p-4 pt-3">
+          <DialogTitle className="text-base">Advanced</DialogTitle>
+          <DialogDescription className="sr-only">Advanced</DialogDescription>
+        </DialogHeader>
+        <div className="flex min-h-0 flex-1 flex-col">
+          {!component || componentLoading ? (
+            <div className="space-y-4 p-4">
+              <div className="flex items-center gap-4">
+                <Skeleton className="h-8 w-48" />
+                <Skeleton className="h-8 w-32" />
+              </div>
+
+              <div className="space-y-4">
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            </div>
+          ) : (
+            <Tabs
+              value={tab}
+              onValueChange={(value) => setTab(value as typeof tab)}
+              className="flex min-h-0 min-w-0 flex-1 flex-col gap-0"
+            >
+              <TabsSwitch
+                className="pt-8 pb-0"
+                options={[
+                  {
+                    value: "attributes",
+                    label: "Other attributes",
+                    icon: Text,
+                  },
+                  {
+                    value: "inspect",
+                    label: "Inspect component",
+                    icon: CurlyBraces,
+                  },
+                ]}
+              />
+              <TabsContent
+                value="attributes"
+                className="flex min-h-0 min-w-0 flex-1 flex-col"
+              >
+                <ScrollArea className="min-h-0 w-full min-w-0">
+                  <div className="flex min-w-0 flex-col gap-2 p-2">
+                    <Components.AllAttributes component={component} />
+
+                    <CollapsibleCard title="Metadata" contentClass="p-0">
+                      <Metadata resource={component} className="p-2" />
+                    </CollapsibleCard>
+                  </div>
+                </ScrollArea>
+              </TabsContent>
+
+              <TabsContent
+                value="inspect"
+                className="flex min-h-0 min-w-0 flex-1 p-0"
+              >
+                <InspectResource resource={component} />
+              </TabsContent>
+            </Tabs>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/components/all-attributes.tsx
+++ b/src/components/components/all-attributes.tsx
@@ -1,0 +1,31 @@
+import { humanize } from "@/lib/utils"
+import { componentAttributeTypeSchema } from "@/lib/components"
+
+import { Component } from "@/types/components"
+
+import AttributeGroup from "@/components/components/attribute-group"
+
+type Key = keyof typeof componentAttributeTypeSchema
+
+interface AllAttributesProps {
+  component: Component
+  className?: string
+}
+
+export default function AllAttributes({
+  component,
+  className,
+}: AllAttributesProps): React.ReactElement {
+  const keys = (Object.keys(componentAttributeTypeSchema) as Key[]).sort(
+    (a, b) => humanize(a).localeCompare(humanize(b)),
+  )
+
+  return (
+    <AttributeGroup
+      component={component}
+      title="Attributes"
+      keys={keys}
+      className={className}
+    />
+  )
+}

--- a/src/components/components/attribute-group.tsx
+++ b/src/components/components/attribute-group.tsx
@@ -1,0 +1,58 @@
+import { humanize } from "@/lib/utils"
+import { componentAttributeTypeSchema } from "@/lib/components"
+import { Component, ComponentAttributeDescriptions } from "@/types/components"
+import * as Attribute from "@/components/attribute"
+import CollapsibleCard from "@/components/collapsible-card"
+
+type Key = keyof typeof componentAttributeTypeSchema
+
+type AttributeGroupProps = {
+  component: Component
+  title: string
+  keys: readonly Key[]
+  when?: (component: Component) => boolean
+  className?: string
+}
+
+export default function AttributeGroup({
+  component,
+  title,
+  keys,
+  when,
+  className,
+}: AttributeGroupProps): React.ReactElement | null {
+  if (when && !when(component)) return null
+  if (keys.length === 0) return null
+
+  const middle = Math.ceil(keys.length / 2)
+  const left = keys.slice(0, middle)
+  const right = keys.slice(middle)
+
+  const row = (k: Key) => (
+    <Attribute.Field
+      key={k}
+      label={humanize(k)}
+      variant="none"
+      value={
+        <Attribute.Value
+          type={componentAttributeTypeSchema[k]}
+          value={component.attributes[k]}
+          tooltip={
+            (ComponentAttributeDescriptions as Record<Key, string | undefined>)[
+              k
+            ]
+          }
+        />
+      }
+    />
+  )
+
+  return (
+    <CollapsibleCard title={title} contentClass={className}>
+      <div className="md:grid md:grid-cols-2 md:gap-x-6 md:divide-x md:divide-dashed">
+        <div className="space-y-4 md:pr-3">{left.map(row)}</div>
+        <div className="mt-4 space-y-4 md:mt-0 md:pl-3">{right.map(row)}</div>
+      </div>
+    </CollapsibleCard>
+  )
+}

--- a/src/components/components/create/index.ts
+++ b/src/components/components/create/index.ts
@@ -1,0 +1,1 @@
+export { default as Modal } from "./modal"

--- a/src/components/components/create/modal.tsx
+++ b/src/components/components/create/modal.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useState } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+
+import { Form } from "@/components/ui/form"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog"
+
+import * as Forms from "@/forms"
+
+import { MockMachines } from "@/types/machines"
+import { Component, MockComponents } from "@/types/components"
+
+import { toast } from "@/lib/toast"
+
+import * as Loading from "@/components/loading"
+import * as Components from "@/components/components"
+import DocumentationLink from "@/components/documentation-link"
+
+interface ComponentsCreateModalProps {
+  onSelectComponent: (component: Component | null) => void
+  onClose: () => void
+}
+
+export default function ComponentsCreateModal({
+  onSelectComponent,
+  onClose,
+}: ComponentsCreateModalProps) {
+  const [loading, setLoading] = useState(false)
+
+  const form = useForm<Forms.Components.CreateValues>({
+    resolver: zodResolver(Forms.Components.CreateSchema),
+    mode: "onChange",
+    defaultValues: {
+      fingerprint: "",
+      name: "",
+      metadata: {},
+      machineId: "",
+    },
+  })
+
+  const handleCreateComponent = useCallback(
+    (values: Forms.Components.CreateValues) => {
+      if (!values.machineId) {
+        toast({
+          message: "Failed to create component",
+          description: "Machine is required.",
+          variant: "error",
+        })
+        return
+      }
+
+      const machine = MockMachines.find((m) => m.id === values.machineId)
+      const licenseId = machine?.relationships?.license?.data?.id
+      const productId = machine?.relationships?.product?.data?.id
+
+      setLoading(true)
+
+      const newComponent: Component = {
+        id: crypto.randomUUID(),
+        type: "components",
+        links: {
+          self: `/v1/accounts/{ACCOUNT}/components/${crypto.randomUUID()}`,
+        },
+        attributes: {
+          fingerprint: values.fingerprint,
+          name: values.name ?? null,
+          metadata: values.metadata ?? {},
+          created: new Date().toISOString(),
+          updated: new Date().toISOString(),
+        },
+        relationships: {
+          account: {
+            links: { related: "/v1/accounts/{ACCOUNT}" },
+            data: { type: "accounts", id: "{ACCOUNT}" },
+          },
+          environment: {
+            links: { related: null },
+            data: null,
+          },
+          product: {
+            links: { related: null },
+            data: productId ? { type: "products", id: productId } : undefined,
+          },
+          license: {
+            links: { related: null },
+            data: licenseId ? { type: "licenses", id: licenseId } : undefined,
+          },
+          machine: {
+            links: { related: null },
+            data: { type: "machines", id: values.machineId },
+          },
+        },
+      }
+
+      MockComponents.push(newComponent)
+      setLoading(false)
+      toast({ message: "Component created", variant: "success" })
+      onSelectComponent(newComponent)
+      onClose()
+    },
+    [onSelectComponent, onClose],
+  )
+
+  return (
+    <DialogContent className="min-w-fit">
+      <DialogHeader className="h-fit items-start border-b border-accent p-4">
+        <DialogDescription className="text-xs">
+          Creating a new component
+        </DialogDescription>
+        <DialogTitle className="sr-only">New Component</DialogTitle>
+      </DialogHeader>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(handleCreateComponent)}>
+          <ScrollArea className="h-[calc(100vh-11rem)] md:h-[50vh] md:w-4xl">
+            <Components.Fields.All layout="create" />
+
+            <DocumentationLink page="components" />
+          </ScrollArea>
+
+          <DialogFooter className="flex flex-row gap-4 border-t border-accent p-4">
+            <Button
+              variant="outline"
+              type="button"
+              onClick={onClose}
+              disabled={loading}
+              className="max-w-48 flex-1 basis-1/2"
+            >
+              Cancel
+            </Button>
+
+            <Button
+              type="submit"
+              disabled={loading}
+              className="max-w-48 flex-1 basis-1/2"
+            >
+              {loading ? <Loading.Dots className="bg-background" /> : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </Form>
+    </DialogContent>
+  )
+}

--- a/src/components/components/edit/edit-form.tsx
+++ b/src/components/components/edit/edit-form.tsx
@@ -1,0 +1,81 @@
+import { useCallback } from "react"
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+
+import { Form } from "@/components/ui/form"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { DialogFooter } from "@/components/ui/dialog"
+
+import * as Forms from "@/forms"
+import { Component } from "@/types/components"
+
+import * as Loading from "@/components/loading"
+import * as Components from "@/components/components"
+import DocumentationLink from "@/components/documentation-link"
+
+interface EditFormProps {
+  component: Component
+  loading?: boolean
+  onUpdate: (values: Forms.Components.UpdateValues) => Promise<void> | void
+  onCancel: () => void
+}
+
+export default function EditForm({
+  component,
+  loading,
+  onUpdate,
+  onCancel,
+}: EditFormProps) {
+  const form = useForm<Forms.Components.UpdateValues>({
+    resolver: zodResolver(Forms.Components.UpdateSchema),
+    mode: "onChange",
+    defaultValues: {
+      name: component.attributes.name ?? "",
+      metadata: component.attributes.metadata ?? {},
+    },
+  })
+
+  const update = useCallback(
+    async (values: Forms.Components.UpdateValues) => {
+      await onUpdate(values)
+    },
+    [onUpdate],
+  )
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault()
+          await form.handleSubmit(update)()
+        }}
+      >
+        <ScrollArea type="always" className="h-[calc(100dvh-8rem)]">
+          <Components.Fields.All />
+
+          <DocumentationLink page="components" />
+        </ScrollArea>
+
+        <DialogFooter className="flex flex-row gap-4 border-t border-accent p-4">
+          <Button
+            variant="outline"
+            type="button"
+            onClick={onCancel}
+            disabled={loading}
+            className="max-w-48 flex-1 basis-1/2"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            disabled={loading}
+            className="max-w-48 flex-1 basis-1/2"
+          >
+            {loading ? <Loading.Dots className="bg-background" /> : "Update"}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
+  )
+}

--- a/src/components/components/edit/index.ts
+++ b/src/components/components/edit/index.ts
@@ -1,0 +1,1 @@
+export { default as Modal } from "./modal"

--- a/src/components/components/edit/modal.tsx
+++ b/src/components/components/edit/modal.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useState } from "react"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+
+import { toast } from "@/lib/toast"
+
+import * as Forms from "@/forms"
+import { Component, MockComponents } from "@/types/components"
+
+import EditForm from "./edit-form"
+
+import * as Loading from "@/components/loading"
+
+interface ComponentsEditModalProps {
+  open: boolean
+  onClose: () => void
+  component: Component | null
+}
+
+export default function ComponentsEditModal({
+  open,
+  onClose,
+  component,
+}: ComponentsEditModalProps) {
+  const [loading, setLoading] = useState(false)
+
+  const handleUpdateComponent = useCallback(
+    (values: Forms.Components.UpdateValues) => {
+      if (!component) return
+
+      setLoading(true)
+
+      const index = MockComponents.findIndex((c) => c.id === component.id)
+      if (index === -1) {
+        toast({ message: "Component not found", variant: "error" })
+        setLoading(false)
+        return
+      }
+
+      const updated: Component = {
+        ...component,
+        attributes: {
+          ...component.attributes,
+          name:
+            values.name !== undefined ? values.name : component.attributes.name,
+          metadata: values.metadata ?? component.attributes.metadata,
+          updated: new Date().toISOString(),
+        },
+      }
+
+      MockComponents[index] = updated
+      setLoading(false)
+      toast({ message: "Component updated", variant: "success" })
+      onClose()
+    },
+    [component, onClose],
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+        className="min-h-screen min-w-screen rounded-none border-none"
+      >
+        <DialogHeader className="h-fit border-b border-accent p-2">
+          <DialogDescription className="flex h-8 items-center space-x-1 text-xs">
+            Updating an existing component
+          </DialogDescription>
+          <DialogTitle className="sr-only" />
+        </DialogHeader>
+        {!component ? (
+          <div className="flex w-full justify-center">
+            <Loading.Dots />
+          </div>
+        ) : (
+          open && (
+            <EditForm
+              component={component}
+              loading={loading}
+              onUpdate={handleUpdateComponent}
+              onCancel={onClose}
+            />
+          )
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/components/fields/all.tsx
+++ b/src/components/components/fields/all.tsx
@@ -1,0 +1,214 @@
+import { useFormContext } from "react-hook-form"
+
+import { Input } from "@/components/ui/input"
+import { Separator } from "@/components/ui/separator"
+import {
+  FormField,
+  FormItem,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form"
+
+import { cn } from "@/lib/utils"
+
+import * as Forms from "@/forms"
+
+import { MockMachines } from "@/types/machines"
+import { ComponentFormFieldDescriptions } from "@/types/components"
+
+import * as Field from "@/components/field"
+import SectionCard from "@/components/section-card"
+import SearchSelect from "@/components/search-select"
+import KeyValueInput from "@/components/key-value-input"
+
+type Layout = "create" | "edit"
+
+interface AllFieldsProps {
+  layout?: Layout
+  className?: string
+}
+
+export default function AllFields({
+  layout = "edit",
+  className,
+}: AllFieldsProps): React.ReactElement {
+  return layout === "edit" ? (
+    <EditLayout className={className} />
+  ) : (
+    <CreateLayout className={className} />
+  )
+}
+
+function CreateLayout({
+  className,
+}: Omit<AllFieldsProps, "layout">): React.ReactElement {
+  const form = useFormContext<Forms.Components.CreateValues>()
+
+  return (
+    <div className={cn("m-4 md:mb-0", className)}>
+      <FormField
+        control={form.control}
+        name="name"
+        render={({ field }) => (
+          <FormItem className="m-4 md:my-6">
+            <FormControl>
+              <Input
+                {...field}
+                value={field.value || ""}
+                variant="title"
+                placeholder="Enter component name..."
+                className="border-none text-xl placeholder:text-content-subdued! md:text-2xl"
+                autoFocus={!field.value}
+                autoComplete="off"
+              />
+            </FormControl>
+            <FormMessage className="ml-2" />
+          </FormItem>
+        )}
+      />
+
+      <SectionCard title="Component configuration">
+        <div className="flex flex-col gap-4 md:flex-row">
+          <div className="flex-1 space-y-4">
+            <FormField
+              control={form.control}
+              name="fingerprint"
+              render={({ field }) => (
+                <FormItem>
+                  <Field.Header
+                    label="Fingerprint"
+                    variant="stacking"
+                    tooltip={ComponentFormFieldDescriptions.fingerprint}
+                  >
+                    <FormControl>
+                      <Input
+                        {...field}
+                        value={field.value || ""}
+                        placeholder="Enter component fingerprint..."
+                      />
+                    </FormControl>
+                  </Field.Header>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="machineId"
+              render={({ field, fieldState }) => (
+                <FormItem>
+                  <Field.Header
+                    label="Machine"
+                    variant="stacking"
+                    tooltip={ComponentFormFieldDescriptions.machine}
+                  >
+                    <SearchSelect
+                      resource="machine"
+                      value={field.value}
+                      onChange={(value) => field.onChange(value)}
+                      options={MockMachines}
+                      allowClear={false}
+                      invalid={!!fieldState.error}
+                      truncate="middle"
+                    />
+                  </Field.Header>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          <div className="mx-4 hidden md:block">
+            <Separator orientation="vertical" dashed={true} />
+          </div>
+
+          <div className="flex-1 space-y-4">
+            <FormField
+              control={form.control}
+              name="metadata"
+              render={() => (
+                <FormItem>
+                  <Field.Header
+                    label="Metadata"
+                    variant="stacking"
+                    optional
+                    tooltip={ComponentFormFieldDescriptions.metadata}
+                  >
+                    <FormControl>
+                      <KeyValueInput<Forms.Components.CreateValues> name="metadata" />
+                    </FormControl>
+                  </Field.Header>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </div>
+      </SectionCard>
+    </div>
+  )
+}
+
+function EditLayout({
+  className,
+}: Omit<AllFieldsProps, "layout">): React.ReactElement {
+  const form = useFormContext<Forms.Components.UpdateValues>()
+
+  return (
+    <div className={cn("p-4", className)}>
+      <h2 className="text-content-loud/90">Attributes</h2>
+      <section className="mt-4 flex flex-col md:flex-row">
+        <div className="w-full space-y-6">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <Field.Header
+                  label="Component name"
+                  variant="stacking"
+                  tooltip={ComponentFormFieldDescriptions.name}
+                >
+                  <FormControl>
+                    <Input
+                      {...field}
+                      value={field.value || ""}
+                      placeholder="Enter component name..."
+                      autoComplete="off"
+                    />
+                  </FormControl>
+                </Field.Header>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <div className="mx-8 hidden md:block">
+          <Separator orientation="vertical" dashed />
+        </div>
+
+        <div className="mt-4 w-full space-y-6 md:mt-0">
+          <FormField
+            control={form.control}
+            name="metadata"
+            render={() => (
+              <FormItem>
+                <Field.Header
+                  label="Metadata"
+                  variant="stacking"
+                  tooltip={ComponentFormFieldDescriptions.metadata}
+                >
+                  <FormControl>
+                    <KeyValueInput<Forms.Components.UpdateValues> name="metadata" />
+                  </FormControl>
+                </Field.Header>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/components/fields/index.ts
+++ b/src/components/components/fields/index.ts
@@ -1,0 +1,1 @@
+export { default as All } from "./all"

--- a/src/components/components/index.ts
+++ b/src/components/components/index.ts
@@ -6,3 +6,7 @@ export { Edit }
 
 import * as Fields from "./fields"
 export { Fields }
+
+export { default as AttributeGroup } from "./attribute-group"
+export { default as AllAttributes } from "./all-attributes"
+export { default as AdvancedDialog } from "./advanced-dialog"

--- a/src/components/components/index.ts
+++ b/src/components/components/index.ts
@@ -1,2 +1,8 @@
+import * as Create from "./create"
+export { Create }
+
+import * as Edit from "./edit"
+export { Edit }
+
 import * as Fields from "./fields"
 export { Fields }

--- a/src/components/components/index.ts
+++ b/src/components/components/index.ts
@@ -1,0 +1,2 @@
+import * as Fields from "./fields"
+export { Fields }

--- a/src/components/inspect-resource.tsx
+++ b/src/components/inspect-resource.tsx
@@ -8,13 +8,21 @@ import { Policy } from "@/types/policies"
 import { Machine } from "@/types/machines"
 import { Product } from "@/types/products"
 import { License } from "@/types/licenses"
+import { Component } from "@/types/components"
 import { Entitlement } from "@/types/entitlements"
 
 import { cn } from "@/lib/utils"
 import { copyToClipboard } from "@/lib/clipboard"
 
 interface InspectResourceProps {
-  resource: Policy | Product | License | Entitlement | Group | Machine
+  resource:
+    | Policy
+    | Product
+    | License
+    | Entitlement
+    | Group
+    | Machine
+    | Component
   className?: string
 }
 

--- a/src/components/search-select.tsx
+++ b/src/components/search-select.tsx
@@ -15,6 +15,7 @@ import { ChevronsUpDown } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { getGroupLabel } from "@/lib/groups"
 import { getLicenseLabel } from "@/lib/licenses"
+import { getMachineLabel } from "@/lib/machines"
 import { truncator, TruncateStyle } from "@/lib/truncate"
 
 import * as keygen from "@/keygen"
@@ -24,7 +25,7 @@ import GoToButton from "@/components/go-to-button"
 type BaseOption = { id: string }
 type NamedOption = BaseOption & { attributes: { name: string } }
 
-type ResourceType = "license" | "group" | "user"
+type ResourceType = "license" | "group" | "user" | "machine"
 
 interface ResourceConfig {
   getLabel: (option: BaseOption) => string
@@ -77,6 +78,21 @@ const resourceConfigs: Record<ResourceType, ResourceConfig> = {
           params={{ id: keygen.config.id }}
           label="View users"
         /> */}
+      </span>
+    ),
+  },
+  machine: {
+    getLabel: getMachineLabel as (option: BaseOption) => string,
+    placeholder: "Select a machine...",
+    searchPlaceholder: "Search by ID, name, or fingerprint...",
+    emptyMessage: (
+      <span className="flex items-center gap-2">
+        No machines found.
+        <GoToButton
+          path="/$id/app/machines"
+          params={{ id: keygen.config.id }}
+          label="View machines"
+        />
       </span>
     ),
   },

--- a/src/components/sidebar/panel.tsx
+++ b/src/components/sidebar/panel.tsx
@@ -123,6 +123,11 @@ const licensingOptions = linkOptions([
     params: { id: keygen.config.id },
   },
   {
+    to: "/$id/app/components",
+    label: "Components",
+    params: { id: keygen.config.id },
+  },
+  {
     to: "/$id/app/groups",
     label: "Groups",
     params: { id: keygen.config.id },

--- a/src/components/tables/index.ts
+++ b/src/components/tables/index.ts
@@ -1,3 +1,4 @@
 export { default as LicenseCell } from "./license-cell"
+export { default as MachineCell } from "./machine-cell"
 export { default as PolicyCell } from "./policy-cell"
 export { default as ProductCell } from "./product-cell"

--- a/src/components/tables/machine-cell.tsx
+++ b/src/components/tables/machine-cell.tsx
@@ -1,0 +1,29 @@
+// TODO(cazden) Add machines query
+// import { useGetMachine } from "@/queries/machines"
+
+import ResourceCell from "./resource-cell"
+
+interface MachineCellProps {
+  id: string | undefined
+}
+
+export default function MachineCell({
+  id,
+}: MachineCellProps): React.ReactElement {
+  if (!id) return <ResourceCell isEmpty />
+  return <MachineCellContent id={id} />
+}
+
+function MachineCellContent({ id }: { id: string }): React.ReactElement {
+  // const { data, isLoading: machineLoading } = useGetMachine(id)
+
+  void id
+  const data = { attributes: { name: "--" } }
+  const machineLoading = false
+
+  return (
+    <ResourceCell isEmpty={!data} isLoading={machineLoading}>
+      {data?.attributes.name}
+    </ResourceCell>
+  )
+}

--- a/src/forms/components.ts
+++ b/src/forms/components.ts
@@ -1,0 +1,36 @@
+import { z } from "zod"
+
+import { Writable, OptionalExcept } from "@/types/api"
+import { ComponentAttributes } from "@/types/components"
+
+export type BaseValues = Writable<OptionalExcept<ComponentAttributes, "name">>
+export type CreateValues = BaseValues & {
+  fingerprint: string
+  machineId: string
+}
+export type UpdateValues = Partial<BaseValues>
+
+const BaseShape = z.object({
+  name: z.string().trim().min(1, "Name is required"),
+  metadata: z.record(z.unknown()).default({}),
+})
+
+const FingerprintShape = z.object({
+  fingerprint: z.string().trim().min(1, "Fingerprint is required"),
+})
+
+const MachineRelationshipShape = z.object({
+  machineId: z.string().min(1, "Machine is required"),
+})
+
+const BaseRules = (schema: z.ZodType<BaseValues>): z.ZodType<BaseValues> => {
+  // Custom rules can be added here in the future, e.g.
+  // schema.refine(...)
+  return schema
+}
+
+export const BaseSchema: z.ZodType<BaseValues> = BaseRules(BaseShape)
+export const CreateSchema: z.ZodType<CreateValues> = BaseRules(
+  BaseShape.merge(FingerprintShape).merge(MachineRelationshipShape),
+) as z.ZodType<CreateValues>
+export const UpdateSchema: z.ZodType<UpdateValues> = BaseSchema

--- a/src/forms/index.ts
+++ b/src/forms/index.ts
@@ -18,3 +18,6 @@ export { Machines }
 
 import * as Groups from "./groups"
 export { Groups }
+
+import * as Components from "./components"
+export { Components }

--- a/src/hooks/use-component-table-columns.tsx
+++ b/src/hooks/use-component-table-columns.tsx
@@ -1,0 +1,54 @@
+import { useMemo } from "react"
+
+import { Component } from "@/types/components"
+
+import { createTableColumnHelper } from "@/lib/tables"
+
+import * as Tables from "@/components/tables"
+import ClipboardButton from "@/components/clipboard-button"
+
+const column = createTableColumnHelper<Component>()
+
+export function useComponentTableColumns() {
+  const columns = useMemo(
+    () => [
+      column.id({
+        header: "ID",
+        cell: (info) => <ClipboardButton value={info.getValue()} />,
+      }),
+      column.attr("name", {
+        header: "Name",
+        cell: (info) =>
+          info.getValue() || <span className="text-content-muted">--</span>,
+      }),
+      column.attr("fingerprint", {
+        header: "Fingerprint",
+        cell: (info) =>
+          info.getValue() || <span className="text-content-muted">--</span>,
+      }),
+      column.rel("machine", {
+        sortingFn: "alphanumeric",
+        header: "Machine",
+        cell: (info) => <Tables.MachineCell id={info.getValue()?.data?.id} />,
+      }),
+      column.rel("license", {
+        sortingFn: "alphanumeric",
+        header: "License",
+        cell: (info) => <Tables.LicenseCell id={info.getValue()?.data?.id} />,
+      }),
+      column.attr("created", {
+        sortingFn: "datetime",
+        header: "Created",
+        cell: (info) => new Date(info.getValue()).toLocaleDateString(),
+      }),
+      column.attr("updated", {
+        sortingFn: "datetime",
+        header: "Updated",
+        cell: (info) => new Date(info.getValue()).toLocaleDateString(),
+      }),
+    ],
+    [],
+  )
+
+  return columns
+}

--- a/src/lib/components.ts
+++ b/src/lib/components.ts
@@ -1,0 +1,11 @@
+import { AttributeType } from "@/components/attribute/value"
+
+import { Component } from "@/types/components"
+
+export const componentAttributeTypeSchema: Record<
+  keyof Omit<Component["attributes"], "metadata" | "created" | "updated">,
+  AttributeType
+> = {
+  fingerprint: "string",
+  name: "string",
+}

--- a/src/lib/machines.ts
+++ b/src/lib/machines.ts
@@ -36,3 +36,7 @@ export const getHeartbeatStatusVariant = (
       return "default"
   }
 }
+
+export function getMachineLabel(machine: Machine) {
+  return machine.attributes.name || machine.attributes.fingerprint
+}

--- a/src/pages/app/component/details.tsx
+++ b/src/pages/app/component/details.tsx
@@ -1,0 +1,519 @@
+import { useState, useEffect } from "react"
+import { useNavigate, useParams } from "@tanstack/react-router"
+import { formatDate } from "date-fns"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Separator } from "@/components/ui/separator"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent } from "@/components/ui/tabs"
+import {
+  Sidebar,
+  SidebarHeader,
+  SidebarContent,
+  SidebarFooter,
+} from "@/components/ui/sidebar"
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu"
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbPage,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+
+import {
+  Copy,
+  Logs,
+  Menu,
+  GitFork,
+  SquarePen,
+  SquarePlus,
+  EllipsisVertical,
+} from "lucide-react"
+
+import { MockMachines } from "@/types/machines"
+import { MockLicenses } from "@/types/licenses"
+import {
+  MockComponents,
+  ComponentAttributeDescriptions,
+} from "@/types/components"
+
+import { useGetProduct } from "@/queries/products"
+
+import { useMobile } from "@/hooks/use-mobile"
+
+import { truncateKey } from "@/lib/licenses"
+import { copyToClipboard } from "@/lib/clipboard"
+
+import * as keygen from "@/keygen"
+import * as Components from "@/components/components"
+import * as Property from "@/components/property"
+import * as Attribute from "@/components/attribute"
+import Metadata from "@/components/metadata"
+import PageHeader from "@/components/page-header"
+import TabsSwitch from "@/components/tabs-switch"
+import BackButton from "@/components/back-button"
+import GoToButton from "@/components/go-to-button"
+import DeleteModal from "@/components/delete-modal"
+import CollapsibleMenu from "@/components/collapsible-menu"
+import CollapsibleCard from "@/components/collapsible-card"
+
+export default function ComponentDetails() {
+  const { componentId } = useParams({
+    from: "/$id/app/components/$componentId",
+  })
+
+  const component = MockComponents.find((c) => c.id === componentId)
+  const [componentLoading, setComponentLoading] = useState(true)
+  const componentError = false
+
+  const machineId = component?.relationships.machine?.data?.id || ""
+  const machine = MockMachines.find((m) => m.id === machineId)
+  const [machineLoading, setMachineLoading] = useState(true)
+  const machineError = false
+
+  const licenseId = component?.relationships.license?.data?.id || ""
+  const license = MockLicenses.find((l) => l.id === licenseId)
+  const [licenseLoading, setLicenseLoading] = useState(true)
+  const licenseError = false
+
+  const productId = component?.relationships.product?.data?.id || ""
+  const {
+    data: product,
+    isLoading: productLoading,
+    isError: productError,
+  } = useGetProduct(productId)
+
+  const navigate = useNavigate()
+
+  const isMobile = useMobile()
+  const [open, setOpen] = useState({
+    edit: false,
+    delete: false,
+    attributes: false,
+  })
+
+  useEffect(() => {
+    ;(async () => {
+      if (componentError) {
+        await navigate({ to: ".." })
+      }
+    })()
+  }, [componentError, navigate])
+
+  useEffect(() => {
+    setTimeout(() => {
+      setComponentLoading(false)
+      setMachineLoading(false)
+      setLicenseLoading(false)
+    }, 300)
+  }, [])
+
+  const toggleOpen = (key: keyof typeof open, value: boolean) => {
+    setOpen((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const handleDeleteComponent = () => {
+    console.log("Component deleted.")
+    // TODO: Implement API call to delete component
+  }
+
+  return (
+    <section className="flex h-screen w-full">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <PageHeader>
+          <Breadcrumb className="flex-1">
+            <BreadcrumbList className="text-base">
+              <BreadcrumbItem>
+                <BreadcrumbLink
+                  className="cursor-pointer"
+                  onClick={() => navigate({ to: `..` })}
+                >
+                  Components
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                {component ? (
+                  <BreadcrumbPage className="w-40 truncate md:w-auto">
+                    {component?.attributes.name ||
+                      component?.attributes.fingerprint}
+                  </BreadcrumbPage>
+                ) : (
+                  <Skeleton className="h-6 w-32" />
+                )}
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+
+          {isMobile ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  disabled={componentLoading}
+                  className="text-content-muted"
+                >
+                  <EllipsisVertical className="size-5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="mr-4 p-0">
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    toggleOpen("edit", true)
+                    e.currentTarget.blur()
+                  }}
+                  className="pb-2 text-base"
+                >
+                  Edit
+                </DropdownMenuItem>
+                <Separator />
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    toggleOpen("delete", true)
+                    e.currentTarget.blur()
+                  }}
+                  className="pb-2 text-base"
+                >
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <div className="flex items-center space-x-2">
+              <Button
+                variant="outline"
+                disabled={componentLoading}
+                onClick={() => toggleOpen("edit", true)}
+              >
+                Edit
+              </Button>
+              <Button
+                variant="outline"
+                disabled={componentLoading}
+                onClick={() => toggleOpen("delete", true)}
+              >
+                Delete
+              </Button>
+            </div>
+          )}
+        </PageHeader>
+
+        {component ? (
+          <ScrollArea className="min-h-0 flex-1 overflow-y-auto">
+            <div className="px-4 py-6 md:px-10 md:py-8">
+              <BackButton path=".." className="mb-8" />
+
+              <div className="flex flex-col gap-3 md:flex-row md:items-center">
+                <h1 className="font-owners-wide text-2xl font-medium">
+                  {component?.attributes.name ||
+                    component?.attributes.fingerprint}
+                </h1>
+                <Button
+                  variant="clipboard"
+                  size="clipboard"
+                  onClick={() => copyToClipboard(component.id)}
+                  className="w-fit pb-0.5"
+                >
+                  {component.id}
+                  <Copy className="size-4 pt-0.5 md:size-3" />
+                </Button>
+              </div>
+
+              <div className="mt-6 space-y-6 md:mt-8">
+                <CollapsibleCard title="Attributes">
+                  <div className="flex flex-col space-y-4 md:flex-row md:space-y-0">
+                    <div className="flex-1 space-y-4">
+                      <Attribute.Field
+                        label="Fingerprint"
+                        variant="none"
+                        value={
+                          <Attribute.Value
+                            type="string"
+                            value={component.attributes.fingerprint}
+                            tooltip={ComponentAttributeDescriptions.fingerprint}
+                          />
+                        }
+                      />
+                    </div>
+
+                    <div className="mx-4 hidden md:block">
+                      <Separator orientation="vertical" dashed={true} />
+                    </div>
+
+                    <div className="flex-1 space-y-4">
+                      <Attribute.Field
+                        label="Name"
+                        variant="none"
+                        value={
+                          <Attribute.Value
+                            type="string"
+                            value={component.attributes.name}
+                            tooltip={ComponentAttributeDescriptions.name}
+                          />
+                        }
+                      />
+                    </div>
+                  </div>
+                </CollapsibleCard>
+
+                <CollapsibleCard title="Relationships">
+                  <Attribute.Field
+                    variant="text"
+                    label="Machine"
+                    value={
+                      machineError ? (
+                        <Badge variant="destructive">ERROR</Badge>
+                      ) : machineLoading ? (
+                        <Skeleton className="h-5 w-32 rounded-sm" />
+                      ) : machine ? (
+                        <GoToButton
+                          path="/$id/app/machines/$machineId"
+                          params={{
+                            id: keygen.config.id,
+                            machineId: machine.id,
+                          }}
+                          label={
+                            machine.attributes.name ||
+                            machine.attributes.fingerprint
+                          }
+                        />
+                      ) : (
+                        <GoToButton
+                          path="/$id/app/machines"
+                          params={{ id: keygen.config.id }}
+                          label="View all"
+                        />
+                      )
+                    }
+                  />
+
+                  <Attribute.Field
+                    variant="text"
+                    label="License"
+                    value={
+                      licenseError ? (
+                        <Badge variant="destructive">ERROR</Badge>
+                      ) : licenseLoading ? (
+                        <Skeleton className="h-5 w-32 rounded-sm" />
+                      ) : license ? (
+                        <GoToButton
+                          path="/$id/app/licenses/$licenseId"
+                          params={{
+                            id: keygen.config.id,
+                            licenseId: license.id,
+                          }}
+                          label={
+                            license.attributes.name ||
+                            truncateKey(license.attributes.key, {
+                              maxLength: isMobile ? 24 : 64,
+                            })
+                          }
+                        />
+                      ) : (
+                        <GoToButton
+                          path="/$id/app/licenses"
+                          params={{ id: keygen.config.id }}
+                          label="View all"
+                        />
+                      )
+                    }
+                  />
+
+                  <Attribute.Field
+                    variant="text"
+                    label="Product"
+                    value={
+                      productError ? (
+                        <Badge variant="destructive">ERROR</Badge>
+                      ) : productLoading ? (
+                        <Skeleton className="h-5 w-32 rounded-sm" />
+                      ) : product ? (
+                        <GoToButton
+                          path="/$id/app/products/$productId"
+                          params={{
+                            id: keygen.config.id,
+                            productId: product.id,
+                          }}
+                          label={product.attributes.name}
+                        />
+                      ) : (
+                        <GoToButton
+                          path="/$id/app/products"
+                          params={{ id: keygen.config.id }}
+                          label="View all"
+                        />
+                      )
+                    }
+                  />
+                </CollapsibleCard>
+
+                <CollapsibleCard title="Metadata" contentClass="p-0">
+                  <Metadata resource={component} />
+                </CollapsibleCard>
+
+                {isMobile && (
+                  <CollapsibleCard
+                    title="Other attributes"
+                    contentClass="space-y-2"
+                  >
+                    {component ? (
+                      <CollapsibleMenu title="Properties" className="space-y-2">
+                        <Attribute.Field
+                          label="Created at"
+                          value={formatDate(
+                            new Date(String(component.attributes.created)),
+                            "PP",
+                          )}
+                        />
+                        <Attribute.Field
+                          label="Updated at"
+                          value={formatDate(
+                            new Date(String(component.attributes.updated)),
+                            "PP",
+                          )}
+                        />
+                      </CollapsibleMenu>
+                    ) : (
+                      <div className="flex flex-col space-y-2">
+                        <Skeleton className="h-4 w-3/4" />
+                        <Skeleton className="h-4 w-1/2" />
+                        <Skeleton className="h-4 w-1/3" />
+                      </div>
+                    )}
+                  </CollapsibleCard>
+                )}
+
+                {isMobile && (
+                  <CollapsibleCard title="Events">
+                    <p className="text-sm text-content-subdued">
+                      Nothing here yet.
+                    </p>
+                  </CollapsibleCard>
+                )}
+
+                {isMobile && (
+                  <Button
+                    variant="outline"
+                    onClick={() => toggleOpen("attributes", true)}
+                    className="w-full text-content-muted"
+                  >
+                    <Logs className="mt-0.5 size-4 text-content-normal" />
+                    View All Attributes
+                  </Button>
+                )}
+              </div>
+            </div>
+          </ScrollArea>
+        ) : (
+          <div className="space-y-4 p-4 md:px-10 md:py-8">
+            <Skeleton className="h-6 w-24" />
+            <Skeleton className="h-6 w-32" />
+            <div className="mb-8 flex items-center gap-4">
+              <Skeleton className="h-8 w-48" />
+              <Skeleton className="h-8 w-32" />
+            </div>
+
+            <div className="space-y-4">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {!isMobile && (
+        <Tabs defaultValue="overview">
+          <Sidebar className="w-64 shrink-0" side="right">
+            <SidebarHeader className="p-0 pt-4">
+              <TabsSwitch
+                options={[
+                  { value: "overview", label: "Overview", icon: Menu },
+                  { value: "events", label: "Events", icon: GitFork },
+                ]}
+              />
+            </SidebarHeader>
+            <SidebarContent>
+              <TabsContent value="overview">
+                {component ? (
+                  <>
+                    <Property.Section title="Properties" className="p-4">
+                      <Property.Field
+                        icon={SquarePlus}
+                        label="Created at"
+                        value={formatDate(
+                          new Date(String(component.attributes.created)),
+                          "PP",
+                        )}
+                      />
+                      <Property.Field
+                        icon={SquarePen}
+                        label="Updated at"
+                        value={formatDate(
+                          new Date(String(component.attributes.updated)),
+                          "PP",
+                        )}
+                      />
+                    </Property.Section>
+
+                    <Separator />
+                  </>
+                ) : (
+                  <div className="flex flex-col space-y-2">
+                    <Skeleton className="h-4 w-3/4" />
+                    <Skeleton className="h-4 w-1/2" />
+                    <Skeleton className="h-4 w-1/3" />
+                  </div>
+                )}
+              </TabsContent>
+
+              <TabsContent value="events" className="p-4"></TabsContent>
+            </SidebarContent>
+            <SidebarFooter className="p-4">
+              <Button
+                variant="outline"
+                onClick={() => toggleOpen("attributes", true)}
+                className="w-full text-content-muted"
+              >
+                <Logs className="mt-0.5 size-4 text-content-normal" />
+                View All Attributes
+              </Button>
+            </SidebarFooter>
+          </Sidebar>
+        </Tabs>
+      )}
+
+      <Components.Edit.Modal
+        open={open.edit}
+        onClose={() => toggleOpen("edit", false)}
+        component={component!}
+      />
+
+      <DeleteModal
+        title={`Delete ${component?.attributes.name || component?.attributes.fingerprint}`}
+        description="Are you sure you want to delete this component? This action cannot be undone."
+        open={open.delete}
+        disabled={componentLoading}
+        onClose={() => toggleOpen("delete", false)}
+        onDelete={handleDeleteComponent}
+      />
+
+      {component && (
+        <Components.AdvancedDialog
+          id={component.id}
+          open={open.attributes}
+          onOpenChange={() => toggleOpen("attributes", false)}
+        />
+      )}
+    </section>
+  )
+}

--- a/src/pages/app/component/index.ts
+++ b/src/pages/app/component/index.ts
@@ -1,0 +1,2 @@
+export { default as List } from "./list"
+export { default as Details } from "./details"

--- a/src/pages/app/component/list.tsx
+++ b/src/pages/app/component/list.tsx
@@ -1,0 +1,73 @@
+import { useState, useEffect } from "react"
+import { useNavigate } from "@tanstack/react-router"
+
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogTrigger } from "@/components/ui/dialog"
+
+import { useComponentTableColumns } from "@/hooks/use-component-table-columns"
+import { Component, MockComponents } from "@/types/components"
+
+import * as keygen from "@/keygen"
+import * as Components from "@/components/components"
+import * as Skeletons from "@/components/skeletons"
+import DataTable from "@/components/data-table"
+import PageHeader from "@/components/page-header"
+
+export default function ComponentsList() {
+  const [componentsLoading, setComponentsLoading] = useState(true)
+  const columns = useComponentTableColumns()
+
+  const navigate = useNavigate()
+
+  const [open, setOpen] = useState(false)
+
+  const handleSelectComponent = async (component: Component | null) => {
+    if (!component) return
+
+    await navigate({
+      to: "/$id/app/components/$componentId",
+      params: { id: keygen.config.id, componentId: component.id },
+    })
+  }
+
+  useEffect(() => {
+    setTimeout(() => {
+      setComponentsLoading(false)
+    }, 300)
+  }, [])
+
+  return (
+    <section>
+      <PageHeader title="Components">
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button size="sm" disabled={componentsLoading}>
+              New Component
+            </Button>
+          </DialogTrigger>
+
+          <Components.Create.Modal
+            onSelectComponent={(component) => handleSelectComponent(component)}
+            onClose={() => setOpen(false)}
+          />
+        </Dialog>
+      </PageHeader>
+
+      {componentsLoading ? (
+        <Skeletons.Table />
+      ) : (
+        <DataTable<Component>
+          data={MockComponents}
+          columns={columns}
+          hideOnMobile={[
+            "relationships.machine",
+            "relationships.license",
+            "attributes.created",
+            "attributes.updated",
+          ]}
+          onRowClick={(c) => handleSelectComponent(c)}
+        />
+      )}
+    </section>
+  )
+}

--- a/src/pages/app/components.tsx
+++ b/src/pages/app/components.tsx
@@ -1,0 +1,26 @@
+import { Outlet, useParams } from "@tanstack/react-router"
+
+import { ComponentView } from "@/types/components"
+
+import * as Motion from "@/components/motion"
+import * as Page from "@/pages"
+
+export default function Components() {
+  const { componentId } = useParams({ strict: false })
+
+  const view = componentId ? ComponentView.Details : ComponentView.List
+
+  const direction: 1 | -1 = view === ComponentView.Details ? 1 : -1
+
+  const key = view === ComponentView.List ? "list" : `details-${componentId}`
+
+  return (
+    <Motion.Slide direction={direction}>
+      {view === ComponentView.List ? (
+        <Page.App.Component.List key={key} />
+      ) : (
+        <Outlet key={key} />
+      )}
+    </Motion.Slide>
+  )
+}

--- a/src/pages/app/index.ts
+++ b/src/pages/app/index.ts
@@ -5,6 +5,7 @@ export { default as Entitlements } from "./entitlements"
 export { default as Licenses } from "./licenses"
 export { default as Machines } from "./machines"
 export { default as Groups } from "./groups"
+export { default as Components } from "./components"
 
 import * as Product from "./product"
 export { Product }
@@ -23,3 +24,6 @@ export { Machine }
 
 import * as Group from "./group"
 export { Group }
+
+import * as Component from "./component"
+export { Component }

--- a/src/routes/$id/app.components.$componentId.tsx
+++ b/src/routes/$id/app.components.$componentId.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import * as Page from "@/pages/index"
+
+export const Route = createFileRoute("/$id/app/components/$componentId")({
+  component: () => <Page.App.Component.Details />,
+})

--- a/src/routes/$id/app.components.tsx
+++ b/src/routes/$id/app.components.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import * as Page from "@/pages/index"
+
+export const Route = createFileRoute("/$id/app/components")({
+  component: () => <Page.App.Components />,
+})

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -1,0 +1,66 @@
+import { APIResponse, Resource, Relationship, Linkage } from "@/types/api"
+
+export enum ComponentMode {
+  View = "view",
+  Edit = "edit",
+  Create = "create",
+}
+
+export enum ComponentView {
+  List = "list",
+  Details = "details",
+}
+
+export type ComponentAttributes = {
+  fingerprint: string
+  name: string | null
+  metadata: Record<string, unknown>
+  created: string
+  updated: string
+}
+
+export interface ComponentInput {
+  fingerprint?: string
+  name?: string | null
+  metadata?: Record<string, unknown>
+}
+
+export type ComponentRelationships = {
+  account: Relationship<Linkage<"accounts">>
+  environment: Relationship<Linkage<"environments"> | null>
+  product: Relationship<Linkage<"products">>
+  license: Relationship<Linkage<"licenses">>
+  machine: Relationship<Linkage<"machines">>
+}
+
+export type Component = Resource<
+  "components",
+  ComponentAttributes,
+  ComponentRelationships
+>
+
+export type ComponentResponse = APIResponse<Component>
+export type ComponentListResponse = APIResponse<Component[]>
+
+export const ComponentAttributeDescriptions: Readonly<
+  Record<keyof Omit<ComponentAttributes, "created" | "updated">, string>
+> = {
+  fingerprint: "The unique fingerprint of the component.",
+  name: "The human-readable name of the component.",
+  metadata:
+    "Store arbitrary key/value data on the component for book keeping purposes, entitlements, etc.",
+} as const
+
+export const ComponentFormFieldDescriptions: Readonly<
+  Record<
+    keyof Omit<ComponentAttributes, "created" | "updated"> | "machine",
+    string
+  >
+> = {
+  ...ComponentAttributeDescriptions,
+  fingerprint:
+    "The unique fingerprint of the component, e.g. a motherboard serial number. This can be an arbitrary string, but must be unique within the scope of the machine it belongs to or according to the policy's component uniqueness strategy.",
+  machine: "The machine that the component is for.",
+}
+
+export const MockComponents: Component[] = []


### PR DESCRIPTION
Adds base interface for the Components resource that includes list and details pages, CRUD dialogs/forms, and mobile styles. Also just want to make a formal note that passing over relationships/integrating resources with eachother across other resource pages will be handled once all the CRUD is done.