### PR TITLE
Add resource navigation hook

### DIFF
--- a/src/components/policies/duplicate/modal.tsx
+++ b/src/components/policies/duplicate/modal.tsx
@@ -47,7 +47,7 @@ export default function PoliciesDuplicateModal({
         toast({ message: "Policy created", variant: "success" })
         onOpenChange(false)
 
-        await navigateToResource(created, "policy")
+        await navigateToResource(created)
       },
       onError: () => {
         toast({ message: "Failed to create policy", variant: "error" })

--- a/src/components/policies/duplicate/modal.tsx
+++ b/src/components/policies/duplicate/modal.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 import {
   Dialog,
   DialogContent,
@@ -14,9 +14,9 @@ import {
   useCreatePolicy,
   useListPolicyEntitlements,
 } from "@/queries/policies"
+import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 import DuplicateForm from "./duplicate-form"
 import * as Loading from "@/components/loading"
-import * as keygen from "@/keygen"
 
 interface PoliciesDuplicateModalProps {
   open: boolean
@@ -37,7 +37,7 @@ export default function PoliciesDuplicateModal({
   const { data: entitlements = [] } = useListPolicyEntitlements(id)
 
   const createPolicy = useCreatePolicy()
-  const navigate = useNavigate()
+  const navigateToResource = useResourceNavigate()
 
   const handleCreatePolicy = (values: Forms.Policies.CreateValues) => {
     if (!policy) return
@@ -47,13 +47,7 @@ export default function PoliciesDuplicateModal({
         toast({ message: "Policy created", variant: "success" })
         onOpenChange(false)
 
-        await navigate({
-          to: "/$accountId/app/policies/$id",
-          params: {
-            accountId: keygen.config.id,
-            id: created.id,
-          },
-        })
+        await navigateToResource(created, "policy")
       },
       onError: () => {
         toast({ message: "Failed to create policy", variant: "error" })

--- a/src/hooks/use-resource-navigate.ts
+++ b/src/hooks/use-resource-navigate.ts
@@ -1,38 +1,20 @@
 import { useNavigate } from "@tanstack/react-router"
 
-import { AnyResource, ResourceType } from "@/types/api"
+import { AnyResource } from "@/types/api"
 
 import * as keygen from "@/keygen"
-
-const ResourcePlurals: Record<ResourceType, string> = {
-  component: "components",
-  entitlement: "entitlements",
-  group: "groups",
-  license: "licenses",
-  machine: "machines",
-  policy: "policies",
-  process: "processes",
-  product: "products",
-  user: "users",
-}
 
 export function useResourceNavigate() {
   const navigate = useNavigate()
 
-  return async (
-    resource: AnyResource | null,
-    resourceType: ResourceType,
-  ): Promise<void> => {
+  return async (resource: AnyResource | null): Promise<void> => {
     if (!resource) return
 
-    const plural = ResourcePlurals[resourceType]
-    const param = `${resourceType}Id`
-
     return navigate({
-      to: `/$id/app/${plural}/$${param}`,
+      to: `/$accountId/app/${resource.type}/$id`,
       params: {
-        id: keygen.config.id,
-        [param]: resource.id,
+        accountId: keygen.config.id,
+        id: resource.id,
       },
     })
   }

--- a/src/hooks/use-resource-navigate.ts
+++ b/src/hooks/use-resource-navigate.ts
@@ -1,0 +1,39 @@
+import { useNavigate } from "@tanstack/react-router"
+
+import { AnyResource, ResourceType } from "@/types/api"
+
+import * as keygen from "@/keygen"
+
+const ResourcePlurals: Record<ResourceType, string> = {
+  component: "components",
+  entitlement: "entitlements",
+  group: "groups",
+  license: "licenses",
+  machine: "machines",
+  policy: "policies",
+  process: "processes",
+  product: "products",
+  user: "users",
+}
+
+export function useResourceNavigate() {
+  const navigate = useNavigate()
+
+  return async (
+    resource: AnyResource | null,
+    resourceType: ResourceType,
+  ): Promise<void> => {
+    if (!resource) return
+
+    const plural = ResourcePlurals[resourceType]
+    const param = `${resourceType}Id`
+
+    return navigate({
+      to: `/$id/app/${plural}/$${param}`,
+      params: {
+        id: keygen.config.id,
+        [param]: resource.id,
+      },
+    })
+  }
+}

--- a/src/pages/app/component/list.tsx
+++ b/src/pages/app/component/list.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import { useNavigate } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
@@ -9,7 +8,8 @@ import { useComponentTableColumns } from "@/hooks/use-component-table-columns"
 import { Component } from "@/types/components"
 import { useListComponents } from "@/queries/components"
 
-import * as keygen from "@/keygen"
+import { useResourceNavigate } from "@/hooks/use-resource-navigate"
+
 import * as Skeletons from "@/components/skeletons"
 import * as Components from "@/components/components"
 import DataTable from "@/components/data-table"
@@ -19,19 +19,9 @@ export default function ComponentsList() {
   const { data: components = [], isLoading: componentsLoading } =
     useListComponents()
   const columns = useComponentTableColumns()
-
-  const navigate = useNavigate()
+  const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
-
-  const handleSelectComponent = async (component: Component | null) => {
-    if (!component) return
-
-    await navigate({
-      to: "/$accountId/app/components/$id",
-      params: { accountId: keygen.config.id, id: component.id },
-    })
-  }
 
   return (
     <section>
@@ -44,7 +34,9 @@ export default function ComponentsList() {
           </DialogTrigger>
 
           <Components.Create.Modal
-            onSelectComponent={(component) => handleSelectComponent(component)}
+            onSelectComponent={(component) =>
+              navigateToResource(component, "component")
+            }
             onClose={() => setOpen(false)}
           />
         </Dialog>
@@ -62,7 +54,7 @@ export default function ComponentsList() {
             "attributes.created",
             "attributes.updated",
           ]}
-          onRowClick={(c) => handleSelectComponent(c)}
+          onRowClick={(component) => navigateToResource(component, "component")}
         />
       )}
     </section>

--- a/src/pages/app/component/list.tsx
+++ b/src/pages/app/component/list.tsx
@@ -34,9 +34,7 @@ export default function ComponentsList() {
           </DialogTrigger>
 
           <Components.Create.Modal
-            onSelectComponent={(component) =>
-              navigateToResource(component, "component")
-            }
+            onSelectComponent={(component) => navigateToResource(component)}
             onClose={() => setOpen(false)}
           />
         </Dialog>
@@ -54,7 +52,7 @@ export default function ComponentsList() {
             "attributes.created",
             "attributes.updated",
           ]}
-          onRowClick={(component) => navigateToResource(component, "component")}
+          onRowClick={(component) => navigateToResource(component)}
         />
       )}
     </section>

--- a/src/pages/app/entitlement/list.tsx
+++ b/src/pages/app/entitlement/list.tsx
@@ -36,7 +36,7 @@ export default function EntitlementsList() {
 
           <Entitlements.Create.Modal
             onSelectEntitlement={(entitlement) =>
-              navigateToResource(entitlement, "entitlement")
+              navigateToResource(entitlement)
             }
             onClose={() => setOpen(false)}
           />
@@ -56,9 +56,7 @@ export default function EntitlementsList() {
             "attributes.created",
             "attributes.updated",
           ]}
-          onRowClick={(entitlement) =>
-            navigateToResource(entitlement, "entitlement")
-          }
+          onRowClick={(entitlement) => navigateToResource(entitlement)}
         />
       )}
     </section>

--- a/src/pages/app/entitlement/list.tsx
+++ b/src/pages/app/entitlement/list.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import { useNavigate } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
@@ -10,7 +9,8 @@ import { Entitlement } from "@/types/entitlements"
 
 import { useListEntitlements } from "@/queries/entitlements"
 
-import * as keygen from "@/keygen"
+import { useResourceNavigate } from "@/hooks/use-resource-navigate"
+
 import * as Skeletons from "@/components/skeletons"
 import * as Entitlements from "@/components/entitlements"
 import DataTable from "@/components/data-table"
@@ -20,19 +20,9 @@ export default function EntitlementsList() {
   const { data: entitlements = [], isLoading: entitlementsLoading } =
     useListEntitlements()
   const columns = useEntitlementTableColumns()
-
-  const navigate = useNavigate()
+  const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
-
-  const handleSelectEntitlement = async (entitlement: Entitlement | null) => {
-    if (!entitlement) return
-
-    await navigate({
-      to: "/$accountId/app/entitlements/$id",
-      params: { accountId: keygen.config.id, id: entitlement.id },
-    })
-  }
 
   return (
     <section>
@@ -46,7 +36,7 @@ export default function EntitlementsList() {
 
           <Entitlements.Create.Modal
             onSelectEntitlement={(entitlement) =>
-              handleSelectEntitlement(entitlement)
+              navigateToResource(entitlement, "entitlement")
             }
             onClose={() => setOpen(false)}
           />
@@ -66,7 +56,9 @@ export default function EntitlementsList() {
             "attributes.created",
             "attributes.updated",
           ]}
-          onRowClick={(entitlement) => handleSelectEntitlement(entitlement)}
+          onRowClick={(entitlement) =>
+            navigateToResource(entitlement, "entitlement")
+          }
         />
       )}
     </section>

--- a/src/pages/app/group/list.tsx
+++ b/src/pages/app/group/list.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import { useNavigate } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
@@ -8,7 +7,8 @@ import { useGroupTableColumns } from "@/hooks/use-group-table-columns"
 import { useListGroups } from "@/queries/groups"
 import { Group } from "@/types/groups"
 
-import * as keygen from "@/keygen"
+import { useResourceNavigate } from "@/hooks/use-resource-navigate"
+
 import * as Groups from "@/components/groups"
 import * as Skeletons from "@/components/skeletons"
 import DataTable from "@/components/data-table"
@@ -17,19 +17,9 @@ import PageHeader from "@/components/page-header"
 export default function GroupsList() {
   const { data: groups = [], isLoading: groupsLoading } = useListGroups()
   const columns = useGroupTableColumns()
-
-  const navigate = useNavigate()
+  const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
-
-  const handleSelectGroup = async (group: Group | null) => {
-    if (!group) return
-
-    await navigate({
-      to: "/$accountId/app/groups/$id",
-      params: { accountId: keygen.config.id, id: group.id },
-    })
-  }
 
   return (
     <section>
@@ -42,7 +32,7 @@ export default function GroupsList() {
           </DialogTrigger>
 
           <Groups.Create.Modal
-            onSelectGroup={(group) => handleSelectGroup(group)}
+            onSelectGroup={(group) => navigateToResource(group, "group")}
             onClose={() => setOpen(false)}
           />
         </Dialog>
@@ -61,7 +51,7 @@ export default function GroupsList() {
             "attributes.maxMachines",
             "attributes.created",
           ]}
-          onRowClick={(g) => handleSelectGroup(g)}
+          onRowClick={(group) => navigateToResource(group, "group")}
         />
       )}
     </section>

--- a/src/pages/app/group/list.tsx
+++ b/src/pages/app/group/list.tsx
@@ -32,7 +32,7 @@ export default function GroupsList() {
           </DialogTrigger>
 
           <Groups.Create.Modal
-            onSelectGroup={(group) => navigateToResource(group, "group")}
+            onSelectGroup={(group) => navigateToResource(group)}
             onClose={() => setOpen(false)}
           />
         </Dialog>
@@ -51,7 +51,7 @@ export default function GroupsList() {
             "attributes.maxMachines",
             "attributes.created",
           ]}
-          onRowClick={(group) => navigateToResource(group, "group")}
+          onRowClick={(group) => navigateToResource(group)}
         />
       )}
     </section>

--- a/src/pages/app/license/list.tsx
+++ b/src/pages/app/license/list.tsx
@@ -33,9 +33,7 @@ export default function LicensesList() {
           </DialogTrigger>
 
           <Licenses.Create.Modal
-            onSelectLicense={(license) =>
-              navigateToResource(license, "license")
-            }
+            onSelectLicense={(license) => navigateToResource(license)}
             onClose={() => setOpen(false)}
           />
         </Dialog>
@@ -54,7 +52,7 @@ export default function LicensesList() {
             "attributes.expiry",
             "attributes.created",
           ]}
-          onRowClick={(license) => navigateToResource(license, "license")}
+          onRowClick={(license) => navigateToResource(license)}
         />
       )}
     </section>

--- a/src/pages/app/license/list.tsx
+++ b/src/pages/app/license/list.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import { useNavigate } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
@@ -9,7 +8,8 @@ import { License } from "@/types/licenses"
 
 import { useListLicenses } from "@/queries/licenses"
 
-import * as keygen from "@/keygen"
+import { useResourceNavigate } from "@/hooks/use-resource-navigate"
+
 import * as Licenses from "@/components/licenses"
 import * as Skeletons from "@/components/skeletons"
 import DataTable from "@/components/data-table"
@@ -18,20 +18,9 @@ import PageHeader from "@/components/page-header"
 export default function LicensesList() {
   const { data: licenses = [], isLoading: licensesLoading } = useListLicenses()
   const columns = useLicenseTableColumns()
-
-  const navigate = useNavigate()
+  const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
-
-  const handleSelectLicense = async (license: License | null) => {
-    if (!license) return
-
-    await navigate({
-      to: "/$accountId/app/licenses/$id",
-      params: { accountId: keygen.config.id, id: license.id },
-    })
-    setOpen(false)
-  }
 
   return (
     <section>
@@ -44,7 +33,9 @@ export default function LicensesList() {
           </DialogTrigger>
 
           <Licenses.Create.Modal
-            onSelectLicense={(license) => handleSelectLicense(license)}
+            onSelectLicense={(license) =>
+              navigateToResource(license, "license")
+            }
             onClose={() => setOpen(false)}
           />
         </Dialog>
@@ -63,7 +54,7 @@ export default function LicensesList() {
             "attributes.expiry",
             "attributes.created",
           ]}
-          onRowClick={(l) => handleSelectLicense(l)}
+          onRowClick={(license) => navigateToResource(license, "license")}
         />
       )}
     </section>

--- a/src/pages/app/machine/list.tsx
+++ b/src/pages/app/machine/list.tsx
@@ -32,9 +32,7 @@ export default function MachinesList() {
           </DialogTrigger>
 
           <Machines.Create.Modal
-            onSelectMachine={(machine) =>
-              navigateToResource(machine, "machine")
-            }
+            onSelectMachine={(machine) => navigateToResource(machine)}
             onClose={() => setOpen(false)}
           />
         </Dialog>
@@ -52,7 +50,7 @@ export default function MachinesList() {
             "attributes.created",
             "attributes.updated",
           ]}
-          onRowClick={(machine) => navigateToResource(machine, "machine")}
+          onRowClick={(machine) => navigateToResource(machine)}
         />
       )}
     </section>

--- a/src/pages/app/machine/list.tsx
+++ b/src/pages/app/machine/list.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import { useNavigate } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
@@ -8,7 +7,8 @@ import { useMachineTableColumns } from "@/hooks/use-machine-table-columns"
 import { useListMachines } from "@/queries/machines"
 import { Machine } from "@/types/machines"
 
-import * as keygen from "@/keygen"
+import { useResourceNavigate } from "@/hooks/use-resource-navigate"
+
 import * as Machines from "@/components/machines"
 import * as Skeletons from "@/components/skeletons"
 import DataTable from "@/components/data-table"
@@ -17,19 +17,9 @@ import PageHeader from "@/components/page-header"
 export default function MachinesList() {
   const { data: machines = [], isLoading: machinesLoading } = useListMachines()
   const columns = useMachineTableColumns()
-
-  const navigate = useNavigate()
+  const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
-
-  const handleSelectMachine = async (machine: Machine | null) => {
-    if (!machine) return
-
-    await navigate({
-      to: "/$accountId/app/machines/$id",
-      params: { accountId: keygen.config.id, id: machine.id },
-    })
-  }
 
   return (
     <section>
@@ -42,7 +32,9 @@ export default function MachinesList() {
           </DialogTrigger>
 
           <Machines.Create.Modal
-            onSelectMachine={(machine) => handleSelectMachine(machine)}
+            onSelectMachine={(machine) =>
+              navigateToResource(machine, "machine")
+            }
             onClose={() => setOpen(false)}
           />
         </Dialog>
@@ -60,7 +52,7 @@ export default function MachinesList() {
             "attributes.created",
             "attributes.updated",
           ]}
-          onRowClick={(m) => handleSelectMachine(m)}
+          onRowClick={(machine) => navigateToResource(machine, "machine")}
         />
       )}
     </section>

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import { useNavigate } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
@@ -10,7 +9,8 @@ import { Policy } from "@/types/policies"
 
 import { useListPolicies } from "@/queries/policies"
 
-import * as keygen from "@/keygen"
+import { useResourceNavigate } from "@/hooks/use-resource-navigate"
+
 import * as Policies from "@/components/policies"
 import * as Skeletons from "@/components/skeletons"
 import DataTable from "@/components/data-table"
@@ -19,19 +19,9 @@ import PageHeader from "@/components/page-header"
 export default function PoliciesList() {
   const { data: policies = [], isLoading: policiesLoading } = useListPolicies()
   const columns = usePolicyTableColumns()
-
-  const navigate = useNavigate()
+  const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
-
-  const handleSelectPolicy = async (policy: Policy | null) => {
-    if (!policy) return
-
-    await navigate({
-      to: "/$accountId/app/policies/$id",
-      params: { accountId: keygen.config.id, id: policy.id },
-    })
-  }
 
   return (
     <section>
@@ -44,7 +34,7 @@ export default function PoliciesList() {
           </DialogTrigger>
 
           <Policies.Create.Modal
-            onSelectPolicy={(policy) => handleSelectPolicy(policy)}
+            onSelectPolicy={(policy) => navigateToResource(policy, "policy")}
             open={open}
             onClose={() => setOpen(false)}
           />
@@ -63,7 +53,7 @@ export default function PoliciesList() {
             "attributes.created",
             "attributes.updated",
           ]}
-          onRowClick={(p) => handleSelectPolicy(p)}
+          onRowClick={(policy) => navigateToResource(policy, "policy")}
         />
       )}
     </section>

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -34,7 +34,7 @@ export default function PoliciesList() {
           </DialogTrigger>
 
           <Policies.Create.Modal
-            onSelectPolicy={(policy) => navigateToResource(policy, "policy")}
+            onSelectPolicy={(policy) => navigateToResource(policy)}
             open={open}
             onClose={() => setOpen(false)}
           />
@@ -53,7 +53,7 @@ export default function PoliciesList() {
             "attributes.created",
             "attributes.updated",
           ]}
-          onRowClick={(policy) => navigateToResource(policy, "policy")}
+          onRowClick={(policy) => navigateToResource(policy)}
         />
       )}
     </section>

