### PR TITLE
Add Licenses API integration for CRUD actions

### DIFF
--- a/src/components/licenses/advanced-dialog.tsx
+++ b/src/components/licenses/advanced-dialog.tsx
@@ -12,7 +12,7 @@ import {
 
 import { Text, CurlyBraces } from "lucide-react"
 
-import { MockLicenses } from "@/types/licenses"
+import { useGetLicense } from "@/queries/licenses"
 
 import * as Licenses from "@/components/licenses"
 import Metadata from "@/components/metadata"
@@ -32,11 +32,12 @@ export default function AdvancedDialog({
   open,
   onOpenChange,
 }: AdvancedDialogProps) {
-  // TODO(cazden) Replace with useGetLicense query when available
-  const license = MockLicenses.find((l) => l.id === id)
-  const licenseLoading = false
-  const licenseFetching = false
-  const licenseError = !license
+  const {
+    data: license,
+    isLoading: licenseLoading,
+    isFetching: licenseFetching,
+    isError: licenseError,
+  } = useGetLicense(id)
 
   const [tab, setTab] = useState<"attributes" | "inspect">("attributes")
 

--- a/src/components/licenses/create/modal.tsx
+++ b/src/components/licenses/create/modal.tsx
@@ -15,7 +15,7 @@ import {
 
 import * as Forms from "@/forms"
 
-import { License, LicenseStatus, MockLicenses } from "@/types/licenses"
+import { License } from "@/types/licenses"
 
 import { toast } from "@/lib/toast"
 
@@ -23,6 +23,7 @@ import { useSlide } from "@/hooks/use-slide"
 import { useMobile } from "@/hooks/use-mobile"
 
 import { useListPolicies } from "@/queries/policies"
+import { useCreateLicense } from "@/queries/licenses"
 
 import * as Motion from "@/components/motion"
 import * as Licenses from "@/components/licenses"
@@ -58,7 +59,7 @@ export default function LicensesCreateModal({
 }: LicensesCreateModalProps) {
   const isMobile = useMobile()
 
-  const [loading, setLoading] = useState(false)
+  const createLicense = useCreateLicense()
   const [completedStep, setCompletedStep] = useState<Set<string>>(new Set())
 
   const form = useForm<Forms.Licenses.CreateValues>({
@@ -119,7 +120,9 @@ export default function LicensesCreateModal({
         key: Steps.Additional,
         title: "Additional configuration",
         fields: ["protected", "suspended", "metadata"],
-        render: () => <Licenses.Fields.Additional />,
+        render: () => (
+          <Licenses.Fields.Additional selectedPolicy={selectedPolicy} />
+        ),
       },
     ],
     [selectedPolicy],
@@ -164,83 +167,20 @@ export default function LicensesCreateModal({
         return
       }
 
-      const policy = policies.find((p) => p.id === values.policyId)
-      const productId = policy?.relationships?.product?.data?.id
-
-      setLoading(true)
-
-      setTimeout(() => {
-        const newLicense: License = {
-          id: crypto.randomUUID(),
-          type: "licenses",
-          links: {
-            self: `/v1/accounts/{ACCOUNT}/licenses/${crypto.randomUUID()}`,
-          },
-          attributes: {
-            name: values.name || null,
-            key: values.key || "XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX-XXXX",
-            expiry: values.expiry || null,
-            status: LicenseStatus.Active,
-            uses: 0,
-            suspended: values.suspended || false,
-            protected: values.protected || false,
-            version: null,
-            maxMachines: values.maxMachines || null,
-            maxProcesses: values.maxProcesses || null,
-            maxUsers: values.maxUsers || null,
-            maxCores: values.maxCores || null,
-            maxUses: values.maxUses || null,
-            requireHeartbeat: false,
-            requireCheckIn: false,
-            lastValidated: null,
-            lastCheckOut: null,
-            lastCheckIn: null,
-            nextCheckIn: null,
-            metadata: values.metadata || {},
-            created: new Date().toISOString(),
-            updated: new Date().toISOString(),
-          },
-          relationships: {
-            account: {
-              links: { related: "/v1/accounts/{ACCOUNT}" },
-              data: { type: "accounts", id: "{ACCOUNT}" },
-            },
-            product: {
-              links: { related: null },
-              data: productId ? { type: "products", id: productId } : undefined,
-            },
-            policy: {
-              links: { related: null },
-              data: { type: "policies", id: values.policyId },
-            },
-            group: {
-              links: { related: null },
-              data: null,
-            },
-            owner: {
-              links: { related: null },
-              data: null,
-            },
-            users: {
-              links: { related: null },
-            },
-            machines: {
-              links: { related: null },
-            },
-            entitlements: {
-              links: { related: null },
-            },
-          },
-        }
-
-        MockLicenses.push(newLicense)
-        setLoading(false)
-        toast({ message: "License created", variant: "success" })
-        onSelectLicense(newLicense)
-        onClose()
-      }, 500)
+      createLicense.mutate(values, {
+        onSuccess: (license) => {
+          toast({ message: "License created", variant: "success" })
+          onSelectLicense(license)
+        },
+        onError: () => {
+          toast({
+            message: "Failed to create license",
+            variant: "error",
+          })
+        },
+      })
     },
-    [policies, onSelectLicense, onClose],
+    [createLicense, onSelectLicense],
   )
 
   return (
@@ -293,7 +233,7 @@ export default function LicensesCreateModal({
               variant="outline"
               type="button"
               onClick={step === 0 ? onClose : back}
-              disabled={loading}
+              disabled={createLicense.isPending}
               className="max-w-48 flex-1 basis-1/2"
             >
               {step === 0 ? "Cancel" : "Back"}
@@ -303,10 +243,10 @@ export default function LicensesCreateModal({
               key={last ? "create" : "next"}
               type="button"
               onClick={last ? form.handleSubmit(handleCreateLicense) : next}
-              disabled={loading}
+              disabled={createLicense.isPending}
               className="max-w-48 flex-1 basis-1/2"
             >
-              {loading ? (
+              {createLicense.isPending ? (
                 <Loading.Dots className="bg-background" />
               ) : last ? (
                 "Create"

--- a/src/components/licenses/edit/modal.tsx
+++ b/src/components/licenses/edit/modal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react"
+import { useParams } from "@tanstack/react-router"
 
 import {
   Dialog,
@@ -11,88 +11,48 @@ import {
 import { toast } from "@/lib/toast"
 
 import * as Forms from "@/forms"
-import { License, MockLicenses } from "@/types/licenses"
+
+import { useGetLicense, useUpdateLicense } from "@/queries/licenses"
 
 import EditForm from "./edit-form"
-
 import * as Loading from "@/components/loading"
 
 interface LicensesEditModalProps {
   open: boolean
-  onClose: () => void
-  license: License | null
+  onOpenChange: (value: boolean) => void
 }
 
 export default function LicensesEditModal({
   open,
-  onClose,
-  license,
+  onOpenChange,
 }: LicensesEditModalProps) {
-  const [loading, setLoading] = useState(false)
+  const { licenseId } = useParams({ from: "/$id/app/licenses/$licenseId" })
+  const {
+    data: license,
+    isLoading: licenseLoading,
+    isError: licenseError,
+  } = useGetLicense(licenseId)
+  const updateLicense = useUpdateLicense(licenseId)
 
-  const handleUpdateLicense = useCallback(
-    (values: Forms.Licenses.UpdateValues) => {
-      if (!license) return
-
-      setLoading(true)
-
-      // Mock update
-      setTimeout(() => {
-        const index = MockLicenses.findIndex((l) => l.id === license.id)
-        if (index === -1) {
-          toast({ message: "License not found", variant: "error" })
-          setLoading(false)
-          return
-        }
-
-        const updated: License = {
-          ...license,
-          attributes: {
-            ...license.attributes,
-            name:
-              values.name !== undefined ? values.name : license.attributes.name,
-            expiry:
-              values.expiry !== undefined
-                ? values.expiry
-                : license.attributes.expiry,
-            suspended: values.suspended ?? license.attributes.suspended,
-            protected: values.protected ?? license.attributes.protected,
-            maxMachines:
-              values.maxMachines !== undefined
-                ? values.maxMachines
-                : license.attributes.maxMachines,
-            maxProcesses:
-              values.maxProcesses !== undefined
-                ? values.maxProcesses
-                : license.attributes.maxProcesses,
-            maxUsers:
-              values.maxUsers !== undefined
-                ? values.maxUsers
-                : license.attributes.maxUsers,
-            maxCores:
-              values.maxCores !== undefined
-                ? values.maxCores
-                : license.attributes.maxCores,
-            maxUses:
-              values.maxUses !== undefined
-                ? values.maxUses
-                : license.attributes.maxUses,
-            metadata: values.metadata ?? license.attributes.metadata,
-            updated: new Date().toISOString(),
-          },
-        }
-
-        MockLicenses[index] = updated
-        setLoading(false)
+  const handleUpdateLicense = (values: Forms.Licenses.UpdateValues) => {
+    if (!license) return
+    updateLicense.mutate(values, {
+      onSuccess: () => {
         toast({ message: "License updated", variant: "success" })
-        onClose()
-      }, 500)
-    },
-    [license, onClose],
-  )
+        onOpenChange(false)
+      },
+      onError: () =>
+        toast({ message: "Failed to update license", variant: "error" }),
+      onSettled() {
+        if (!updateLicense.isError) {
+          onOpenChange(false)
+        }
+      },
+    })
+  }
 
   return (
-    <Dialog open={open} onOpenChange={onClose}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         onOpenAutoFocus={(e) => e.preventDefault()}
         onCloseAutoFocus={(e) => e.preventDefault()}
@@ -104,17 +64,21 @@ export default function LicensesEditModal({
           </DialogDescription>
           <DialogTitle className="sr-only" />
         </DialogHeader>
-        {!license ? (
+        {licenseLoading ? (
           <div className="flex w-full justify-center">
             <Loading.Dots />
           </div>
+        ) : licenseError ? (
+          <p className="text-center text-sm text-red-500">
+            Failed to load policy.
+          </p>
         ) : (
-          open && (
+          open &&
+          license && (
             <EditForm
               license={license}
-              loading={loading}
               onUpdate={handleUpdateLicense}
-              onCancel={onClose}
+              onCancel={() => onOpenChange(false)}
             />
           )
         )}

--- a/src/components/licenses/fields/additional.tsx
+++ b/src/components/licenses/fields/additional.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/lib/utils"
 
 import * as Forms from "@/forms"
 import { LicenseFormFieldDescriptions } from "@/types/licenses"
+import { Policy } from "@/types/policies"
 
 import * as Field from "@/components/field"
 import SectionCard from "@/components/section-card"
@@ -24,23 +25,30 @@ interface OptionsFieldsProps {
   layout?: Layout
   title?: string
   className?: string
+  selectedPolicy?: Policy | null
 }
 
 export default function OptionsFields({
   layout = "create",
   title,
   className,
+  selectedPolicy,
 }: OptionsFieldsProps): React.ReactElement {
   return layout === "edit" ? (
     <EditLayout title={title} className={className} />
   ) : (
-    <CreateLayout title={title} className={className} />
+    <CreateLayout
+      title={title}
+      className={className}
+      selectedPolicy={selectedPolicy}
+    />
   )
 }
 
 function CreateLayout({
   title,
   className,
+  selectedPolicy,
 }: Omit<OptionsFieldsProps, "layout">): React.ReactElement {
   const form = useFormContext<Forms.Licenses.CreateValues>()
 
@@ -62,7 +70,11 @@ function CreateLayout({
                     <FormControl>
                       <Checkbox
                         id="protected"
-                        checked={!!field.value}
+                        checked={
+                          field.value ??
+                          selectedPolicy?.attributes.protected ??
+                          false
+                        }
                         onCheckedChange={(value) => field.onChange(!!value)}
                       />
                     </FormControl>
@@ -197,8 +209,7 @@ function EditLayout({
                   tooltip={LicenseFormFieldDescriptions.metadata}
                 >
                   <FormControl>
-                    {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                    <KeyValueInput<any> name="metadata" />
+                    <KeyValueInput<Forms.Licenses.UpdateValues> name="metadata" />
                   </FormControl>
                 </Field.Header>
                 <FormMessage />

--- a/src/components/licenses/fields/limits.tsx
+++ b/src/components/licenses/fields/limits.tsx
@@ -13,7 +13,10 @@ import { cn } from "@/lib/utils"
 import { getLimitPlaceholder } from "@/lib/licenses"
 
 import * as Forms from "@/forms"
-import { LicenseFormFieldDescriptions } from "@/types/licenses"
+import {
+  LicenseFormFieldDescriptions,
+  LicenseDisabledFormFieldDescriptions,
+} from "@/types/licenses"
 import { Policy } from "@/types/policies"
 
 import * as Field from "@/components/field"
@@ -88,6 +91,10 @@ function CreateLayout({
                           field.onChange(
                             e.target.value ? parseInt(e.target.value) : null,
                           )
+                        }
+                        disabled={selectedPolicy?.attributes.floating === false}
+                        disabledTooltip={
+                          LicenseDisabledFormFieldDescriptions.maxMachines
                         }
                       />
                     </FormControl>
@@ -294,6 +301,10 @@ function EditLayout({
                         field.onChange(
                           e.target.value ? parseInt(e.target.value) : null,
                         )
+                      }
+                      disabled={selectedPolicy?.attributes.floating === false}
+                      disabledTooltip={
+                        LicenseDisabledFormFieldDescriptions.maxMachines
                       }
                     />
                   </FormControl>

--- a/src/components/machines/create/modal.tsx
+++ b/src/components/machines/create/modal.tsx
@@ -16,12 +16,13 @@ import {
 import * as Forms from "@/forms"
 
 import { Machine, HeartbeatStatus, MockMachines } from "@/types/machines"
-import { MockLicenses } from "@/types/licenses"
 
 import { toast } from "@/lib/toast"
 
 import { useSlide } from "@/hooks/use-slide"
 import { useMobile } from "@/hooks/use-mobile"
+
+import { useListLicenses } from "@/queries/licenses"
 
 import * as Motion from "@/components/motion"
 import * as Machines from "@/components/machines"
@@ -55,6 +56,7 @@ export default function MachinesCreateModal({
   onClose,
 }: MachinesCreateModalProps) {
   const isMobile = useMobile()
+  const { data: licenses = [] } = useListLicenses()
 
   const [loading, setLoading] = useState(false)
   const [completedStep, setCompletedStep] = useState<Set<string>>(new Set())
@@ -141,7 +143,7 @@ export default function MachinesCreateModal({
         return
       }
 
-      const license = MockLicenses.find((l) => l.id === values.licenseId)
+      const license = licenses.find((l) => l.id === values.licenseId)
       const productId = license?.relationships?.product?.data?.id
 
       setLoading(true)
@@ -220,7 +222,7 @@ export default function MachinesCreateModal({
         onClose()
       }, 500)
     },
-    [onSelectMachine, onClose],
+    [licenses, onSelectMachine, onClose],
   )
 
   return (

--- a/src/components/machines/fields/general.tsx
+++ b/src/components/machines/fields/general.tsx
@@ -13,8 +13,9 @@ import { cn } from "@/lib/utils"
 
 import * as Forms from "@/forms"
 
-import { MockLicenses } from "@/types/licenses"
 import { MachineFormFieldDescriptions } from "@/types/machines"
+
+import { useListLicenses } from "@/queries/licenses"
 
 import * as Field from "@/components/field"
 import SectionCard from "@/components/section-card"
@@ -30,6 +31,7 @@ export default function GeneralFields({
   className,
 }: GeneralFieldsProps): React.ReactElement {
   const form = useFormContext<Forms.Machines.CreateValues>()
+  const { data: licenses = [] } = useListLicenses()
 
   return (
     <div className={cn("m-4 md:mb-0", className)}>
@@ -96,7 +98,7 @@ export default function GeneralFields({
                       resource="license"
                       value={field.value}
                       onChange={(value) => field.onChange(value)}
-                      options={MockLicenses}
+                      options={licenses}
                       allowClear={false}
                       invalid={!!fieldState.error}
                       truncate="middle"

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,6 +2,12 @@ import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Eye, EyeOff } from "lucide-react"
 
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip"
+
 import { cn } from "@/lib/utils"
 
 const inputVariants = cva(
@@ -47,32 +53,65 @@ function Input({
   toggle = false,
   type = "text",
   className,
+  disabled,
+  disabledTooltip,
   ...props
 }: React.ComponentProps<"input"> &
   VariantProps<typeof inputVariants> & {
     asChild?: boolean
+    disabledTooltip?: string
   }) {
   const [isPasswordVisible, setIsPasswordVisible] = React.useState(false)
 
   const inputClasses = inputVariants({ variant, fieldSize, toggle, className })
 
   const isToggleable = toggle === true && type === "password"
-  if (!isToggleable) {
-    return <input type={type} className={cn(inputClasses)} {...props} />
+
+  const input = (inputType: string) => (
+    <input
+      type={inputType}
+      className={cn(inputClasses)}
+      disabled={disabled}
+      {...props}
+    />
+  )
+
+  const tooltip = (element: React.ReactElement) => {
+    if (disabled && disabledTooltip) {
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span tabIndex={0} className="block">
+              {element}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-64 bg-background-4 text-pretty text-content-muted">
+            {disabledTooltip}
+          </TooltipContent>
+        </Tooltip>
+      )
+    }
+    return element
   }
 
-  return (
+  if (!isToggleable) {
+    return tooltip(input(type))
+  }
+
+  return tooltip(
     <div className="relative">
       <input
         {...props}
         type={isPasswordVisible ? "text" : "password"}
         className={cn(inputClasses)}
+        disabled={disabled}
       />
       <button
         type="button"
         onClick={() => setIsPasswordVisible((prev) => !prev)}
         className="absolute top-1/2 right-2 -translate-y-1/2 text-muted-foreground"
         aria-label={isPasswordVisible ? "Hide password" : "Show password"}
+        disabled={disabled}
       >
         {isPasswordVisible ? (
           <EyeOff className="h-4 w-4 text-content-subdued" />
@@ -80,7 +119,7 @@ function Input({
           <Eye className="h-4 w-4 text-content-subdued" />
         )}
       </button>
-    </div>
+    </div>,
   )
 }
 

--- a/src/forms/components.ts
+++ b/src/forms/components.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 
-import { Writable, OptionalExcept } from "@/types/api"
 import { ComponentAttributes } from "@/types/components"
+import { Writable, OptionalExcept } from "@/types/utility"
 
 export type BaseValues = Writable<OptionalExcept<ComponentAttributes, "name">>
 export type CreateValues = BaseValues & {

--- a/src/forms/entitlements.ts
+++ b/src/forms/entitlements.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 
 import { FormFieldError } from "@/types/forms"
-import { Writable, OptionalExcept } from "@/types/api"
+import { Writable, OptionalExcept } from "@/types/utility"
 import { EntitlementAttributes } from "@/types/entitlements"
 
 import * as Forms from "@/forms"
@@ -9,7 +9,6 @@ import * as Forms from "@/forms"
 export type BaseValues = Writable<
   OptionalExcept<EntitlementAttributes, "name" | "code">
 >
-
 export type CreateValues = BaseValues
 export type UpdateValues = Partial<BaseValues>
 

--- a/src/forms/environments.ts
+++ b/src/forms/environments.ts
@@ -1,10 +1,9 @@
 import { z } from "zod"
 
-import { Writable } from "@/types/api"
+import { Writable } from "@/types/utility"
 import { EnvironmentAttributes, IsolationStrategy } from "@/types/environments"
 
 export type BaseValues = Writable<EnvironmentAttributes>
-
 export type CreateValues = BaseValues
 export type UpdateValues = Partial<BaseValues>
 

--- a/src/forms/groups.ts
+++ b/src/forms/groups.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-import { Writable, OptionalExcept } from "@/types/api"
+import { Writable, OptionalExcept } from "@/types/utility"
 import { GroupAttributes } from "@/types/groups"
 
 export type BaseValues = Writable<OptionalExcept<GroupAttributes, "name">>

--- a/src/forms/licenses.ts
+++ b/src/forms/licenses.ts
@@ -1,14 +1,16 @@
 import { z } from "zod"
 
-import { Writable } from "@/types/api"
+import { Override } from "@/types/utility"
 import { LicenseAttributes } from "@/types/licenses"
 
-export type BaseValues = Writable<
-  Partial<
+export type BaseValues = Partial<
+  Override<
     Pick<
       LicenseAttributes,
       | "name"
       | "key"
+      | "suspended"
+      | "protected"
       | "expiry"
       | "maxMachines"
       | "maxProcesses"
@@ -16,22 +18,30 @@ export type BaseValues = Writable<
       | "maxCores"
       | "maxUses"
       | "metadata"
-    >
+    >,
+    {
+      key?: string | null
+      suspended?: boolean | null
+      protected?: boolean | null
+    }
   >
-> & {
-  suspended?: boolean | null
-  protected?: boolean | null
-}
+>
 
 export type CreateValues = BaseValues & { policyId: string }
 export type UpdateValues = Partial<BaseValues>
 
 const BaseShape = z.object({
-  name: z.string().trim().nullable().optional(),
+  name: z
+    .string()
+    .trim()
+    .nullable()
+    .optional()
+    .transform((value) => (value === "" ? null : value)),
   key: z
     .string()
     .trim()
     .optional()
+    .transform((value) => (value === "" ? null : value))
     .refine(
       (value) => !value || value.length >= 8,
       "Key must be at least 8 characters",

--- a/src/forms/machines.ts
+++ b/src/forms/machines.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-import { Writable } from "@/types/api"
+import { Writable } from "@/types/utility"
 import { MachineAttributes } from "@/types/machines"
 
 export type BaseValues = Writable<
@@ -21,12 +21,10 @@ export type BaseValues = Writable<
   groupId?: string | null
   ownerId?: string | null
 }
-
 export type CreateValues = BaseValues & {
   fingerprint: string
   licenseId: string
 }
-
 export type UpdateValues = Partial<BaseValues>
 
 const BaseShape = z.object({

--- a/src/forms/policies.ts
+++ b/src/forms/policies.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 
-import { Writable, OptionalExcept } from "@/types/api"
+import { Writable, OptionalExcept } from "@/types/utility"
 import {
   Policy,
   PolicyAttributes,

--- a/src/forms/products.ts
+++ b/src/forms/products.ts
@@ -1,12 +1,11 @@
 import { z } from "zod"
 
-import { Writable, OptionalExcept } from "@/types/api"
+import { Writable, OptionalExcept } from "@/types/utility"
 import { ProductAttributes, DistributionStrategy } from "@/types/products"
 
 export type BaseValues = Writable<
   OptionalExcept<ProductAttributes, "name" | "code">
 >
-
 export type CreateValues = BaseValues
 export type UpdateValues = Partial<BaseValues>
 

--- a/src/forms/users.ts
+++ b/src/forms/users.ts
@@ -1,13 +1,12 @@
 import { z } from "zod"
 
-import { Writable, OptionalExcept } from "@/types/api"
 import { UserAttributes, UserRole } from "@/types/users"
+import { Writable, OptionalExcept } from "@/types/utility"
 
 export type BaseValues = Writable<OptionalExcept<UserAttributes, "email">> & {
   groupId?: string | null
   password?: string | null
 }
-
 export type CreateValues = BaseValues
 export type UpdateValues = Partial<BaseValues>
 

--- a/src/keygen/index.ts
+++ b/src/keygen/index.ts
@@ -22,6 +22,9 @@ export { entitlements }
 import * as policies from "./policies"
 export { policies }
 
+import * as licenses from "./licenses"
+export { licenses }
+
 import * as tokens from "./tokens"
 export { tokens }
 

--- a/src/keygen/licenses/create.ts
+++ b/src/keygen/licenses/create.ts
@@ -1,0 +1,37 @@
+import config from "@/keygen/config"
+import client from "@/keygen/client"
+
+import { LicenseResponse } from "@/types/licenses"
+import { compact } from "@/lib/compact"
+
+import * as Forms from "@/forms"
+
+config.validate()
+
+export default async function create(
+  values: Forms.Licenses.CreateValues,
+): Promise<LicenseResponse> {
+  const { policyId, ...attributes } = values
+
+  const body = {
+    data: {
+      type: "licenses",
+      attributes: compact(attributes),
+      relationships: {
+        policy: {
+          data: {
+            type: "policies",
+            id: policyId,
+          },
+        },
+      },
+    },
+  }
+
+  const result = (await client.request(`/accounts/${config.id}/licenses`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  })) as LicenseResponse
+
+  return result
+}

--- a/src/keygen/licenses/get.ts
+++ b/src/keygen/licenses/get.ts
@@ -1,0 +1,20 @@
+import config from "@/keygen/config"
+import client from "@/keygen/client"
+import { LicenseResponse } from "@/types/licenses"
+
+config.validate()
+
+interface GetProps {
+  id: string
+}
+
+export default async function get({ id }: GetProps): Promise<LicenseResponse> {
+  const result = (await client.request(
+    `/accounts/${config.id}/licenses/${id}`,
+    {
+      method: "GET",
+    },
+  )) as LicenseResponse
+
+  return result
+}

--- a/src/keygen/licenses/index.ts
+++ b/src/keygen/licenses/index.ts
@@ -1,0 +1,5 @@
+export { default as create } from "./create"
+export { default as get } from "./get"
+export { default as list } from "./list"
+export { default as update } from "./update"
+export { default as remove } from "./remove"

--- a/src/keygen/licenses/list.ts
+++ b/src/keygen/licenses/list.ts
@@ -1,0 +1,37 @@
+import config from "@/keygen/config"
+import client from "@/keygen/client"
+import { LicenseListResponse } from "@/types/licenses"
+
+config.validate()
+
+interface ListProps {
+  limit?: number
+  pageNumber?: number
+  pageSize?: number
+}
+
+export default async function list({
+  limit,
+  pageNumber,
+  pageSize,
+}: ListProps): Promise<LicenseListResponse> {
+  const params = new URLSearchParams()
+  if (limit != null) {
+    params.set("limit", limit.toString())
+  }
+  if (pageNumber != null) {
+    params.set("page[number]", pageNumber.toString())
+  }
+  if (pageSize != null) {
+    params.set("page[size]", pageSize.toString())
+  }
+
+  const result = (await client.request(
+    `/accounts/${config.id}/licenses?${params.toString()}`,
+    {
+      method: "GET",
+    },
+  )) as LicenseListResponse
+
+  return result
+}

--- a/src/keygen/licenses/remove.ts
+++ b/src/keygen/licenses/remove.ts
@@ -1,0 +1,16 @@
+import config from "@/keygen/config"
+import client from "@/keygen/client"
+
+config.validate()
+
+interface RemoveProps {
+  id: string
+}
+
+export default async function remove({ id }: RemoveProps): Promise<null> {
+  await client.request(`/accounts/${config.id}/licenses/${id}`, {
+    method: "DELETE",
+  })
+
+  return null
+}

--- a/src/keygen/licenses/update.ts
+++ b/src/keygen/licenses/update.ts
@@ -1,0 +1,35 @@
+import config from "@/keygen/config"
+import client from "@/keygen/client"
+
+import { LicenseResponse } from "@/types/licenses"
+
+import * as Forms from "@/forms"
+
+config.validate()
+
+interface UpdateProps {
+  id: string
+  values: Forms.Licenses.UpdateValues
+}
+
+export default async function update({
+  id,
+  values,
+}: UpdateProps): Promise<LicenseResponse> {
+  const body = {
+    data: {
+      type: "licenses",
+      attributes: values,
+    },
+  }
+
+  const result = (await client.request(
+    `/accounts/${config.id}/licenses/${id}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    },
+  )) as LicenseResponse
+
+  return result
+}

--- a/src/pages/app/component/details.tsx
+++ b/src/pages/app/component/details.tsx
@@ -40,13 +40,13 @@ import {
 } from "lucide-react"
 
 import { MockMachines } from "@/types/machines"
-import { MockLicenses } from "@/types/licenses"
 import {
   MockComponents,
   ComponentAttributeDescriptions,
 } from "@/types/components"
 
 import { useGetProduct } from "@/queries/products"
+import { useGetLicense } from "@/queries/licenses"
 
 import { useMobile } from "@/hooks/use-mobile"
 
@@ -81,9 +81,11 @@ export default function ComponentDetails() {
   const machineError = false
 
   const licenseId = component?.relationships.license?.data?.id || ""
-  const license = MockLicenses.find((l) => l.id === licenseId)
-  const [licenseLoading, setLicenseLoading] = useState(true)
-  const licenseError = false
+  const {
+    data: license,
+    isLoading: licenseLoading,
+    isError: licenseError,
+  } = useGetLicense(licenseId)
 
   const productId = component?.relationships.product?.data?.id || ""
   const {
@@ -113,7 +115,6 @@ export default function ComponentDetails() {
     setTimeout(() => {
       setComponentLoading(false)
       setMachineLoading(false)
-      setLicenseLoading(false)
     }, 300)
   }, [])
 

--- a/src/pages/app/license/details.tsx
+++ b/src/pages/app/license/details.tsx
@@ -53,7 +53,6 @@ import {
 } from "lucide-react"
 
 import {
-  MockLicenses,
   LicenseStatus,
   LicenseStatusLabels,
   LicenseStatusVariants,
@@ -63,9 +62,11 @@ import {
 
 import { useGetPolicy } from "@/queries/policies"
 import { useGetProduct } from "@/queries/products"
+import { useGetLicense, useRemoveLicense } from "@/queries/licenses"
 
 import { useMobile } from "@/hooks/use-mobile"
 
+import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
 import {
   getMachinesLimitDisplay,
@@ -103,10 +104,13 @@ const LicenseStatusIcons: Record<LicenseStatus, React.ReactNode> = {
 export default function LicenseDetails() {
   const { licenseId } = useParams({ from: "/$id/app/licenses/$licenseId" })
 
-  const license = MockLicenses.find((l) => l.id === licenseId)
-  const [licenseLoading, setLicenseLoading] = useState(true)
-  const [licenseFetching, setLicenseFetching] = useState(true)
-  const licenseError = false
+  const {
+    data: license,
+    isLoading: licenseLoading,
+    isFetching: licenseFetching,
+    isError: licenseError,
+  } = useGetLicense(licenseId)
+  const removeLicense = useRemoveLicense(licenseId)
 
   const policyId = license?.relationships.policy?.data?.id || ""
   const {
@@ -141,20 +145,18 @@ export default function LicenseDetails() {
     })()
   }, [licenseError, licenseFetching, navigate])
 
-  useEffect(() => {
-    setTimeout(() => {
-      setLicenseLoading(false)
-      setLicenseFetching(false)
-    }, 1000)
-  }, [])
-
   const toggleOpen = (key: keyof typeof open, value: boolean) => {
     setOpen((prev) => ({ ...prev, [key]: value }))
   }
 
-  const handleDeleteLicense = () => {
-    console.log("License deleted.")
-    // TODO(cazden) Implement API call to delete license
+  const handleDeleteLicense = async () => {
+    try {
+      await removeLicense.mutateAsync()
+      toast({ message: "License deleted", variant: "success" })
+      await navigate({ to: ".." })
+    } catch {
+      toast({ message: "Failed to delete license", variant: "error" })
+    }
   }
 
   return (
@@ -277,7 +279,7 @@ export default function LicenseDetails() {
               <div className="flex flex-col gap-3 md:flex-row md:items-center">
                 <h1 className="font-owners-wide text-2xl font-medium">
                   {license?.attributes.name || (
-                    <span className="text-lg font-normal text-content-disabled">
+                    <span className="flex items-center text-lg font-normal text-content-disabled">
                       {"(name not set)"}
                     </span>
                   )}
@@ -286,7 +288,7 @@ export default function LicenseDetails() {
                   variant="clipboard"
                   size="clipboard"
                   onClick={() => copyToClipboard(license.id)}
-                  className="w-fit pb-0.5"
+                  className="w-fit"
                 >
                   {license.id}
                   <Copy className="size-4 pt-0.5 md:size-3" />
@@ -889,11 +891,12 @@ export default function LicenseDetails() {
         </Tabs>
       )}
 
-      <Licenses.Edit.Modal
-        open={open.edit}
-        onClose={() => toggleOpen("edit", false)}
-        license={license!}
-      />
+      {license && (
+        <Licenses.Edit.Modal
+          open={open.edit}
+          onOpenChange={(value) => toggleOpen("edit", value)}
+        />
+      )}
 
       {license && (
         <ConfirmationModal

--- a/src/pages/app/license/list.tsx
+++ b/src/pages/app/license/list.tsx
@@ -1,11 +1,13 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
 
 import { useLicenseTableColumns } from "@/hooks/use-license-table-columns"
-import { License, MockLicenses } from "@/types/licenses"
+import { License } from "@/types/licenses"
+
+import { useListLicenses } from "@/queries/licenses"
 
 import * as keygen from "@/keygen"
 import * as Licenses from "@/components/licenses"
@@ -14,7 +16,7 @@ import DataTable from "@/components/data-table"
 import PageHeader from "@/components/page-header"
 
 export default function LicensesList() {
-  const [licensesLoading, setLicensesLoading] = useState(true)
+  const { data: licenses = [], isLoading: licensesLoading } = useListLicenses()
   const columns = useLicenseTableColumns()
 
   const navigate = useNavigate()
@@ -28,14 +30,8 @@ export default function LicensesList() {
       to: "/$id/app/licenses/$licenseId",
       params: { id: keygen.config.id, licenseId: license.id },
     })
+    setOpen(false)
   }
-
-  // Mock API call
-  useEffect(() => {
-    setTimeout(() => {
-      setLicensesLoading(false)
-    }, 1000)
-  }, [])
 
   return (
     <section>
@@ -58,10 +54,9 @@ export default function LicensesList() {
         <Skeletons.Table />
       ) : (
         <DataTable<License>
-          data={MockLicenses}
+          data={licenses}
           columns={columns}
           hideOnMobile={[
-            "id",
             "attributes.key",
             "relationships.policy",
             "relationships.product",

--- a/src/pages/app/machine/details.tsx
+++ b/src/pages/app/machine/details.tsx
@@ -40,10 +40,10 @@ import {
 } from "lucide-react"
 
 import { MockGroups } from "@/types/groups"
-import { MockLicenses } from "@/types/licenses"
 import { MockMachines, MachineAttributeDescriptions } from "@/types/machines"
 
 import { useGetProduct } from "@/queries/products"
+import { useGetLicense } from "@/queries/licenses"
 
 import { useMobile } from "@/hooks/use-mobile"
 
@@ -72,9 +72,11 @@ export default function MachineDetails() {
   const machineError = false
 
   const licenseId = machine?.relationships.license?.data?.id || ""
-  const license = MockLicenses.find((l) => l.id === licenseId)
-  const [licenseLoading, setLicenseLoading] = useState(true)
-  const licenseError = false
+  const {
+    data: license,
+    isLoading: licenseLoading,
+    isError: licenseError,
+  } = useGetLicense(licenseId)
 
   const groupId = machine?.relationships.group?.data?.id || ""
   const group = MockGroups.find((g) => g.id === groupId)
@@ -108,7 +110,6 @@ export default function MachineDetails() {
   useEffect(() => {
     setTimeout(() => {
       setMachineLoading(false)
-      setLicenseLoading(false)
       setGroupLoading(false)
     }, 300)
   }, [])
@@ -395,7 +396,7 @@ export default function MachineDetails() {
                         <Skeleton className="h-5 w-32 rounded-sm" />
                       ) : license ? (
                         <GoToButton
-                          path="/$id/app/license/$licenseId"
+                          path="/$id/app/licenses/$licenseId"
                           params={{
                             id: keygen.config.id,
                             licenseId: license.id,
@@ -427,7 +428,7 @@ export default function MachineDetails() {
                         <Skeleton className="h-5 w-32 rounded-sm" />
                       ) : product ? (
                         <GoToButton
-                          path="/$id/app/product/$productId"
+                          path="/$id/app/products/$productId"
                           params={{
                             id: keygen.config.id,
                             productId: product.id,

--- a/src/pages/app/process/details.tsx
+++ b/src/pages/app/process/details.tsx
@@ -43,7 +43,6 @@ import {
 } from "lucide-react"
 
 import { MockMachines } from "@/types/machines"
-import { MockLicenses } from "@/types/licenses"
 import {
   MockProcesses,
   ProcessAttributeDescriptions,
@@ -54,6 +53,7 @@ import {
 } from "@/types/processes"
 
 import { useGetProduct } from "@/queries/products"
+import { useGetLicense } from "@/queries/licenses"
 
 import { useMobile } from "@/hooks/use-mobile"
 
@@ -95,9 +95,11 @@ export default function ProcessDetails() {
   const machineError = false
 
   const licenseId = process?.relationships.license?.data?.id || ""
-  const license = MockLicenses.find((l) => l.id === licenseId)
-  const [licenseLoading, setLicenseLoading] = useState(true)
-  const licenseError = false
+  const {
+    data: license,
+    isLoading: licenseLoading,
+    isError: licenseError,
+  } = useGetLicense(licenseId)
 
   const productId = process?.relationships.product?.data?.id || ""
   const {
@@ -127,7 +129,6 @@ export default function ProcessDetails() {
     setTimeout(() => {
       setProcessLoading(false)
       setMachineLoading(false)
-      setLicenseLoading(false)
     }, 300)
   }, [])
 

--- a/src/queries/entitlements.ts
+++ b/src/queries/entitlements.ts
@@ -24,8 +24,6 @@ export function useGetEntitlement(entitlementId: string) {
 
       return response.data
     },
-    retry: (failures, error) =>
-      error.message !== "Entitlement not found" && failures < 3,
     enabled: !!entitlementId,
   })
 }

--- a/src/queries/licenses.ts
+++ b/src/queries/licenses.ts
@@ -1,0 +1,117 @@
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+
+import { useEnvironment } from "@/hooks/use-environment"
+
+import * as Forms from "@/forms"
+
+import { APIError } from "@/types/api"
+import { License } from "@/types/licenses"
+
+import * as keygen from "@/keygen"
+import { diff } from "@/lib/utils"
+
+export function useGetLicense(licenseId: string) {
+  const { code } = useEnvironment()
+
+  return useQuery({
+    queryKey: ["licenses", licenseId, { environment: code }],
+    queryFn: async () => {
+      const response = await keygen.licenses.get({ id: licenseId })
+
+      if (!response.data) {
+        throw new Error("License not found")
+      }
+
+      return response.data
+    },
+    retry: (failures, error) =>
+      error.message !== "License not found" && failures < 3,
+    enabled: !!licenseId,
+  })
+}
+
+export function useListLicenses() {
+  const { code } = useEnvironment()
+
+  return useQuery({
+    queryKey: ["licenses", { environment: code }],
+    queryFn: () =>
+      keygen.licenses.list({}).then((response) => response.data ?? []),
+  })
+}
+
+export function useCreateLicense() {
+  const queryClient = useQueryClient()
+  const { code } = useEnvironment()
+
+  return useMutation<License, APIError, Forms.Licenses.CreateValues>({
+    mutationFn: (values) =>
+      keygen.licenses
+        .create(values)
+        .then((response) => response.data as License),
+
+    onSuccess: (newLicense) => {
+      queryClient.setQueryData<License[]>(
+        ["licenses", { environment: code }],
+        (old) => (old ? [newLicense, ...old] : [newLicense]),
+      )
+      queryClient.setQueryData(
+        ["licenses", newLicense.id, { environment: code }],
+        newLicense,
+      )
+    },
+  })
+}
+
+export function useUpdateLicense(licenseId: string) {
+  const queryClient = useQueryClient()
+  const { code } = useEnvironment()
+
+  return useMutation<License, APIError, Forms.Licenses.UpdateValues>({
+    mutationFn: (values) =>
+      keygen.licenses.get({ id: licenseId }).then(async (response) => {
+        const current = response.data as License
+
+        const changes = diff(
+          current.attributes,
+          values,
+        ) as Forms.Licenses.UpdateValues
+        if (Object.keys(changes).length === 0) return current
+
+        const updated = await keygen.licenses
+          .update({ id: licenseId, values: changes })
+          .then((response) => response.data as License)
+
+        return updated
+      }),
+
+    onSuccess: async (updated) => {
+      queryClient.setQueryData(
+        ["licenses", licenseId, { environment: code }],
+        updated,
+      )
+      await queryClient.invalidateQueries({
+        queryKey: ["licenses", { environment: code }],
+      })
+    },
+  })
+}
+
+export function useRemoveLicense(licenseId: string) {
+  const queryClient = useQueryClient()
+  const { code } = useEnvironment()
+
+  return useMutation({
+    mutationFn: () => keygen.licenses.remove({ id: licenseId }),
+
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["licenses", { environment: code }],
+      })
+      queryClient.removeQueries({
+        queryKey: ["licenses", licenseId, { environment: code }],
+      })
+    },
+  })
+}
+

--- a/src/queries/licenses.ts
+++ b/src/queries/licenses.ts
@@ -24,8 +24,6 @@ export function useGetLicense(licenseId: string) {
 
       return response.data
     },
-    retry: (failures, error) =>
-      error.message !== "License not found" && failures < 3,
     enabled: !!licenseId,
   })
 }

--- a/src/queries/licenses.ts
+++ b/src/queries/licenses.ts
@@ -114,4 +114,3 @@ export function useRemoveLicense(licenseId: string) {
     },
   })
 }
-

--- a/src/queries/policies.ts
+++ b/src/queries/policies.ts
@@ -24,8 +24,6 @@ export function useGetPolicy(policyId: string) {
 
       return response.data
     },
-    retry: (failures, error) =>
-      error.message !== "Policy not found" && failures < 3,
     enabled: !!policyId,
   })
 }

--- a/src/queries/products.ts
+++ b/src/queries/products.ts
@@ -23,8 +23,6 @@ export function useGetProduct(productId: string) {
 
       return response.data
     },
-    retry: (failures, error) =>
-      error.message !== "Product not found" && failures < 3,
     enabled: !!productId,
   })
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -99,8 +99,3 @@ export type AnyResource =
   | Component
   | Process
   | User
-
-export type Writable<T> = Omit<T, "created" | "updated">
-
-export type OptionalExcept<T, K extends keyof T> = Partial<Omit<T, K>> &
-  Pick<T, K>

--- a/src/types/licenses.ts
+++ b/src/types/licenses.ts
@@ -180,5 +180,3 @@ export const LicenseStatusVariants: Readonly<
   [LicenseStatus.Suspended]: "destructive",
   [LicenseStatus.Banned]: "destructive",
 } as const
-
-export const MockLicenses: License[] = []

--- a/src/types/licenses.ts
+++ b/src/types/licenses.ts
@@ -123,20 +123,6 @@ export const LicenseAttributeDescriptions: Readonly<
     "Store arbitrary key/value data on the license for book keeping purposes, entitlements, etc.",
 } as const
 
-export const LicenseStatusDescriptions: Readonly<
-  Record<LicenseStatus, string>
-> = {
-  [LicenseStatus.Active]:
-    "License has been created, validated, checked out, or checked in within the last 90 days.",
-  [LicenseStatus.Inactive]: "License has had no activity in the past 90 days.",
-  [LicenseStatus.Expiring]: "License is expiring within the next 3 days.",
-  [LicenseStatus.Expired]: "License expiration date has passed.",
-  [LicenseStatus.Suspended]:
-    "License has been suspended and will always fail validation.",
-  [LicenseStatus.Banned]:
-    "License is associated with a user who has been banned.",
-} as const
-
 export const LicenseFormFieldDescriptions: Readonly<
   typeof LicenseAttributeDescriptions
 > = {
@@ -150,6 +136,27 @@ export const LicenseFormFieldDescriptions: Readonly<
   maxCores: "Override the policy's max cores limit for this license.",
   maxUses: "Override the policy's max uses limit for this license.",
 }
+
+export const LicenseDisabledFormFieldDescriptions: Readonly<
+  Partial<Record<keyof LicenseAttributes, string>>
+> = {
+  maxMachines:
+    "Max machines cannot be overridden for licenses with a non-floating policy. Value must be 1.",
+}
+
+export const LicenseStatusDescriptions: Readonly<
+  Record<LicenseStatus, string>
+> = {
+  [LicenseStatus.Active]:
+    "License has been created, validated, checked out, or checked in within the last 90 days.",
+  [LicenseStatus.Inactive]: "License has had no activity in the past 90 days.",
+  [LicenseStatus.Expiring]: "License is expiring within the next 3 days.",
+  [LicenseStatus.Expired]: "License expiration date has passed.",
+  [LicenseStatus.Suspended]:
+    "License has been suspended and will always fail validation.",
+  [LicenseStatus.Banned]:
+    "License is associated with a user who has been banned.",
+} as const
 
 export const LicenseStatusLabels: Readonly<Record<LicenseStatus, string>> = {
   [LicenseStatus.Active]: "Active",

--- a/src/types/tokens.ts
+++ b/src/types/tokens.ts
@@ -1,10 +1,5 @@
-import {
-  APIResponse,
-  Resource,
-  Relationship,
-  Linkage,
-  Writable,
-} from "@/types/api"
+import { Writable } from "@/types/utility"
+import { APIResponse, Resource, Relationship, Linkage } from "@/types/api"
 
 export interface TokenAttributes {
   kind: string

--- a/src/types/utility.ts
+++ b/src/types/utility.ts
@@ -1,0 +1,6 @@
+export type Writable<T> = Omit<T, "created" | "updated">
+
+export type OptionalExcept<T, K extends keyof T> = Partial<Omit<T, K>> &
+  Pick<T, K>
+
+export type Override<T, U> = Omit<T, keyof U> & U


### PR DESCRIPTION
Adds API integration for License CRUD actions and removes mock License data across all resources. Also extends the Input component with a disabled tooltip option, which is used in license forms for letting users know why the `maxMachines` form field is disabled when trying to create a license using a non-floating policy.