### PR TITLE
Add standardized form API error handling

### DIFF
--- a/src/components/components/form/create.tsx
+++ b/src/components/components/form/create.tsx
@@ -36,29 +36,13 @@ export default function CreateComponentForm({
   const createComponent = useCreateComponent()
   const navigateToResource = useResourceNavigate()
 
-  const handleCreateComponent = useCallback(
-    (values: Schemas.Components.CreateValues) => {
-      createComponent.mutate(values, {
-        onSuccess: async (component) => {
-          toast({ message: "Component created", variant: "success" })
-          onOpenChange(false)
-          await navigateToResource(component)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to create component",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    },
-    [createComponent, navigateToResource, onOpenChange],
-  )
-
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit(handleCreateComponent)()
-  }, [form, handleCreateComponent])
+    const values = form.getValues()
+    const component = await createComponent.mutateAsync(values)
+    toast({ message: "Component created", variant: "success" })
+    onOpenChange(false)
+    await navigateToResource(component)
+  }, [form, createComponent, navigateToResource, onOpenChange])
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
@@ -68,6 +52,7 @@ export default function CreateComponentForm({
           onSubmit={handleSubmit}
           isPending={createComponent.isPending}
           description="Creating a new component"
+          errorMessage="Failed to create component"
         >
           <Forms.Section.Step
             crumb="Component attributes"

--- a/src/components/components/form/edit.tsx
+++ b/src/components/components/form/edit.tsx
@@ -38,21 +38,10 @@ export default function EditComponentForm({
   })
 
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit((values) => {
-      updateComponent.mutate(values, {
-        onSuccess: () => {
-          toast({ message: "Component updated", variant: "success" })
-          onOpenChange(false)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to update component",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    })()
+    const values = form.getValues()
+    await updateComponent.mutateAsync(values)
+    toast({ message: "Component updated", variant: "success" })
+    onOpenChange(false)
   }, [form, updateComponent, onOpenChange])
 
   return (
@@ -62,6 +51,7 @@ export default function EditComponentForm({
           title="Editing an existing component"
           onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
+          errorMessage="Failed to update component"
           isPending={updateComponent.isPending}
           submitLabel="Update"
         >

--- a/src/components/entitlements/form/create.tsx
+++ b/src/components/entitlements/form/create.tsx
@@ -35,29 +35,13 @@ export default function CreateEntitlementForm({
   const createEntitlement = useCreateEntitlement()
   const navigateToResource = useResourceNavigate()
 
-  const handleCreateEntitlement = useCallback(
-    (values: Schemas.Entitlements.CreateValues) => {
-      createEntitlement.mutate(values, {
-        onSuccess: async (entitlement) => {
-          toast({ message: "Entitlement created", variant: "success" })
-          onOpenChange(false)
-          await navigateToResource(entitlement)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to create entitlement",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    },
-    [createEntitlement, navigateToResource, onOpenChange],
-  )
-
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit(handleCreateEntitlement)()
-  }, [form, handleCreateEntitlement])
+    const values = form.getValues()
+    const entitlement = await createEntitlement.mutateAsync(values)
+    toast({ message: "Entitlement created", variant: "success" })
+    onOpenChange(false)
+    await navigateToResource(entitlement)
+  }, [form, createEntitlement, navigateToResource, onOpenChange])
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
@@ -67,6 +51,7 @@ export default function CreateEntitlementForm({
           onSubmit={handleSubmit}
           isPending={createEntitlement.isPending}
           description="Creating a new entitlement"
+          errorMessage="Failed to create entitlement"
         >
           <Forms.Section.Step
             crumb="Entitlement attributes"

--- a/src/components/entitlements/form/edit.tsx
+++ b/src/components/entitlements/form/edit.tsx
@@ -39,21 +39,10 @@ export default function EditEntitlementForm({
   })
 
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit((values) => {
-      updateEntitlement.mutate(values, {
-        onSuccess: () => {
-          toast({ message: "Entitlement updated", variant: "success" })
-          onOpenChange(false)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to update entitlement",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    })()
+    const values = form.getValues()
+    await updateEntitlement.mutateAsync(values)
+    toast({ message: "Entitlement updated", variant: "success" })
+    onOpenChange(false)
   }, [form, updateEntitlement, onOpenChange])
 
   return (
@@ -63,6 +52,7 @@ export default function EditEntitlementForm({
           title="Editing an existing entitlement"
           onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
+          errorMessage="Failed to update entitlement"
           isPending={updateEntitlement.isPending}
           submitLabel="Update"
         >

--- a/src/components/environments/form/create.tsx
+++ b/src/components/environments/form/create.tsx
@@ -44,21 +44,10 @@ export default function CreateEnvironmentForm({
   })
 
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit((values) => {
-      createEnvironment.mutate(values, {
-        onSuccess: () => {
-          toast({ message: "Environment created", variant: "success" })
-          onOpenChange(false)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to create environment",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    })()
+    const values = form.getValues()
+    await createEnvironment.mutateAsync(values)
+    toast({ message: "Environment created", variant: "success" })
+    onOpenChange(false)
   }, [form, createEnvironment, onOpenChange])
 
   return (
@@ -72,6 +61,7 @@ export default function CreateEnvironmentForm({
           onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           isPending={createEnvironment.isPending}
+          errorMessage="Failed to create environment"
           description={
             <BadgeGroup prefix="Creating a new" suffix="environment">
               {selectedStrategy === IsolationStrategy.Isolated ? (

--- a/src/components/environments/form/edit.tsx
+++ b/src/components/environments/form/edit.tsx
@@ -38,21 +38,10 @@ export default function EditEnvironmentForm({
   })
 
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit((values) => {
-      updateEnvironment.mutate(values, {
-        onSuccess: () => {
-          toast({ message: "Environment updated", variant: "success" })
-          onOpenChange(false)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to update environment",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    })()
+    const values = form.getValues()
+    await updateEnvironment.mutateAsync(values)
+    toast({ message: "Environment updated", variant: "success" })
+    onOpenChange(false)
   }, [form, updateEnvironment, onOpenChange])
 
   return (
@@ -66,6 +55,7 @@ export default function EditEnvironmentForm({
           title="Editing an existing environment"
           onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
+          errorMessage="Failed to update environment"
           isPending={updateEnvironment.isPending}
           submitLabel="Update"
         >

--- a/src/components/forms/layout/sheet.tsx
+++ b/src/components/forms/layout/sheet.tsx
@@ -1,14 +1,21 @@
+import { useCallback } from "react"
+import { useFormContext } from "react-hook-form"
+
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { APIError } from "@/types/api"
+
 import { cn } from "@/lib/utils"
+import { handleFormError } from "@/lib/form-errors"
 
 import * as Loading from "@/components/loading"
 
 interface FormsContentSheetProps {
   title: string
-  onSubmit: () => void
+  onSubmit: () => void | Promise<void>
   onCancel: () => void
+  errorMessage?: string
   submitLabel?: string
   cancelLabel?: string
   isPending?: boolean
@@ -21,6 +28,7 @@ export default function FormsContentSheet({
   title,
   onSubmit,
   onCancel,
+  errorMessage,
   submitLabel = "Submit",
   cancelLabel = "Cancel",
   isPending = false,
@@ -28,6 +36,24 @@ export default function FormsContentSheet({
   children,
   className,
 }: FormsContentSheetProps) {
+  const form = useFormContext()
+
+  const handleSubmit = useCallback(async () => {
+    const valid = await form.trigger()
+    if (!valid) return
+
+    try {
+      await onSubmit()
+    } catch (error) {
+      if (errorMessage && error instanceof APIError) {
+        await handleFormError({
+          form,
+          apiError: error,
+          toastMessage: errorMessage,
+        })
+      }
+    }
+  }, [onSubmit, errorMessage, form])
   return (
     <div
       className={cn(
@@ -63,7 +89,7 @@ export default function FormsContentSheet({
         </Button>
         <Button
           type="button"
-          onClick={onSubmit}
+          onClick={handleSubmit}
           disabled={isPending}
           className="max-w-48 flex-1 basis-1/2"
         >

--- a/src/components/forms/layout/wizard.tsx
+++ b/src/components/forms/layout/wizard.tsx
@@ -4,7 +4,10 @@ import { useFormContext } from "react-hook-form"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { APIError } from "@/types/api"
+
 import { cn } from "@/lib/utils"
+import { handleFormError } from "@/lib/form-errors"
 
 import { useMobile } from "@/hooks/use-mobile"
 import { useSlide } from "@/hooks/use-slide"
@@ -31,9 +34,10 @@ interface FormsContentWizardProps {
   variant?: WizardVariant
   title?: string
   description?: React.ReactNode
-  onSubmit: () => void
+  onSubmit: () => void | Promise<void>
   onBack: () => void
   onCancel?: () => void
+  errorMessage?: string
   submitLabel?: string
   backLabel?: string
   cancelLabel?: string
@@ -75,6 +79,7 @@ export default function FormsContentWizard({
   onSubmit,
   onBack,
   onCancel,
+  errorMessage,
   submitLabel = "Submit",
   backLabel = "Back",
   cancelLabel = "Cancel",
@@ -93,6 +98,15 @@ export default function FormsContentWizard({
   const isFirst = currentIndex === 0
   const isLast = currentIndex === steps.length - 1
 
+  const goToIndex = useCallback(
+    (index: number) => {
+      if (index >= 0 && index < steps.length) {
+        goTo(index)
+      }
+    },
+    [steps.length, goTo],
+  )
+
   const next = useCallback(async () => {
     if (currentStep?.fields?.length) {
       const ok = await form.trigger(currentStep.fields)
@@ -108,11 +122,47 @@ export default function FormsContentWizard({
     }
 
     if (isLast) {
-      onSubmit()
+      const valid = await form.trigger()
+
+      // Catch schema errors
+      if (!valid) {
+        await handleFormError({
+          form,
+          steps: steps.map((step) => ({ key: step.id, fields: step.fields })),
+          goToStep: goToIndex,
+          toastMessage: errorMessage ?? "",
+        })
+        return
+      }
+
+      try {
+        await onSubmit()
+      } catch (error) {
+        // Catch API errors
+        if (errorMessage && error instanceof APIError) {
+          await handleFormError({
+            form,
+            steps: steps.map((step) => ({ key: step.id, fields: step.fields })),
+            goToStep: goToIndex,
+            toastMessage: errorMessage ?? "",
+            apiError: error,
+          })
+        }
+      }
     } else {
       goTo(currentIndex + 1)
     }
-  }, [currentStep, currentIndex, isLast, form, goTo, onSubmit])
+  }, [
+    currentStep,
+    currentIndex,
+    isLast,
+    form,
+    goTo,
+    goToIndex,
+    steps,
+    onSubmit,
+    errorMessage,
+  ])
 
   const back = useCallback(() => {
     if (isFirst) {
@@ -121,15 +171,6 @@ export default function FormsContentWizard({
       goTo(currentIndex - 1)
     }
   }, [currentIndex, isFirst, goTo, onBack])
-
-  const goToIndex = useCallback(
-    (index: number) => {
-      if (index >= 0 && index < steps.length) {
-        goTo(index)
-      }
-    },
-    [steps.length, goTo],
-  )
 
   return variant === "sidebar" ? (
     <SidebarContent

--- a/src/components/groups/form/create.tsx
+++ b/src/components/groups/form/create.tsx
@@ -38,22 +38,11 @@ export default function CreateGroupForm({
   const navigateToResource = useResourceNavigate()
 
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit((values) => {
-      createGroup.mutate(values, {
-        onSuccess: async (group) => {
-          toast({ message: "Group created", variant: "success" })
-          onOpenChange(false)
-          await navigateToResource(group)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to create group",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    })()
+    const values = form.getValues()
+    const group = await createGroup.mutateAsync(values)
+    toast({ message: "Group created", variant: "success" })
+    onOpenChange(false)
+    await navigateToResource(group)
   }, [form, createGroup, navigateToResource, onOpenChange])
 
   return (
@@ -64,6 +53,7 @@ export default function CreateGroupForm({
           onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           isPending={createGroup.isPending}
+          errorMessage="Failed to create group"
           className="md:h-[52vh]!"
         >
           <Forms.Section.Step

--- a/src/components/groups/form/edit.tsx
+++ b/src/components/groups/form/edit.tsx
@@ -42,21 +42,10 @@ export default function EditGroupForm({
   })
 
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit((values) => {
-      updateGroup.mutate(values, {
-        onSuccess: () => {
-          toast({ message: "Group updated", variant: "success" })
-          onOpenChange(false)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to update group",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    })()
+    const values = form.getValues()
+    await updateGroup.mutateAsync(values)
+    toast({ message: "Group updated", variant: "success" })
+    onOpenChange(false)
   }, [form, updateGroup, onOpenChange])
 
   return (
@@ -66,6 +55,7 @@ export default function EditGroupForm({
           title="Editing an existing group"
           onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
+          errorMessage="Failed to update group"
           isPending={updateGroup.isPending}
           submitLabel="Update"
         >

--- a/src/components/licenses/form/create.tsx
+++ b/src/components/licenses/form/create.tsx
@@ -52,38 +52,13 @@ export default function CreateLicenseForm({
     [policies, selectedPolicyId],
   )
 
-  const handleCreateLicense = useCallback(
-    (values: Schemas.Licenses.CreateValues) => {
-      if (!values.policyId) {
-        toast({
-          message: "Failed to create license",
-          description: "Policy is required.",
-          variant: "error",
-        })
-        return
-      }
-
-      createLicense.mutate(values, {
-        onSuccess: async (license) => {
-          toast({ message: "License created", variant: "success" })
-          onOpenChange(false)
-          await navigateToResource(license)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to create license",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    },
-    [createLicense, navigateToResource, onOpenChange],
-  )
-
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit(handleCreateLicense)()
-  }, [form, handleCreateLicense])
+    const values = form.getValues()
+    const license = await createLicense.mutateAsync(values)
+    toast({ message: "License created", variant: "success" })
+    onOpenChange(false)
+    await navigateToResource(license)
+  }, [form, createLicense, navigateToResource, onOpenChange])
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
@@ -93,6 +68,7 @@ export default function CreateLicenseForm({
           onSubmit={handleSubmit}
           isPending={createLicense.isPending}
           description="Creating a new license"
+          errorMessage="Failed to create license"
         >
           <Forms.Section.Step
             crumb="General attributes"

--- a/src/components/licenses/form/edit.tsx
+++ b/src/components/licenses/form/edit.tsx
@@ -52,21 +52,10 @@ export default function EditLicenseForm({
   })
 
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit((values) => {
-      updateLicense.mutate(values, {
-        onSuccess: () => {
-          toast({ message: "License updated", variant: "success" })
-          onOpenChange(false)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to update license",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    })()
+    const values = form.getValues()
+    await updateLicense.mutateAsync(values)
+    toast({ message: "License updated", variant: "success" })
+    onOpenChange(false)
   }, [form, updateLicense, onOpenChange])
 
   return (
@@ -76,6 +65,7 @@ export default function EditLicenseForm({
           title="Editing an existing license"
           onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
+          errorMessage="Failed to update license"
           isPending={updateLicense.isPending}
           submitLabel="Update"
           className="md:h-[56vh]!"

--- a/src/components/machines/form/create.tsx
+++ b/src/components/machines/form/create.tsx
@@ -5,7 +5,6 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { Form } from "@/components/ui/form"
 
 import * as Schemas from "@/schemas"
-import { MachineErrorCode } from "@/types/machines"
 import { useCreateMachine } from "@/queries/machines"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
@@ -45,36 +44,13 @@ export default function CreateMachineForm({
   const createMachine = useCreateMachine()
   const navigateToResource = useResourceNavigate()
 
-  const handleCreateMachine = useCallback(
-    (values: Schemas.Machines.CreateValues) => {
-      createMachine.mutate(values, {
-        onSuccess: async (machine) => {
-          toast({ message: "Machine activated", variant: "success" })
-          onOpenChange(false)
-          await navigateToResource(machine)
-        },
-        onError: (error) => {
-          if (error.code === MachineErrorCode.MachineLimitExceeded) {
-            form.setError("licenseId", {
-              type: "manual",
-              message: "Machine limit exceeded for this license",
-            })
-          }
-
-          toast({
-            message: "Failed to activate machine",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    },
-    [createMachine, navigateToResource, onOpenChange, form],
-  )
-
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit(handleCreateMachine)()
-  }, [form, handleCreateMachine])
+    const values = form.getValues()
+    const machine = await createMachine.mutateAsync(values)
+    toast({ message: "Machine activated", variant: "success" })
+    onOpenChange(false)
+    await navigateToResource(machine)
+  }, [form, createMachine, navigateToResource, onOpenChange])
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
@@ -85,6 +61,7 @@ export default function CreateMachineForm({
           isPending={createMachine.isPending}
           submitLabel="Activate"
           description="Activating a new machine"
+          errorMessage="Failed to activate machine"
         >
           <Forms.Section.Step
             crumb="General attributes"

--- a/src/components/machines/form/edit.tsx
+++ b/src/components/machines/form/edit.tsx
@@ -46,21 +46,10 @@ export default function EditMachineForm({
   })
 
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit((values) => {
-      updateMachine.mutate(values, {
-        onSuccess: () => {
-          toast({ message: "Machine updated", variant: "success" })
-          onOpenChange(false)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to update machine",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    })()
+    const values = form.getValues()
+    await updateMachine.mutateAsync(values)
+    toast({ message: "Machine updated", variant: "success" })
+    onOpenChange(false)
   }, [form, updateMachine, onOpenChange])
 
   return (
@@ -70,6 +59,7 @@ export default function EditMachineForm({
           title="Editing an existing machine"
           onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
+          errorMessage="Failed to update machine"
           isPending={updateMachine.isPending}
           submitLabel="Update"
           className="md:h-[76vh]!"

--- a/src/components/policies/form/create.tsx
+++ b/src/components/policies/form/create.tsx
@@ -174,19 +174,18 @@ export default function CreatePolicyForm({
         return
       }
 
-      createPolicy.mutate(values, {
-        onSuccess: async (policy) => {
-          toast({ message: "Policy created", variant: "success" })
-          await navigateToResource(policy)
-          onOpenChange(false)
-        },
-        onError: () => {
-          toast({ message: "Failed to create policy", variant: "error" })
-        },
-      })
+      const policy = await createPolicy.mutateAsync(values)
+      toast({ message: "Policy created", variant: "success" })
+      await navigateToResource(policy)
+      onOpenChange(false)
     },
     [form, createPolicy, navigateToResource, createEntitlement, onOpenChange],
   )
+
+  const handleSubmit = useCallback(async () => {
+    const values = form.getValues()
+    await handleCreatePolicy(values)
+  }, [form, handleCreatePolicy])
 
   const handleOpenChange = useCallback(
     (value: boolean) => {
@@ -229,8 +228,9 @@ export default function CreatePolicyForm({
           onOpenChange={handleOpenChange}
           selection={selection}
           onBack={() => setSelection(null)}
-          onSubmit={() => form.handleSubmit(handleCreatePolicy)()}
+          onSubmit={handleSubmit}
           isPending={createPolicy.isPending}
+          errorMessage="Failed to create policy"
         />
       )}
 
@@ -243,8 +243,9 @@ export default function CreatePolicyForm({
             setMode("templates")
             setSelection(null)
           }}
-          onSubmit={() => form.handleSubmit(handleCreatePolicy)()}
+          onSubmit={handleSubmit}
           isPending={createPolicy.isPending}
+          errorMessage="Failed to create policy"
         />
       )}
     </>
@@ -523,6 +524,7 @@ interface TemplatesFormProps {
   onSubmit: () => void
   onBack: () => void
   isPending: boolean
+  errorMessage?: string
 }
 
 function TemplatesForm({
@@ -533,6 +535,7 @@ function TemplatesForm({
   onSubmit,
   onBack,
   isPending,
+  errorMessage,
 }: TemplatesFormProps) {
   return (
     <Forms.Container.Dialog
@@ -545,6 +548,7 @@ function TemplatesForm({
           onSubmit={onSubmit}
           onBack={onBack}
           isPending={isPending}
+          errorMessage={errorMessage}
           description={
             <BadgeGroup prefix="Creating a new" suffix="policy" mobileMax={1}>
               {selection.timing === TimingTemplates.Perpetual && (
@@ -882,6 +886,7 @@ interface ScratchFormProps {
   onSubmit: () => void
   onBack: () => void
   isPending: boolean
+  errorMessage?: string
 }
 
 function ScratchForm({
@@ -891,6 +896,7 @@ function ScratchForm({
   onSubmit,
   onBack,
   isPending,
+  errorMessage,
 }: ScratchFormProps) {
   return (
     <Forms.Container.Dialog
@@ -907,6 +913,7 @@ function ScratchForm({
           onCancel={onBack}
           onBack={onBack}
           isPending={isPending}
+          errorMessage={errorMessage}
         >
           <Forms.Section.Step
             crumb="General attributes"

--- a/src/components/policies/form/duplicate.tsx
+++ b/src/components/policies/form/duplicate.tsx
@@ -69,53 +69,47 @@ export default function DuplicatePolicyForm({
 
   const handleSubmit = useCallback(async () => {
     if (!policy) return
-    await form.handleSubmit(async (values) => {
-      const attachIds = values.entitlements?.attach ?? []
-      const toCreate = values.entitlements?.create ?? []
-      const [createdEntitlements, errors] = await settleMutations<Entitlement>(
-        toCreate.map((attrs) => createEntitlement.mutateAsync(attrs)),
-      )
-      const entitlementIds = Array.from(
-        new Set([...attachIds, ...createdEntitlements.map((e) => e.id)]),
-      )
+    const values = form.getValues()
 
-      if (errors.length > 0) {
-        const nextAttach = [...entitlementIds]
-        const nextCreate = errors.map(({ index }) => toCreate[index])
-        form.setValue("entitlements.attach", nextAttach)
-        form.setValue("entitlements.create", nextCreate)
-        errors.forEach((error, index) => {
-          let message = ""
-          if (error.reason.code === EntitlementErrorCode.CodeTaken) {
-            message = "Code already exists"
-          } else {
-            message = "Field is invalid"
-          }
-          form.setError(`entitlements.create.${index}.code`, {
-            type: "validate",
-            message,
-          })
+    const attachIds = values.entitlements?.attach ?? []
+    const toCreate = values.entitlements?.create ?? []
+    const [createdEntitlements, errors] = await settleMutations<Entitlement>(
+      toCreate.map((attrs) => createEntitlement.mutateAsync(attrs)),
+    )
+    const entitlementIds = Array.from(
+      new Set([...attachIds, ...createdEntitlements.map((e) => e.id)]),
+    )
+
+    if (errors.length > 0) {
+      const nextAttach = [...entitlementIds]
+      const nextCreate = errors.map(({ index }) => toCreate[index])
+      form.setValue("entitlements.attach", nextAttach)
+      form.setValue("entitlements.create", nextCreate)
+      errors.forEach((error, index) => {
+        let message = ""
+        if (error.reason.code === EntitlementErrorCode.CodeTaken) {
+          message = "Code already exists"
+        } else {
+          message = "Field is invalid"
+        }
+        form.setError(`entitlements.create.${index}.code`, {
+          type: "validate",
+          message,
         })
-        toast({ message: "Failed to create entitlement(s)", variant: "error" })
-        return
-      }
+      })
+      toast({ message: "Failed to create entitlement(s)", variant: "error" })
+      return
+    }
 
-      createPolicy.mutate(
-        { ...values, entitlements: { attach: entitlementIds, create: [] } },
-        {
-          onSuccess: async (created) => {
-            if (entitlementIds.length > 0)
-              await attachEntitlements.mutateAsync(entitlementIds)
-            toast({ message: "Policy created", variant: "success" })
-            onOpenChange(false)
-            await navigateToResource(created)
-          },
-          onError: () => {
-            toast({ message: "Failed to create policy", variant: "error" })
-          },
-        },
-      )
-    })()
+    const created = await createPolicy.mutateAsync({
+      ...values,
+      entitlements: { attach: entitlementIds, create: [] },
+    })
+    if (entitlementIds.length > 0)
+      await attachEntitlements.mutateAsync(entitlementIds)
+    toast({ message: "Policy created", variant: "success" })
+    onOpenChange(false)
+    await navigateToResource(created)
   }, [
     form,
     policy,
@@ -156,6 +150,7 @@ export default function DuplicatePolicyForm({
             title="Duplicating an existing policy"
             onSubmit={handleSubmit}
             onCancel={() => onOpenChange(false)}
+            errorMessage="Failed to create policy"
             isPending={
               createPolicy.isPending ||
               createEntitlement.isPending ||

--- a/src/components/policies/form/edit.tsx
+++ b/src/components/policies/form/edit.tsx
@@ -60,60 +60,51 @@ export default function EditPolicyForm({
 
   const handleSubmit = useCallback(async () => {
     if (!policy) return
-    await form.handleSubmit(async (values) => {
-      const attachIds = values.entitlements?.attach ?? []
-      const toCreate = values.entitlements?.create ?? []
-      const [entitlements, errors] = await settleMutations<Entitlement>(
-        toCreate.map((attrs) => createEntitlement.mutateAsync(attrs)),
-      )
-      const entitlementIds = Array.from(
-        new Set([...attachIds, ...entitlements.map((e) => e.id)]),
-      )
+    const values = form.getValues()
 
-      if (errors.length > 0) {
-        const nextAttach = [...entitlementIds]
-        const nextCreate = errors.map(({ index }) => toCreate[index])
-        form.setValue("entitlements.attach", nextAttach)
-        form.setValue("entitlements.create", nextCreate)
-        errors.forEach((error, index) => {
-          let message = ""
-          if (error.reason.code === EntitlementErrorCode.CodeTaken) {
-            message = "Code already exists"
-          } else {
-            message = "Field is invalid"
-          }
-          form.setError(`entitlements.create.${index}.code`, {
-            type: "validate",
-            message,
-          })
+    const attachIds = values.entitlements?.attach ?? []
+    const toCreate = values.entitlements?.create ?? []
+    const [entitlements, errors] = await settleMutations<Entitlement>(
+      toCreate.map((attrs) => createEntitlement.mutateAsync(attrs)),
+    )
+    const entitlementIds = Array.from(
+      new Set([...attachIds, ...entitlements.map((e) => e.id)]),
+    )
+
+    if (errors.length > 0) {
+      const nextAttach = [...entitlementIds]
+      const nextCreate = errors.map(({ index }) => toCreate[index])
+      form.setValue("entitlements.attach", nextAttach)
+      form.setValue("entitlements.create", nextCreate)
+      errors.forEach((error, index) => {
+        let message = ""
+        if (error.reason.code === EntitlementErrorCode.CodeTaken) {
+          message = "Code already exists"
+        } else {
+          message = "Field is invalid"
+        }
+        form.setError(`entitlements.create.${index}.code`, {
+          type: "validate",
+          message,
         })
-        toast({ message: "Failed to create entitlement(s)", variant: "error" })
-        return
-      }
+      })
+      toast({ message: "Failed to create entitlement(s)", variant: "error" })
+      return
+    }
 
-      const currentIds = currentEntitlements.map((e) => e.id)
-      const newIds = entitlementIds
-      const toAttach = newIds.filter((id) => !currentIds.includes(id))
-      const toDetach = currentIds.filter((id) => !newIds.includes(id))
+    const currentIds = currentEntitlements.map((e) => e.id)
+    const newIds = entitlementIds
+    const toAttach = newIds.filter((id) => !currentIds.includes(id))
+    const toDetach = currentIds.filter((id) => !newIds.includes(id))
 
-      try {
-        if (toDetach.length > 0) await detachEntitlements.mutateAsync(toDetach)
-        if (toAttach.length > 0) await attachEntitlements.mutateAsync(toAttach)
-        updatePolicy.mutate(
-          { ...values, entitlements: { attach: entitlementIds, create: [] } },
-          {
-            onSuccess: () => {
-              toast({ message: "Policy updated", variant: "success" })
-              onOpenChange(false)
-            },
-            onError: () =>
-              toast({ message: "Failed to update policy", variant: "error" }),
-          },
-        )
-      } catch {
-        toast({ message: "Failed to update entitlements", variant: "error" })
-      }
-    })()
+    if (toDetach.length > 0) await detachEntitlements.mutateAsync(toDetach)
+    if (toAttach.length > 0) await attachEntitlements.mutateAsync(toAttach)
+    await updatePolicy.mutateAsync({
+      ...values,
+      entitlements: { attach: entitlementIds, create: [] },
+    })
+    toast({ message: "Policy updated", variant: "success" })
+    onOpenChange(false)
   }, [
     form,
     policy,
@@ -132,6 +123,7 @@ export default function EditPolicyForm({
           title="Editing an existing policy"
           onSubmit={handleSubmit}
           onCancel={() => onOpenChange(false)}
+          errorMessage="Failed to update policy"
           isPending={
             updatePolicy.isPending ||
             attachEntitlements.isPending ||

--- a/src/components/processes/form/create.tsx
+++ b/src/components/processes/form/create.tsx
@@ -35,29 +35,13 @@ export default function CreateProcessForm({
   const createProcess = useCreateProcess()
   const navigateToResource = useResourceNavigate()
 
-  const handleCreateProcess = useCallback(
-    (values: Schemas.Processes.CreateValues) => {
-      createProcess.mutate(values, {
-        onSuccess: async (process) => {
-          toast({ message: "Process spawned", variant: "success" })
-          onOpenChange(false)
-          await navigateToResource(process)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to spawn process",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    },
-    [createProcess, navigateToResource, onOpenChange],
-  )
-
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit(handleCreateProcess)()
-  }, [form, handleCreateProcess])
+    const values = form.getValues()
+    const process = await createProcess.mutateAsync(values)
+    toast({ message: "Process spawned", variant: "success" })
+    onOpenChange(false)
+    await navigateToResource(process)
+  }, [form, createProcess, navigateToResource, onOpenChange])
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
@@ -68,6 +52,7 @@ export default function CreateProcessForm({
           isPending={createProcess.isPending}
           submitLabel="Spawn"
           description="Spawning a new process"
+          errorMessage="Failed to spawn process"
         >
           <Forms.Section.Step
             crumb="Process attributes"

--- a/src/components/processes/form/edit.tsx
+++ b/src/components/processes/form/edit.tsx
@@ -36,21 +36,10 @@ export default function EditProcessForm({
   })
 
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit((values) => {
-      updateProcess.mutate(values, {
-        onSuccess: () => {
-          toast({ message: "Process updated", variant: "success" })
-          onOpenChange(false)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to update process",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    })()
+    const values = form.getValues()
+    await updateProcess.mutateAsync(values)
+    toast({ message: "Process updated", variant: "success" })
+    onOpenChange(false)
   }, [form, updateProcess, onOpenChange])
 
   return (
@@ -60,6 +49,7 @@ export default function EditProcessForm({
           title="Editing an existing process"
           onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
+          errorMessage="Failed to update process"
           isPending={updateProcess.isPending}
           submitLabel="Update"
         >

--- a/src/components/products/form/create.tsx
+++ b/src/components/products/form/create.tsx
@@ -51,22 +51,11 @@ export default function CreateProductForm({
   })
 
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit((values) => {
-      createProduct.mutate(values, {
-        onSuccess: async (product) => {
-          toast({ message: "Product created", variant: "success" })
-          onOpenChange(false)
-          await navigateToResource(product)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to create product",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    })()
+    const values = form.getValues()
+    const product = await createProduct.mutateAsync(values)
+    toast({ message: "Product created", variant: "success" })
+    onOpenChange(false)
+    await navigateToResource(product)
   }, [form, createProduct, navigateToResource, onOpenChange])
 
   return (
@@ -98,6 +87,7 @@ export default function CreateProductForm({
               )}
             </BadgeGroup>
           }
+          errorMessage="Failed to create product"
           className="md:h-[52vh]!"
         >
           <Forms.Section.Step

--- a/src/components/products/form/edit.tsx
+++ b/src/components/products/form/edit.tsx
@@ -47,21 +47,10 @@ export default function EditProductForm({
   })
 
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit((values) => {
-      updateProduct.mutate(values, {
-        onSuccess: () => {
-          toast({ message: "Product updated", variant: "success" })
-          onOpenChange(false)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to update product",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    })()
+    const values = form.getValues()
+    await updateProduct.mutateAsync(values)
+    toast({ message: "Product updated", variant: "success" })
+    onOpenChange(false)
   }, [form, updateProduct, onOpenChange])
 
   return (
@@ -71,6 +60,7 @@ export default function EditProductForm({
           title="Editing an existing product"
           onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
+          errorMessage="Failed to update product"
           isPending={updateProduct.isPending}
           submitLabel="Update"
           className="md:h-[70vh]!"

--- a/src/components/users/form/create.tsx
+++ b/src/components/users/form/create.tsx
@@ -43,29 +43,13 @@ export default function CreateUserForm({
   const createUser = useCreateUser()
   const navigateToResource = useResourceNavigate()
 
-  const handleCreateUser = useCallback(
-    (values: Schemas.Users.CreateValues) => {
-      createUser.mutate(values, {
-        onSuccess: async (user) => {
-          toast({ message: "User created", variant: "success" })
-          onOpenChange(false)
-          await navigateToResource(user)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to create user",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    },
-    [createUser, onOpenChange, navigateToResource],
-  )
-
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit(handleCreateUser)()
-  }, [form, handleCreateUser])
+    const values = form.getValues()
+    const user = await createUser.mutateAsync(values)
+    toast({ message: "User created", variant: "success" })
+    onOpenChange(false)
+    await navigateToResource(user)
+  }, [form, createUser, navigateToResource, onOpenChange])
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
@@ -75,6 +59,7 @@ export default function CreateUserForm({
           onSubmit={handleSubmit}
           isPending={createUser.isPending}
           description="Creating a new user"
+          errorMessage="Failed to create user"
         >
           <Forms.Section.Step
             crumb="General attributes"

--- a/src/components/users/form/edit.tsx
+++ b/src/components/users/form/edit.tsx
@@ -44,21 +44,10 @@ export default function EditUserForm({
   })
 
   const handleSubmit = useCallback(async () => {
-    await form.handleSubmit((values) => {
-      updateUser.mutate(values, {
-        onSuccess: () => {
-          toast({ message: "User updated", variant: "success" })
-          onOpenChange(false)
-        },
-        onError: (error) => {
-          toast({
-            message: "Failed to update user",
-            description: error.detail,
-            variant: "error",
-          })
-        },
-      })
-    })()
+    const values = form.getValues()
+    await updateUser.mutateAsync(values)
+    toast({ message: "User updated", variant: "success" })
+    onOpenChange(false)
   }, [form, updateUser, onOpenChange])
 
   return (
@@ -68,6 +57,7 @@ export default function EditUserForm({
           title="Editing an existing user"
           onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
+          errorMessage="Failed to update user"
           isPending={userLoading}
           submitLabel="Update"
           className="md:h-[66vh]!"

--- a/src/lib/form-errors.ts
+++ b/src/lib/form-errors.ts
@@ -1,0 +1,130 @@
+import { FieldPath, FieldValues, UseFormReturn } from "react-hook-form"
+
+import { APIError } from "@/types/api"
+
+import { toast } from "@/lib/toast"
+
+export type ErrorFieldMapping<TFieldValues extends FieldValues> = {
+  code: string
+  field: FieldPath<TFieldValues>
+  message?: string
+}
+
+export type FormStep<TFieldValues extends FieldValues> = {
+  key: string
+  fields?: FieldPath<TFieldValues>[]
+}
+
+export type HandleFormErrorOptions<TFieldValues extends FieldValues> = {
+  form: UseFormReturn<TFieldValues>
+  error: APIError
+  fieldMappings?: ErrorFieldMapping<TFieldValues>[]
+  steps?: FormStep<TFieldValues>[]
+  goToStep?: (index: number) => void
+  toastMessage: string
+  showToast?: boolean
+}
+
+function extractFieldFromPointer(pointer: string | undefined): string | null {
+  if (!pointer) return null
+
+  const attributesMatch = pointer.match(/\/data\/attributes\/(\w+)/)
+  if (attributesMatch) return attributesMatch[1]
+
+  const relationshipsMatch = pointer.match(/\/data\/relationships\/(\w+)/)
+  if (relationshipsMatch) {
+    return `${relationshipsMatch[1]}Id`
+  }
+
+  return null
+}
+
+function findStepForField<TFieldValues extends FieldValues>(
+  field: FieldPath<TFieldValues>,
+  steps: FormStep<TFieldValues>[],
+): number {
+  const fieldString = String(field)
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i]
+    if (!step.fields) continue
+
+    for (const stepField of step.fields) {
+      if (stepField === field) return i
+      if (fieldString.startsWith(String(stepField))) return i
+    }
+  }
+
+  return -1
+}
+
+export function handleFormError<TFieldValues extends FieldValues>(
+  options: HandleFormErrorOptions<TFieldValues>,
+): boolean {
+  const {
+    form,
+    error,
+    fieldMappings = [],
+    steps = [],
+    goToStep,
+    toastMessage,
+    showToast = true,
+  } = options
+
+  let fieldSet = false
+  let targetField: FieldPath<TFieldValues> | null = null
+  let errorMessage: string | null = null
+
+  if (error.code) {
+    const mapping = fieldMappings.find((mapping) => mapping.code === error.code)
+    if (mapping) {
+      targetField = mapping.field
+      errorMessage = mapping.message ?? error.detail ?? "Field is invalid"
+    }
+  }
+
+  if (!targetField && error.source?.pointer) {
+    const extractedField = extractFieldFromPointer(error.source.pointer)
+    if (extractedField) {
+      const isKnownField =
+        fieldMappings.some((m) => String(m.field) === extractedField) ||
+        steps.some((s) => s.fields?.some((f) => String(f) === extractedField))
+
+      if (isKnownField) {
+        targetField = extractedField as FieldPath<TFieldValues>
+        errorMessage = error.detail ?? "Field is invalid"
+      }
+    }
+  }
+
+  if (targetField) {
+    form.setError(targetField, {
+      type: "manual",
+      message: errorMessage ?? "Field is invalid",
+    })
+    fieldSet = true
+
+    if (goToStep && steps.length > 0) {
+      const stepIndex = findStepForField(targetField, steps)
+      if (stepIndex >= 0) {
+        goToStep(stepIndex)
+      }
+    }
+  }
+
+  if (showToast) {
+    toast({
+      message: toastMessage,
+      description: error.detail ?? error.message,
+      variant: "error",
+    })
+  }
+
+  return fieldSet
+}
+
+export function createFormErrorHandler<TFieldValues extends FieldValues>(
+  baseOptions: Omit<HandleFormErrorOptions<TFieldValues>, "error">,
+) {
+  return (error: APIError) => handleFormError({ ...baseOptions, error })
+}

--- a/src/lib/form-errors.ts
+++ b/src/lib/form-errors.ts
@@ -75,7 +75,7 @@ export function handleFormError<TFieldValues extends FieldValues>(
 
       form.setError(targetField, {
         type: "manual",
-        message: error.detail ?? "Field is invalid",
+        message: capitalize(error.detail ?? "Field is invalid"),
       })
 
       if (goToStep && steps.length > 0) {

--- a/src/lib/form-errors.ts
+++ b/src/lib/form-errors.ts
@@ -53,10 +53,15 @@ function findStepForField<TFieldValues extends FieldValues>(
 
 export function handleFormError<TFieldValues extends FieldValues>(
   options: HandleFormErrorOptions<TFieldValues>,
-): boolean {
-  const { form, error, steps = [], goToStep, toastMessage, showToast = true } = options
-
-  let fieldSet = false
+): void {
+  const {
+    form,
+    error,
+    steps = [],
+    goToStep,
+    toastMessage,
+    showToast = true,
+  } = options
 
   const extractedField = extractFieldFromPointer(error.source?.pointer)
   if (extractedField) {
@@ -71,7 +76,6 @@ export function handleFormError<TFieldValues extends FieldValues>(
         type: "manual",
         message: error.detail ?? "Field is invalid",
       })
-      fieldSet = true
 
       if (goToStep && steps.length > 0) {
         const stepIndex = findStepForField(targetField, steps)
@@ -89,8 +93,6 @@ export function handleFormError<TFieldValues extends FieldValues>(
       variant: "error",
     })
   }
-
-  return fieldSet
 }
 
 export function createFormErrorHandler<TFieldValues extends FieldValues>(

--- a/src/lib/form-errors.ts
+++ b/src/lib/form-errors.ts
@@ -83,6 +83,15 @@ export function handleFormError<TFieldValues extends FieldValues>(
           goToStep(stepIndex)
         }
       }
+
+      if (showToast) {
+        toast({
+          message: toastMessage,
+          variant: "error",
+        })
+      }
+
+      return
     }
   }
 

--- a/src/lib/form-errors.ts
+++ b/src/lib/form-errors.ts
@@ -4,12 +4,6 @@ import { APIError } from "@/types/api"
 
 import { toast } from "@/lib/toast"
 
-export type ErrorFieldMapping<TFieldValues extends FieldValues> = {
-  code: string
-  field: FieldPath<TFieldValues>
-  message?: string
-}
-
 export type FormStep<TFieldValues extends FieldValues> = {
   key: string
   fields?: FieldPath<TFieldValues>[]
@@ -18,7 +12,6 @@ export type FormStep<TFieldValues extends FieldValues> = {
 export type HandleFormErrorOptions<TFieldValues extends FieldValues> = {
   form: UseFormReturn<TFieldValues>
   error: APIError
-  fieldMappings?: ErrorFieldMapping<TFieldValues>[]
   steps?: FormStep<TFieldValues>[]
   goToStep?: (index: number) => void
   toastMessage: string
@@ -61,53 +54,30 @@ function findStepForField<TFieldValues extends FieldValues>(
 export function handleFormError<TFieldValues extends FieldValues>(
   options: HandleFormErrorOptions<TFieldValues>,
 ): boolean {
-  const {
-    form,
-    error,
-    fieldMappings = [],
-    steps = [],
-    goToStep,
-    toastMessage,
-    showToast = true,
-  } = options
+  const { form, error, steps = [], goToStep, toastMessage, showToast = true } = options
 
   let fieldSet = false
-  let targetField: FieldPath<TFieldValues> | null = null
-  let errorMessage: string | null = null
 
-  if (error.code) {
-    const mapping = fieldMappings.find((mapping) => mapping.code === error.code)
-    if (mapping) {
-      targetField = mapping.field
-      errorMessage = mapping.message ?? error.detail ?? "Field is invalid"
-    }
-  }
+  const extractedField = extractFieldFromPointer(error.source?.pointer)
+  if (extractedField) {
+    const isKnownField = steps.some((s) =>
+      s.fields?.some((f) => String(f) === extractedField),
+    )
 
-  if (!targetField && error.source?.pointer) {
-    const extractedField = extractFieldFromPointer(error.source.pointer)
-    if (extractedField) {
-      const isKnownField =
-        fieldMappings.some((m) => String(m.field) === extractedField) ||
-        steps.some((s) => s.fields?.some((f) => String(f) === extractedField))
+    if (isKnownField) {
+      const targetField = extractedField as FieldPath<TFieldValues>
 
-      if (isKnownField) {
-        targetField = extractedField as FieldPath<TFieldValues>
-        errorMessage = error.detail ?? "Field is invalid"
-      }
-    }
-  }
+      form.setError(targetField, {
+        type: "manual",
+        message: error.detail ?? "Field is invalid",
+      })
+      fieldSet = true
 
-  if (targetField) {
-    form.setError(targetField, {
-      type: "manual",
-      message: errorMessage ?? "Field is invalid",
-    })
-    fieldSet = true
-
-    if (goToStep && steps.length > 0) {
-      const stepIndex = findStepForField(targetField, steps)
-      if (stepIndex >= 0) {
-        goToStep(stepIndex)
+      if (goToStep && steps.length > 0) {
+        const stepIndex = findStepForField(targetField, steps)
+        if (stepIndex >= 0) {
+          goToStep(stepIndex)
+        }
       }
     }
   }

--- a/src/lib/form-errors.ts
+++ b/src/lib/form-errors.ts
@@ -3,6 +3,7 @@ import { FieldPath, FieldValues, UseFormReturn } from "react-hook-form"
 import { APIError } from "@/types/api"
 
 import { toast } from "@/lib/toast"
+import { capitalize } from "@/lib/utils"
 
 export type FormStep<TFieldValues extends FieldValues> = {
   key: string
@@ -98,7 +99,7 @@ export function handleFormError<TFieldValues extends FieldValues>(
   if (showToast) {
     toast({
       message: toastMessage,
-      description: error.detail ?? error.message,
+      description: capitalize(error.detail ?? error.message),
       variant: "error",
     })
   }

--- a/src/lib/form-errors.ts
+++ b/src/lib/form-errors.ts
@@ -10,15 +10,7 @@ export type FormStep<TFieldValues extends FieldValues> = {
   fields?: FieldPath<TFieldValues>[]
 }
 
-export type HandleFormErrorOptions<TFieldValues extends FieldValues> = {
-  form: UseFormReturn<TFieldValues>
-  error: APIError
-  steps?: FormStep<TFieldValues>[]
-  goToStep?: (index: number) => void
-  toastMessage: string
-  showToast?: boolean
-}
-
+// Extracts the related form field from an API error pointer
 function extractFieldFromPointer(pointer: string | undefined): string | null {
   if (!pointer) return null
 
@@ -33,6 +25,7 @@ function extractFieldFromPointer(pointer: string | undefined): string | null {
   return null
 }
 
+// Iterates through all form steps for the step that contains the specified field
 function findStepForField<TFieldValues extends FieldValues>(
   field: FieldPath<TFieldValues>,
   steps: FormStep<TFieldValues>[],
@@ -52,32 +45,54 @@ function findStepForField<TFieldValues extends FieldValues>(
   return -1
 }
 
-export function handleFormError<TFieldValues extends FieldValues>(
+// Sequentially triggers validation for all form steps until a step fails then returns its index
+async function findStepWithError<TFieldValues extends FieldValues>(
+  form: UseFormReturn<TFieldValues>,
+  steps: FormStep<TFieldValues>[],
+): Promise<number> {
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i]
+    if (step.fields && step.fields.length > 0) {
+      const valid = await form.trigger(step.fields)
+      if (!valid) return i
+    }
+  }
+  return -1
+}
+
+export type HandleFormErrorOptions<TFieldValues extends FieldValues> = {
+  form: UseFormReturn<TFieldValues>
+  steps?: FormStep<TFieldValues>[]
+  goToStep?: (index: number) => void
+  apiError?: APIError
+  showToast?: boolean
+  toastMessage?: string
+}
+
+// Handles API and schema validation errors by setting field-level errors, navigating to the relevant step, and/or toasting
+export async function handleFormError<TFieldValues extends FieldValues>(
   options: HandleFormErrorOptions<TFieldValues>,
-): void {
+): Promise<void> {
   const {
     form,
-    error,
     steps = [],
     goToStep,
-    toastMessage,
+    apiError,
     showToast = true,
+    toastMessage = "Failed to submit",
   } = options
 
-  const extractedField = extractFieldFromPointer(error.source?.pointer)
-  if (extractedField) {
-    const isKnownField = steps.some((s) =>
-      s.fields?.some((f) => String(f) === extractedField),
-    )
-
-    if (isKnownField) {
+  if (apiError) {
+    const extractedField = extractFieldFromPointer(apiError.source?.pointer)
+    if (extractedField) {
       const targetField = extractedField as FieldPath<TFieldValues>
 
       form.setError(targetField, {
         type: "manual",
-        message: capitalize(error.detail ?? "Field is invalid"),
+        message: capitalize(apiError.detail ?? "Field is invalid"),
       })
 
+      // Navigate to form step that contains field pointer from API error
       if (goToStep && steps.length > 0) {
         const stepIndex = findStepForField(targetField, steps)
         if (stepIndex >= 0) {
@@ -94,19 +109,32 @@ export function handleFormError<TFieldValues extends FieldValues>(
 
       return
     }
+
+    // Fallback to detailed toast if pointer didn't resolve
+    if (showToast) {
+      toast({
+        message: toastMessage,
+        description: capitalize(apiError.detail ?? apiError.message),
+        variant: "error",
+      })
+    }
+
+    return
   }
 
+  // Navigate to form step that contains error from failed schema validation
+  if (goToStep && steps.length > 0) {
+    const stepIndex = await findStepWithError(form, steps)
+    if (stepIndex >= 0) {
+      goToStep(stepIndex)
+    }
+  }
+
+  // Generic error toast
   if (showToast) {
     toast({
       message: toastMessage,
-      description: capitalize(error.detail ?? error.message),
       variant: "error",
     })
   }
-}
-
-export function createFormErrorHandler<TFieldValues extends FieldValues>(
-  baseOptions: Omit<HandleFormErrorOptions<TFieldValues>, "error">,
-) {
-  return (error: APIError) => handleFormError({ ...baseOptions, error })
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -83,6 +83,10 @@ export function titleCase(s: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
+export function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
 export function labelize(value?: string | null, map?: Record<string, string>) {
   if (!value) return "--"
   return (map && map[value]) || titleCase(value)

--- a/src/queries/components.ts
+++ b/src/queries/components.ts
@@ -46,11 +46,11 @@ export function useCreateComponent() {
     mutationFn: async (values) => {
       const response = await keygen.components.create(values)
 
-      if (response.errors && response.errors.length > 0) {
-        throw response.errors[0]
+      if (response.errors) {
+        throw new APIError(response.errors[0])
       }
 
-      return response.data as Component
+      return response.data
     },
 
     onSuccess: (newComponent) => {
@@ -74,29 +74,29 @@ export function useUpdateComponent(componentId: string) {
     mutationFn: async (values) => {
       const getResponse = await keygen.components.get({ id: componentId })
 
-      if (!getResponse.data) {
-        throw new Error("Component not found")
+      if (getResponse.errors) {
+        throw new APIError(getResponse.errors[0])
       }
 
       const current = getResponse.data
 
       const changes = diff(
-        {
-          ...current.attributes,
-        },
+        current.attributes,
         values,
       ) as Schemas.Components.UpdateValues
 
       if (Object.keys(changes).length === 0) return current
 
-      const updated = await keygen.components
-        .update({
-          id: componentId,
-          values: changes,
-        })
-        .then((response) => response.data as Component)
+      const updateResponse = await keygen.components.update({
+        id: componentId,
+        values: changes,
+      })
 
-      return updated
+      if (updateResponse.errors) {
+        throw new APIError(updateResponse.errors[0])
+      }
+
+      return updateResponse.data
     },
 
     onSuccess: async (updated) => {

--- a/src/queries/entitlements.ts
+++ b/src/queries/entitlements.ts
@@ -46,11 +46,11 @@ export function useCreateEntitlement() {
     mutationFn: async (values) => {
       const response = await keygen.entitlements.create({ values })
 
-      if (response.errors && response.errors.length > 0) {
-        throw response.errors[0]
+      if (response.errors) {
+        throw new APIError(response.errors[0])
       }
 
-      return response?.data as Entitlement
+      return response.data
     },
 
     onSuccess: (newEntitlement) => {
@@ -75,7 +75,11 @@ export function useUpdateEntitlement(entitlementId: string) {
   return useMutation<Entitlement, APIError, Schemas.Entitlements.UpdateValues>({
     mutationFn: (values) =>
       keygen.entitlements.get({ id: entitlementId }).then(async (response) => {
-        const current = response.data as Entitlement
+        if (response.errors) {
+          throw new APIError(response.errors[0])
+        }
+
+        const current = response.data
 
         const changes = diff(
           current.attributes,
@@ -83,11 +87,16 @@ export function useUpdateEntitlement(entitlementId: string) {
         ) as Schemas.Entitlements.UpdateValues
         if (Object.keys(changes).length === 0) return current
 
-        const updated = await keygen.entitlements
-          .update({ id: entitlementId, values: changes })
-          .then((response) => response.data as Entitlement)
+        const updateResponse = await keygen.entitlements.update({
+          id: entitlementId,
+          values: changes,
+        })
 
-        return updated
+        if (updateResponse.errors) {
+          throw new APIError(updateResponse.errors[0])
+        }
+
+        return updateResponse.data
       }),
 
     onSuccess: async (updated) => {

--- a/src/queries/environments.ts
+++ b/src/queries/environments.ts
@@ -30,10 +30,15 @@ export function useCreateEnvironment() {
   const queryClient = useQueryClient()
 
   return useMutation<Environment, APIError, Schemas.Environments.CreateValues>({
-    mutationFn: (values) =>
-      keygen.environments
-        .create({ values })
-        .then((response) => response.data as Environment),
+    mutationFn: async (values) => {
+      const response = await keygen.environments.create({ values })
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response.data
+    },
 
     onSuccess: (newEnvironment) => {
       queryClient.setQueryData<Environment[]>(["environments"], (old) =>
@@ -53,7 +58,11 @@ export function useUpdateEnvironment(environmentId: string) {
   return useMutation<Environment, APIError, Schemas.Environments.UpdateValues>({
     mutationFn: (values) =>
       keygen.environments.get({ id: environmentId }).then(async (response) => {
-        const current = response.data as Environment
+        if (response.errors) {
+          throw new APIError(response.errors[0])
+        }
+
+        const current = response.data
 
         const changes = diff(
           current.attributes,
@@ -61,11 +70,16 @@ export function useUpdateEnvironment(environmentId: string) {
         ) as Schemas.Environments.UpdateValues
         if (Object.keys(changes).length === 0) return current
 
-        const updated = await keygen.environments
-          .update({ id: environmentId, values: changes })
-          .then((response) => response.data as Environment)
+        const updateResponse = await keygen.environments.update({
+          id: environmentId,
+          values: changes,
+        })
 
-        return updated
+        if (updateResponse.errors) {
+          throw new APIError(updateResponse.errors[0])
+        }
+
+        return updateResponse.data
       }),
 
     onSuccess: async (updated) => {

--- a/src/queries/groups.ts
+++ b/src/queries/groups.ts
@@ -45,8 +45,15 @@ export function useCreateGroup() {
   const { code } = useEnvironment()
 
   return useMutation<Group, APIError, Schemas.Groups.CreateValues>({
-    mutationFn: (values) =>
-      keygen.groups.create(values).then((response) => response.data as Group),
+    mutationFn: async (values) => {
+      const response = await keygen.groups.create(values)
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response.data
+    },
 
     onSuccess: (newGroup) => {
       queryClient.setQueryData<Group[]>(
@@ -68,7 +75,11 @@ export function useUpdateGroup(groupId: string) {
   return useMutation<Group, APIError, Schemas.Groups.UpdateValues>({
     mutationFn: (values) =>
       keygen.groups.get({ id: groupId }).then(async (response) => {
-        const current = response.data as Group
+        if (response.errors) {
+          throw new APIError(response.errors[0])
+        }
+
+        const current = response.data
 
         const changes = diff(
           current.attributes,
@@ -76,11 +87,16 @@ export function useUpdateGroup(groupId: string) {
         ) as Schemas.Groups.UpdateValues
         if (Object.keys(changes).length === 0) return current
 
-        const updated = await keygen.groups
-          .update({ id: groupId, values: changes })
-          .then((response) => response.data as Group)
+        const updateResponse = await keygen.groups.update({
+          id: groupId,
+          values: changes,
+        })
 
-        return updated
+        if (updateResponse.errors) {
+          throw new APIError(updateResponse.errors[0])
+        }
+
+        return updateResponse.data
       }),
 
     onSuccess: async (updated) => {

--- a/src/queries/licenses.ts
+++ b/src/queries/licenses.ts
@@ -43,10 +43,15 @@ export function useCreateLicense() {
   const { code } = useEnvironment()
 
   return useMutation<License, APIError, Schemas.Licenses.CreateValues>({
-    mutationFn: (values) =>
-      keygen.licenses
-        .create(values)
-        .then((response) => response.data as License),
+    mutationFn: async (values) => {
+      const response = await keygen.licenses.create(values)
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response.data
+    },
 
     onSuccess: (newLicense) => {
       queryClient.setQueryData<License[]>(
@@ -68,7 +73,11 @@ export function useUpdateLicense(licenseId: string) {
   return useMutation<License, APIError, Schemas.Licenses.UpdateValues>({
     mutationFn: (values) =>
       keygen.licenses.get({ id: licenseId }).then(async (response) => {
-        const current = response.data as License
+        if (response.errors) {
+          throw new APIError(response.errors[0])
+        }
+
+        const current = response.data
 
         const changes = diff(
           current.attributes,
@@ -76,11 +85,16 @@ export function useUpdateLicense(licenseId: string) {
         ) as Schemas.Licenses.UpdateValues
         if (Object.keys(changes).length === 0) return current
 
-        const updated = await keygen.licenses
-          .update({ id: licenseId, values: changes })
-          .then((response) => response.data as License)
+        const updateResponse = await keygen.licenses.update({
+          id: licenseId,
+          values: changes,
+        })
 
-        return updated
+        if (updateResponse.errors) {
+          throw new APIError(updateResponse.errors[0])
+        }
+
+        return updateResponse.data
       }),
 
     onSuccess: async (updated) => {

--- a/src/queries/machines.ts
+++ b/src/queries/machines.ts
@@ -46,11 +46,11 @@ export function useCreateMachine() {
     mutationFn: async (values) => {
       const response = await keygen.machines.create(values)
 
-      if (response.errors && response.errors.length > 0) {
-        throw response.errors[0]
+      if (response.errors) {
+        throw new APIError(response.errors[0])
       }
 
-      return response.data as Machine
+      return response.data
     },
 
     onSuccess: (newMachine) => {
@@ -74,8 +74,8 @@ export function useUpdateMachine(machineId: string) {
     mutationFn: async (values) => {
       const getResponse = await keygen.machines.get({ id: machineId })
 
-      if (!getResponse.data) {
-        throw new Error("Machine not found")
+      if (getResponse.errors) {
+        throw new APIError(getResponse.errors[0])
       }
 
       const current = getResponse.data
@@ -91,14 +91,16 @@ export function useUpdateMachine(machineId: string) {
 
       if (Object.keys(changes).length === 0) return current
 
-      const updated = await keygen.machines
-        .update({
-          id: machineId,
-          values: changes,
-        })
-        .then((response) => response.data as Machine)
+      const updateResponse = await keygen.machines.update({
+        id: machineId,
+        values: changes,
+      })
 
-      return updated
+      if (updateResponse.errors) {
+        throw new APIError(updateResponse.errors[0])
+      }
+
+      return updateResponse.data
     },
 
     onSuccess: async (updated) => {

--- a/src/queries/policies.ts
+++ b/src/queries/policies.ts
@@ -44,7 +44,12 @@ export function useCreatePolicy() {
   return useMutation<Policy, APIError, Schemas.Policies.CreateValues>({
     mutationFn: async (values) => {
       const response = await keygen.policies.create(values)
-      const policy = response.data as Policy
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      const policy = response.data
 
       const entitlementIds = values.entitlements?.attach ?? []
       if (entitlementIds.length > 0) {
@@ -73,7 +78,11 @@ export function useUpdatePolicy(policyId: string) {
   return useMutation<Policy, APIError, Schemas.Policies.UpdateValues>({
     mutationFn: (values) =>
       keygen.policies.get({ id: policyId }).then(async (response) => {
-        const current = response.data as Policy
+        if (response.errors) {
+          throw new APIError(response.errors[0])
+        }
+
+        const current = response.data
 
         const changes = diff(
           current.attributes,
@@ -81,11 +90,16 @@ export function useUpdatePolicy(policyId: string) {
         ) as Schemas.Policies.UpdateValues
         if (Object.keys(changes).length === 0) return current
 
-        const updated = await keygen.policies
-          .update({ id: policyId, values: changes })
-          .then((response) => response.data as Policy)
+        const updateResponse = await keygen.policies.update({
+          id: policyId,
+          values: changes,
+        })
 
-        return updated
+        if (updateResponse.errors) {
+          throw new APIError(updateResponse.errors[0])
+        }
+
+        return updateResponse.data
       }),
 
     onSuccess: async (updated) => {

--- a/src/queries/processes.ts
+++ b/src/queries/processes.ts
@@ -46,11 +46,11 @@ export function useCreateProcess() {
     mutationFn: async (values) => {
       const response = await keygen.processes.create(values)
 
-      if (response.errors && response.errors.length > 0) {
-        throw response.errors[0]
+      if (response.errors) {
+        throw new APIError(response.errors[0])
       }
 
-      return response.data as Process
+      return response.data
     },
 
     onSuccess: (newProcess) => {
@@ -74,29 +74,29 @@ export function useUpdateProcess(processId: string) {
     mutationFn: async (values) => {
       const getResponse = await keygen.processes.get({ id: processId })
 
-      if (!getResponse.data) {
-        throw new Error("Process not found")
+      if (getResponse.errors) {
+        throw new APIError(getResponse.errors[0])
       }
 
       const current = getResponse.data
 
       const changes = diff(
-        {
-          ...current.attributes,
-        },
+        current.attributes,
         values,
       ) as Schemas.Processes.UpdateValues
 
       if (Object.keys(changes).length === 0) return current
 
-      const updated = await keygen.processes
-        .update({
-          id: processId,
-          values: changes,
-        })
-        .then((response) => response.data as Process)
+      const updateResponse = await keygen.processes.update({
+        id: processId,
+        values: changes,
+      })
 
-      return updated
+      if (updateResponse.errors) {
+        throw new APIError(updateResponse.errors[0])
+      }
+
+      return updateResponse.data
     },
 
     onSuccess: async (updated) => {

--- a/src/queries/products.ts
+++ b/src/queries/products.ts
@@ -43,9 +43,13 @@ export function useCreateProduct() {
 
   return useMutation<Product, APIError, Schemas.Products.CreateValues>({
     mutationFn: (values) =>
-      keygen.products
-        .create({ values })
-        .then((response) => response.data as Product),
+      keygen.products.create({ values }).then((response) => {
+        if (response.errors) {
+          throw new APIError(response.errors[0])
+        }
+
+        return response.data
+      }),
 
     onSuccess: (newProduct) => {
       queryClient.setQueryData<Product[]>(
@@ -67,7 +71,11 @@ export function useUpdateProduct(productId: string) {
   return useMutation<Product, APIError, Schemas.Products.UpdateValues>({
     mutationFn: (values) =>
       keygen.products.get({ id: productId }).then(async (response) => {
-        const current = response.data as Product
+        if (response.errors) {
+          throw new APIError(response.errors[0])
+        }
+
+        const current = response.data
 
         const changes = diff(
           current.attributes,
@@ -75,11 +83,16 @@ export function useUpdateProduct(productId: string) {
         ) as Schemas.Products.UpdateValues
         if (Object.keys(changes).length === 0) return current
 
-        const updated = await keygen.products
-          .update({ id: productId, values: changes })
-          .then((response) => response.data as Product)
+        const updateResponse = await keygen.products.update({
+          id: productId,
+          values: changes,
+        })
 
-        return updated
+        if (updateResponse.errors) {
+          throw new APIError(updateResponse.errors[0])
+        }
+
+        return updateResponse.data
       }),
 
     onSuccess: async (updated) => {

--- a/src/queries/users.ts
+++ b/src/queries/users.ts
@@ -46,11 +46,11 @@ export function useCreateUser() {
     mutationFn: async (values) => {
       const response = await keygen.users.create(values)
 
-      if (response.errors && response.errors.length > 0) {
-        throw response.errors[0]
+      if (response.errors) {
+        throw new APIError(response.errors[0])
       }
 
-      return response.data as User
+      return response.data
     },
 
     onSuccess: (newUser) => {
@@ -74,8 +74,8 @@ export function useUpdateUser(userId: string) {
     mutationFn: async (values) => {
       const getResponse = await keygen.users.get({ id: userId })
 
-      if (!getResponse.data) {
-        throw new Error("User not found")
+      if (getResponse.errors) {
+        throw new APIError(getResponse.errors[0])
       }
 
       const current = getResponse.data
@@ -90,14 +90,16 @@ export function useUpdateUser(userId: string) {
 
       if (Object.keys(changes).length === 0) return current
 
-      const updated = await keygen.users
-        .update({
-          id: userId,
-          values: changes,
-        })
-        .then((response) => response.data as User)
+      const updateResponse = await keygen.users.update({
+        id: userId,
+        values: changes,
+      })
 
-      return updated
+      if (updateResponse.errors) {
+        throw new APIError(updateResponse.errors[0])
+      }
+
+      return updateResponse.data
     },
 
     onSuccess: async (updated) => {


### PR DESCRIPTION
Need a way to standardize form error handling across resources, so e.g. in a multistep flow like creating a machine, if the API rejects with a specific error (i.e. `MACHINE_LIMIT_EXCEEDED`), we automatically navigate back to the form step that includes the field related to the error to display a message to the user that's helpful, like "Machine limit exceeded for this license" on the `License Relationship` field. This PR addresses this issue so we have a reusable/standardized format for: selecting what fields to invalidate, what message to display, and what error code is required to trigger it.

Example usage:

```
...
const steps: Step[] = useMemo(
    () => [
      {
        key: Steps.General,
        title: "General configuration",
        fields: ["fingerprint", "licenseId"],
        render: () => <Machines.Fields.General />,
      },
      ...
    ],
    [],
)
...

const handleCreateMachine = useCallback(
    (values: Forms.Machines.CreateValues) => {
      createMachine.mutate(values, {
        onSuccess: (machine) => {
          toast({ message: "Machine activated", variant: "success" })
          onSelectMachine(machine)
          onClose()
        },
        onError: (error) => {
          handleFormError({
            form,
            error,
            steps, // Where we access the fields, defined above 
            goToStep: goTo,
            toastMessage: "Failed to activate machine",
            fieldMappings: [
              {
                code: MachineErrorCode.MachineLimitExceeded, // MACHINE_LIMIT_EXCEEDED
                field: "licenseId", // From the fields in 'steps' so it's type-safe
                message: "Machine limit exceeded for this license",
              },
            ],
          })
        },
      })
    },[],
 )
  ```