--- a/src/pages/app/process/list.tsx
+++ b/src/pages/app/process/list.tsx
@@ -34,9 +34,7 @@ export default function ProcessesList() {
           </DialogTrigger>
 
           <Processes.Create.Modal
-            onSelectProcess={(process) =>
-              navigateToResource(process, "process")
-            }
+            onSelectProcess={(process) => navigateToResource(process)}
             onClose={() => setOpen(false)}
           />
         </Dialog>
@@ -55,7 +53,7 @@ export default function ProcessesList() {
             "attributes.created",
             "attributes.updated",
           ]}
-          onRowClick={(process) => navigateToResource(process, "process")}
+          onRowClick={(process) => navigateToResource(process)}
         />
       )}
     </section>

--- a/src/pages/app/process/list.tsx
+++ b/src/pages/app/process/list.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import { useNavigate } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
@@ -9,7 +8,8 @@ import { useProcessTableColumns } from "@/hooks/use-process-table-columns"
 import { Process } from "@/types/processes"
 import { useListProcesses } from "@/queries/processes"
 
-import * as keygen from "@/keygen"
+import { useResourceNavigate } from "@/hooks/use-resource-navigate"
+
 import * as Processes from "@/components/processes"
 import * as Skeletons from "@/components/skeletons"
 import DataTable from "@/components/data-table"
@@ -19,19 +19,9 @@ export default function ProcessesList() {
   const { data: processes = [], isLoading: processesLoading } =
     useListProcesses()
   const columns = useProcessTableColumns()
-
-  const navigate = useNavigate()
+  const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
-
-  const handleSelectProcess = async (process: Process | null) => {
-    if (!process) return
-
-    await navigate({
-      to: "/$accountId/app/processes/$id",
-      params: { accountId: keygen.config.id, id: process.id },
-    })
-  }
 
   return (
     <section>
@@ -44,7 +34,9 @@ export default function ProcessesList() {
           </DialogTrigger>
 
           <Processes.Create.Modal
-            onSelectProcess={(process) => handleSelectProcess(process)}
+            onSelectProcess={(process) =>
+              navigateToResource(process, "process")
+            }
             onClose={() => setOpen(false)}
           />
         </Dialog>
@@ -63,7 +55,7 @@ export default function ProcessesList() {
             "attributes.created",
             "attributes.updated",
           ]}
-          onRowClick={(p) => handleSelectProcess(p)}
+          onRowClick={(process) => navigateToResource(process, "process")}
         />
       )}
     </section>

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -34,9 +34,7 @@ export default function ProductsList() {
           </DialogTrigger>
 
           <Products.Create.Modal
-            onSelectProduct={(product) =>
-              navigateToResource(product, "product")
-            }
+            onSelectProduct={(product) => navigateToResource(product)}
             onClose={() => setOpen(false)}
           />
         </Dialog>
@@ -54,7 +52,7 @@ export default function ProductsList() {
             "attributes.created",
             "attributes.updated",
           ]}
-          onRowClick={(product) => navigateToResource(product, "product")}
+          onRowClick={(product) => navigateToResource(product)}
         />
       )}
     </section>

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react"
-import { useNavigate } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
@@ -10,7 +9,8 @@ import { Product } from "@/types/products"
 
 import { useListProducts } from "@/queries/products"
 
-import * as keygen from "@/keygen"
+import { useResourceNavigate } from "@/hooks/use-resource-navigate"
+
 import * as Products from "@/components/products"
 import * as Skeletons from "@/components/skeletons"
 import DataTable from "@/components/data-table"
@@ -18,21 +18,10 @@ import PageHeader from "@/components/page-header"
 
 export default function ProductsList() {
   const { data: products = [], isLoading } = useListProducts()
-  const navigate = useNavigate()
+  const columns = useProductTableColumns()
+  const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
-
-  const columns = useProductTableColumns()
-
-  const handleSelectProduct = async (product: Product | null) => {
-    if (!product) return
-
-    await navigate({
-      to: "/$accountId/app/products/$id",
-      params: { accountId: keygen.config.id, id: product.id },
-    })
-    setOpen(false)
-  }
 
   return (
     <section>
@@ -45,7 +34,9 @@ export default function ProductsList() {
           </DialogTrigger>
 
           <Products.Create.Modal
-            onSelectProduct={(product) => handleSelectProduct(product)}
+            onSelectProduct={(product) =>
+              navigateToResource(product, "product")
+            }
             onClose={() => setOpen(false)}
           />
         </Dialog>
@@ -63,12 +54,7 @@ export default function ProductsList() {
             "attributes.created",
             "attributes.updated",
           ]}
-          onRowClick={(p) =>
-            navigate({
-              to: "/$accountId/app/products/$id",
-              params: { accountId: keygen.config.id, id: p.id },
-            })
-          }
+          onRowClick={(product) => navigateToResource(product, "product")}
         />
       )}
     </section>

--- a/src/pages/app/user/list.tsx
+++ b/src/pages/app/user/list.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react"
-import { useNavigate } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
@@ -7,7 +6,8 @@ import { Dialog, DialogTrigger } from "@/components/ui/dialog"
 import { useUserTableColumns } from "@/hooks/use-user-table-columns"
 import { User, MockUsers } from "@/types/users"
 
-import * as keygen from "@/keygen"
+import { useResourceNavigate } from "@/hooks/use-resource-navigate"
+
 import * as Users from "@/components/users"
 import * as Skeletons from "@/components/skeletons"
 import DataTable from "@/components/data-table"
@@ -16,19 +16,9 @@ import PageHeader from "@/components/page-header"
 export default function UsersList() {
   const [usersLoading, setUsersLoading] = useState(true)
   const columns = useUserTableColumns()
-
-  const navigate = useNavigate()
+  const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
-
-  const handleSelectUser = async (user: User | null) => {
-    if (!user) return
-
-    await navigate({
-      to: "/$accountId/app/users/$id",
-      params: { accountId: keygen.config.id, id: user.id },
-    })
-  }
 
   // Mock API call
   useEffect(() => {
@@ -48,7 +38,7 @@ export default function UsersList() {
           </DialogTrigger>
 
           <Users.Create.Modal
-            onSelectUser={(user) => handleSelectUser(user)}
+            onSelectUser={(user) => navigateToResource(user, "user")}
             onClose={() => setOpen(false)}
           />
         </Dialog>
@@ -66,7 +56,7 @@ export default function UsersList() {
             "attributes.created",
             "attributes.updated",
           ]}
-          onRowClick={(u) => handleSelectUser(u)}
+          onRowClick={(user) => navigateToResource(user, "user")}
         />
       )}
     </section>

--- a/src/pages/app/user/list.tsx
+++ b/src/pages/app/user/list.tsx
@@ -38,7 +38,7 @@ export default function UsersList() {
           </DialogTrigger>
 
           <Users.Create.Modal
-            onSelectUser={(user) => navigateToResource(user, "user")}
+            onSelectUser={(user) => navigateToResource(user)}
             onClose={() => setOpen(false)}
           />
         </Dialog>
@@ -56,7 +56,7 @@ export default function UsersList() {
             "attributes.created",
             "attributes.updated",
           ]}
-          onRowClick={(user) => navigateToResource(user, "user")}
+          onRowClick={(user) => navigateToResource(user)}
         />
       )}
     </section>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -99,3 +99,14 @@ export type AnyResource =
   | Component
   | Process
   | User
+
+export type ResourceType =
+  | "product"
+  | "entitlement"
+  | "group"
+  | "policy"
+  | "license"
+  | "machine"
+  | "component"
+  | "process"
+  | "user"


### PR DESCRIPTION
Adds a reusable and more maintainable way for navigating to specific resource pages by using a hook, and refactors existing navigate calls that go to a specific resource id.

Example:

```
const navigateToResource = useResourceNavigate()
...
return (
  <DataTable<Policy>
    ...
    onRowClick={(policy) => navigateToResource(policy, "policy")}
  />
)
 ```
 
Adding this with future refactoring in mind, where I'd like to reduce prop-drilling in forms. We're currently passing around a handler from the list view down to create modal/forms that handle navigating to the resource upon creation, so refactoring that functionality into a reusable hook would eliminate that prop and clean it up a bit.