### PR TITLE
Add license expiration heatmap chart

### DIFF
--- a/src/components/chart/card.tsx
+++ b/src/components/chart/card.tsx
@@ -1,0 +1,46 @@
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardAction,
+} from "@/components/ui/card"
+
+import { cn } from "@/lib/utils"
+
+interface ChartsCardProps {
+  title: string
+  description?: string
+  className?: string
+  children: React.ReactNode
+  isLoading?: boolean
+  action?: React.ReactNode
+}
+
+export default function ChartCard({
+  title,
+  description,
+  className,
+  children,
+  isLoading,
+  action,
+}: ChartsCardProps) {
+  return (
+    <Card className={cn("w-fit border-accent bg-background p-0", className)}>
+      <CardHeader className="items-center border-b border-accent px-4 pt-3 [.border-b]:pb-2">
+        <CardTitle className="text-sm font-medium text-content-muted">
+          {title}
+        </CardTitle>
+        {description && (
+          <CardDescription className="text-xs">{description}</CardDescription>
+        )}
+        {action && <CardAction>{action}</CardAction>}
+      </CardHeader>
+      <CardContent className="p-4">
+        {isLoading ? <Skeleton className="h-40 w-3/4" /> : children}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/chart/index.ts
+++ b/src/components/chart/index.ts
@@ -1,0 +1,1 @@
+export { default as Card } from "./card"

--- a/src/components/chart/index.ts
+++ b/src/components/chart/index.ts
@@ -1,1 +1,2 @@
 export { default as Card } from "./card"
+export { default as LicenseExpirationHeatmap } from "./license-expiration-heatmap"

--- a/src/components/chart/license-expiration-heatmap.tsx
+++ b/src/components/chart/license-expiration-heatmap.tsx
@@ -206,7 +206,7 @@ export default function LicenseExpirationHeatmap() {
     )
 
     return { monthLabels: months, numWeeks: maxX + 1, occupiedCells: occupied }
-  }, [ExpirationHeatmapMockData])
+  }, [])
 
   return (
     <Chart.Card

--- a/src/components/chart/license-expiration-heatmap.tsx
+++ b/src/components/chart/license-expiration-heatmap.tsx
@@ -338,15 +338,12 @@ export default function LicenseExpirationHeatmap() {
           style={{
             left: currentPosRef.current.x,
             top: currentPosRef.current.y,
-            transform: expanded
-              ? "translate(-50%, 8px)"
-              : "translate(-50%, calc(-100% - 6px))",
+            transform: "translate(-50%, 8px)",
           }}
         >
           <div
             className={cn(
-              "w-52 rounded-md border border-accent bg-background-2 p-3 text-xs shadow-lg duration-150 animate-in fade-in-0 zoom-in-95",
-              expanded ? "origin-top" : "origin-bottom",
+              "w-52 origin-top rounded-md border border-accent bg-background-2 p-3 text-xs shadow-lg duration-150 animate-in fade-in-0 zoom-in-95",
             )}
           >
             <p className="font-medium text-content-muted">

--- a/src/components/chart/license-expiration-heatmap.tsx
+++ b/src/components/chart/license-expiration-heatmap.tsx
@@ -1,0 +1,424 @@
+import { useState, useEffect, useCallback, useMemo, useRef } from "react"
+import { format, parseISO } from "date-fns"
+
+import { Skeleton } from "@/components/ui/skeleton"
+
+import {
+  ExpirationHeatmapEntry,
+  ExpiringLicensesMockData,
+  ExpirationHeatmapMockData,
+} from "@/mock/metrics"
+
+import * as keygen from "@/keygen"
+
+import { cn } from "@/lib/utils"
+import { truncateKey } from "@/lib/licenses"
+
+import * as Chart from "@/components/chart"
+import GoToButton from "@/components/go-to-button"
+
+const DayLabels = ["Mon", "", "Wed", "", "Fri", "", "Sun"]
+const CellWidth = 16
+const CellHeight = 8
+const CellGap = 2
+const LabelWidth = 34
+
+function toDisplayRow(y: number): number {
+  return (y + 6) % 7
+}
+
+function getTemperatureColor(temperature: number): string {
+  if (temperature === 0) return "var(--color-background-1)"
+  if (temperature <= 0.25)
+    return "color-mix(in srgb, var(--color-destructive) 30%, var(--color-background-1))"
+  if (temperature <= 0.5)
+    return "color-mix(in srgb, var(--color-destructive) 55%, var(--color-background-1))"
+  if (temperature <= 0.75)
+    return "color-mix(in srgb, var(--color-destructive) 80%, var(--color-background-1))"
+  return "var(--color-destructive)"
+}
+
+export default function LicenseExpirationHeatmap() {
+  // TODO(cazden) Refactor with query
+  const licensesLoading = false
+
+  const [expanded, setExpanded] = useState(false)
+  const [hoveredEntry, setHoveredEntry] =
+    useState<ExpirationHeatmapEntry | null>(null)
+
+  const targetPosRef = useRef({ x: 0, y: 0 })
+  const currentPosRef = useRef({ x: 0, y: 0 })
+  const rafRef = useRef<number | null>(null)
+
+  const lingerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const tooltipRef = useRef<HTMLDivElement>(null)
+
+  const clearLingerTimer = useCallback(() => {
+    if (lingerTimerRef.current) {
+      clearTimeout(lingerTimerRef.current)
+      lingerTimerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      clearLingerTimer()
+    }
+  }, [clearLingerTimer])
+
+  // Resets all popover state back to closed
+  const close = useCallback(() => {
+    setExpanded(false)
+    setHoveredEntry(null)
+    clearLingerTimer()
+  }, [clearLingerTimer])
+
+  // Update tooltip target position while not expanded as cursor moves within the grid
+  const handleGridMouseMove = (e: React.MouseEvent) => {
+    if (!expanded) {
+      targetPosRef.current = { x: e.clientX, y: e.clientY }
+    }
+  }
+
+  const handleCellMouseEnter = (
+    entry: ExpirationHeatmapEntry,
+    e: React.MouseEvent,
+  ) => {
+    clearLingerTimer()
+
+    // Close other expanded cells if any are open
+    if (hoveredEntry?.date !== entry.date) {
+      setExpanded(false)
+    }
+
+    const pos = { x: e.clientX, y: e.clientY }
+    targetPosRef.current = pos
+
+    // Snap tooltip to cursor on first hover so it doesn't lerp
+    if (!hoveredEntry) {
+      currentPosRef.current = { ...pos }
+    }
+
+    setHoveredEntry(entry)
+  }
+
+  // Short linger timer to allow cursor to move between cells without interrupting styles
+  const handleCellMouseLeave = () => {
+    if (!expanded) {
+      lingerTimerRef.current = setTimeout(() => {
+        close()
+      }, 100)
+    }
+  }
+
+  const handleCellClick = () => {
+    setExpanded(true)
+  }
+
+  // Dismiss popover when clicked outside
+  useEffect(() => {
+    if (!expanded) return
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        tooltipRef.current &&
+        !tooltipRef.current.contains(e.target as Node)
+      ) {
+        close()
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside)
+    }
+  }, [expanded, close])
+
+  // Interpolate the tooltip position toward the cursor while not expanded
+  useEffect(() => {
+    if (!hoveredEntry || expanded) {
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
+      return
+    }
+
+    const loop = () => {
+      const target = targetPosRef.current
+      const current = currentPosRef.current
+      const factor = 0.15
+
+      current.x += (target.x - current.x) * factor
+      current.y += (target.y - current.y) * factor
+
+      if (Math.abs(target.x - current.x) < 0.5) current.x = target.x
+      if (Math.abs(target.y - current.y) < 0.5) current.y = target.y
+
+      if (tooltipRef.current) {
+        tooltipRef.current.style.left = `${current.x}px`
+        tooltipRef.current.style.top = `${current.y}px`
+      }
+
+      rafRef.current = requestAnimationFrame(loop)
+    }
+
+    rafRef.current = requestAnimationFrame(loop)
+
+    return () => {
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
+    }
+  }, [hoveredEntry, expanded])
+
+  // Derive grid layout metadata from the heatmap data
+  const { monthLabels, numWeeks, occupiedCells } = useMemo(() => {
+    if (!ExpirationHeatmapMockData?.length)
+      return { monthLabels: [], numWeeks: 0, occupiedCells: new Set<string>() }
+
+    let maxX = 0
+    const occupied = new Set<string>()
+    const monthFirstWeek = new Map<
+      number,
+      { label: string; weekIndex: number }
+    >()
+
+    for (const entry of ExpirationHeatmapMockData) {
+      if (entry.x > maxX) maxX = entry.x
+      occupied.add(`${entry.x},${toDisplayRow(entry.y)}`)
+
+      // Track the earliest week each month appears in for label placement
+      const date = parseISO(entry.date)
+      const monthKey = date.getFullYear() * 12 + date.getMonth()
+      const existing = monthFirstWeek.get(monthKey)
+      if (!existing || entry.x < existing.weekIndex) {
+        monthFirstWeek.set(monthKey, {
+          label: format(date, "MMM"),
+          weekIndex: entry.x,
+        })
+      }
+    }
+
+    const months = Array.from(monthFirstWeek.values()).sort(
+      (a, b) => a.weekIndex - b.weekIndex,
+    )
+
+    return { monthLabels: months, numWeeks: maxX + 1, occupiedCells: occupied }
+  }, [ExpirationHeatmapMockData])
+
+  return (
+    <Chart.Card
+      title="License expirations"
+      isLoading={licensesLoading}
+      action={
+        <GoToButton
+          path="/$accountId/app/licenses"
+          params={{
+            accountId: keygen.config.id,
+          }}
+          label="See more"
+          className="[&_.group:hover_svg]:text-primary [&_button]:text-content-normal [&_button]:hover:text-content-loud [&_svg]:text-content-normal"
+        />
+      }
+    >
+      {ExpirationHeatmapMockData?.length ? (
+        <div className="relative w-full overflow-x-auto">
+          <div
+            style={{ minWidth: LabelWidth + numWeeks * (CellWidth + CellGap) }}
+          >
+            <div
+              onMouseMove={handleGridMouseMove}
+              style={{
+                display: "grid",
+                gridTemplateColumns: `${LabelWidth}px repeat(${numWeeks}, ${CellWidth}px)`,
+                gridTemplateRows: `auto repeat(7, ${CellHeight}px)`,
+                columnGap: CellGap,
+                rowGap: CellGap,
+              }}
+            >
+              {monthLabels.map((month, index) => (
+                <div
+                  key={index}
+                  className="flex flex-col text-[10px] text-content-subdued"
+                  style={{ gridRow: 1, gridColumn: month.weekIndex + 2 }}
+                >
+                  <span>{month.label}</span>
+                  <span className="mt-0.5 mb-1 h-1 w-px self-center bg-content-disabled" />
+                </div>
+              ))}
+
+              {DayLabels.map((label, index) => (
+                <div
+                  key={index}
+                  className="flex items-center text-[10px] leading-none text-content-subdued"
+                  style={{ gridRow: index + 2, gridColumn: 1 }}
+                >
+                  {label}
+                  {label && (
+                    <span className="mr-1 ml-auto h-px w-1 bg-content-disabled" />
+                  )}
+                </div>
+              ))}
+
+              {Array.from({ length: numWeeks }, (_, weekIndex) =>
+                Array.from({ length: 7 }, (_, dayIndex) => {
+                  if (occupiedCells.has(`${weekIndex},${dayIndex}`)) return null
+                  return (
+                    <div
+                      key={`empty-${weekIndex}-${dayIndex}`}
+                      className="bg-background-1"
+                      style={{
+                        gridRow: dayIndex + 2,
+                        gridColumn: weekIndex + 2,
+                      }}
+                    />
+                  )
+                }),
+              )}
+
+              {ExpirationHeatmapMockData.map((entry) =>
+                entry.count > 0 ? (
+                  <div
+                    key={entry.date}
+                    onMouseEnter={(e) => handleCellMouseEnter(entry, e)}
+                    onMouseLeave={handleCellMouseLeave}
+                    onClick={handleCellClick}
+                    className={cn(
+                      "cursor-pointer transition-transform duration-150 ease-out hover:z-10 hover:scale-[1.3]",
+                      hoveredEntry?.date === entry.date && "z-10 scale-[1.3]",
+                    )}
+                    style={{
+                      gridRow: toDisplayRow(entry.y) + 2,
+                      gridColumn: entry.x + 2,
+                      backgroundColor: getTemperatureColor(entry.temperature),
+                    }}
+                  />
+                ) : (
+                  <div
+                    key={entry.date}
+                    style={{
+                      gridRow: toDisplayRow(entry.y) + 2,
+                      gridColumn: entry.x + 2,
+                      backgroundColor: getTemperatureColor(entry.temperature),
+                    }}
+                  />
+                ),
+              )}
+            </div>
+
+            {/* Temperature legend */}
+            <div className="mt-2 flex items-center justify-end gap-1.5 text-[10px] text-content-subdued">
+              <span>Less</span>
+              {[0, 0.25, 0.5, 0.75, 1].map((temperature) => (
+                <div
+                  key={temperature}
+                  style={{
+                    width: CellWidth - 2,
+                    height: CellHeight - 2,
+                    backgroundColor: getTemperatureColor(temperature),
+                  }}
+                />
+              ))}
+              <span>More</span>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {/* Popover/tooltip */}
+      {hoveredEntry && (
+        <div
+          ref={tooltipRef}
+          className={cn(
+            "fixed z-50 transition-transform duration-200 ease-out",
+            !expanded && "pointer-events-none",
+          )}
+          style={{
+            left: currentPosRef.current.x,
+            top: currentPosRef.current.y,
+            transform: expanded
+              ? "translate(-50%, 8px)"
+              : "translate(-50%, calc(-100% - 6px))",
+          }}
+        >
+          <div
+            className={cn(
+              "w-52 rounded-md border border-accent bg-background-2 p-3 text-xs shadow-lg duration-150 animate-in fade-in-0 zoom-in-95",
+              expanded ? "origin-top" : "origin-bottom",
+            )}
+          >
+            <p className="font-medium text-content-muted">
+              {format(parseISO(hoveredEntry.date), "MMM do, yyyy")}
+            </p>
+            <p className="mt-0.5 text-content-subdued">
+              {hoveredEntry.count}{" "}
+              {hoveredEntry.count === 1 ? "license" : "licenses"} expiring
+            </p>
+            <div className="my-2 h-px bg-accent" />
+
+            {!expanded && (
+              <p className="text-[10px] text-content-subdued">
+                + Click to show licenses
+              </p>
+            )}
+
+            <div
+              className="grid transition-[grid-template-rows] duration-200 ease-out"
+              style={{ gridTemplateRows: expanded ? "1fr" : "0fr" }}
+            >
+              <div className="overflow-hidden">
+                {expanded && (
+                  <div className="duration-200 ease-out animate-in [animation-delay:200ms] [animation-fill-mode:both] fade-in-0">
+                    <HeatmapCellExpandedContent date={hoveredEntry.date} />
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </Chart.Card>
+  )
+}
+
+function HeatmapCellExpandedContent({ date }: { date: string }) {
+  // TODO(cazden) Refactor with query
+  const licenses = ExpiringLicensesMockData.get(date)
+  const licensesLoading = false
+
+  if (licensesLoading) {
+    return (
+      <div className="mt-2 space-y-2">
+        <Skeleton className="h-4 w-full rounded-xs" />
+      </div>
+    )
+  }
+
+  if (!licenses?.length) return null
+
+  return (
+    <>
+      <ul>
+        {licenses.map((license) => (
+          <li key={license.id}>
+            <GoToButton
+              path="/$accountId/app/licenses/$id"
+              params={{ accountId: keygen.config.id, id: license.id }}
+              label={
+                license.name || truncateKey(license.key, { maxLength: 24 })
+              }
+              className="[&_button]:truncate [&_button]:text-xs [&_button]:text-content-subdued [&_button]:hover:text-content-loud"
+            />
+          </li>
+        ))}
+      </ul>
+      {licenses.length > 10 && (
+        <p className="mt-1 text-xs text-content-disabled">
+          +{licenses.length - 10} more
+        </p>
+      )}
+    </>
+  )
+}

--- a/src/components/go-to-button.tsx
+++ b/src/components/go-to-button.tsx
@@ -31,7 +31,7 @@ export default function GoToButton({
   return (
     <div
       className={cn(
-        "group flex h-6 w-fit gap-1",
+        "group flex h-6 min-w-0 gap-1",
         disabled && "pointer-events-none",
         className,
       )}
@@ -42,13 +42,13 @@ export default function GoToButton({
         size="link"
         onClick={handleClick}
         disabled={disabled}
-        className="text-primary group-hover:text-primary/80"
+        className="min-w-0 shrink text-primary group-hover:text-primary/80"
         aria-label={label}
       >
-        {label}
+        <span className="truncate">{label}</span>
       </Button>
-      <div className="flex h-full items-center">
-        <ChevronRight className="mt-0.5 size-3.5 text-primary transition-all duration-200 group-hover:translate-x-2" />
+      <div className="flex h-full shrink-0 items-center">
+        <ChevronRight className="mt-0.5 size-3.5 text-primary transition-all duration-200 group-hover:translate-x-2 group-hover:text-primary!" />
       </div>
     </div>
   )

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -31,7 +31,7 @@ const buttonVariants = cva(
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
-        link: "h-6 min-h-0 min-w-0",
+        link: "h-6 min-h-0 min-w-0 rounded-none",
         rail: "size-10",
         command: "h-9 px-2",
         clipboard: "h-7 md:h-5 px-2",

--- a/src/mock/metrics.ts
+++ b/src/mock/metrics.ts
@@ -1,0 +1,475 @@
+export type MockExpiringLicense = {
+  id: string
+  name: string | null
+  key: string
+}
+
+export type ExpirationHeatmapEntry = {
+  date: string
+  x: number
+  y: number
+  temperature: number
+  count: number
+}
+
+export const ExpirationHeatmapMockData: ExpirationHeatmapEntry[] = [
+  { date: "2026-03-02", x: 0, y: 1, count: 1, temperature: 0.2 },
+  { date: "2026-03-06", x: 0, y: 5, count: 1, temperature: 0.2 },
+  { date: "2026-03-10", x: 1, y: 2, count: 2, temperature: 0.4 },
+  { date: "2026-03-16", x: 2, y: 1, count: 1, temperature: 0.2 },
+  { date: "2026-03-19", x: 2, y: 4, count: 1, temperature: 0.2 },
+  { date: "2026-03-25", x: 3, y: 3, count: 3, temperature: 0.6 },
+  { date: "2026-03-30", x: 4, y: 1, count: 1, temperature: 0.2 },
+  { date: "2026-04-03", x: 4, y: 5, count: 2, temperature: 0.4 },
+  { date: "2026-04-08", x: 5, y: 3, count: 1, temperature: 0.2 },
+  { date: "2026-04-14", x: 6, y: 2, count: 1, temperature: 0.2 },
+  { date: "2026-04-18", x: 6, y: 6, count: 3, temperature: 0.6 },
+  { date: "2026-04-22", x: 7, y: 3, count: 1, temperature: 0.2 },
+  { date: "2026-04-28", x: 8, y: 2, count: 2, temperature: 0.4 },
+  { date: "2026-05-04", x: 9, y: 1, count: 1, temperature: 0.2 },
+  { date: "2026-05-09", x: 9, y: 6, count: 1, temperature: 0.2 },
+  { date: "2026-05-14", x: 10, y: 4, count: 4, temperature: 0.8 },
+  { date: "2026-05-19", x: 11, y: 2, count: 1, temperature: 0.2 },
+  { date: "2026-05-26", x: 12, y: 2, count: 2, temperature: 0.4 },
+  { date: "2026-05-29", x: 12, y: 5, count: 1, temperature: 0.2 },
+  { date: "2026-06-01", x: 13, y: 1, count: 1, temperature: 0.2 },
+  { date: "2026-06-05", x: 13, y: 5, count: 2, temperature: 0.4 },
+  { date: "2026-06-11", x: 14, y: 4, count: 1, temperature: 0.2 },
+  { date: "2026-06-17", x: 15, y: 3, count: 3, temperature: 0.6 },
+  { date: "2026-06-25", x: 16, y: 4, count: 1, temperature: 0.2 },
+  { date: "2026-06-29", x: 17, y: 1, count: 1, temperature: 0.2 },
+  { date: "2026-07-02", x: 17, y: 4, count: 2, temperature: 0.4 },
+  { date: "2026-07-08", x: 18, y: 3, count: 1, temperature: 0.2 },
+  { date: "2026-07-13", x: 19, y: 1, count: 5, temperature: 1.0 },
+  { date: "2026-07-17", x: 19, y: 5, count: 1, temperature: 0.2 },
+  { date: "2026-07-23", x: 20, y: 4, count: 2, temperature: 0.4 },
+  { date: "2026-07-28", x: 21, y: 2, count: 1, temperature: 0.2 },
+  { date: "2026-08-03", x: 22, y: 1, count: 1, temperature: 0.2 },
+  { date: "2026-08-05", x: 22, y: 3, count: 2, temperature: 0.4 },
+  { date: "2026-08-12", x: 23, y: 3, count: 1, temperature: 0.2 },
+  { date: "2026-08-20", x: 24, y: 4, count: 3, temperature: 0.6 },
+  { date: "2026-08-27", x: 25, y: 4, count: 1, temperature: 0.2 },
+  { date: "2026-09-02", x: 26, y: 3, count: 1, temperature: 0.2 },
+  { date: "2026-09-07", x: 27, y: 1, count: 2, temperature: 0.4 },
+  { date: "2026-09-15", x: 28, y: 2, count: 3, temperature: 0.6 },
+  { date: "2026-09-21", x: 29, y: 1, count: 1, temperature: 0.2 },
+  { date: "2026-09-25", x: 29, y: 5, count: 1, temperature: 0.2 },
+  { date: "2026-10-01", x: 30, y: 4, count: 2, temperature: 0.4 },
+  { date: "2026-10-07", x: 31, y: 3, count: 1, temperature: 0.2 },
+  { date: "2026-10-13", x: 32, y: 2, count: 1, temperature: 0.2 },
+  { date: "2026-10-20", x: 33, y: 2, count: 4, temperature: 0.8 },
+  { date: "2026-10-29", x: 34, y: 4, count: 1, temperature: 0.2 },
+  { date: "2026-11-03", x: 35, y: 2, count: 1, temperature: 0.2 },
+  { date: "2026-11-09", x: 36, y: 1, count: 2, temperature: 0.4 },
+  { date: "2026-11-16", x: 37, y: 1, count: 3, temperature: 0.6 },
+  { date: "2026-11-20", x: 37, y: 5, count: 1, temperature: 0.2 },
+  { date: "2026-11-25", x: 38, y: 3, count: 1, temperature: 0.2 },
+  { date: "2026-12-03", x: 39, y: 4, count: 1, temperature: 0.2 },
+  { date: "2026-12-09", x: 40, y: 3, count: 2, temperature: 0.4 },
+  { date: "2026-12-15", x: 41, y: 2, count: 1, temperature: 0.2 },
+  { date: "2026-12-22", x: 42, y: 2, count: 3, temperature: 0.6 },
+  { date: "2026-12-30", x: 43, y: 3, count: 1, temperature: 0.2 },
+  { date: "2027-01-05", x: 44, y: 1, count: 1, temperature: 0.2 },
+  { date: "2027-01-11", x: 45, y: 1, count: 2, temperature: 0.4 },
+  { date: "2027-01-16", x: 45, y: 6, count: 1, temperature: 0.2 },
+  { date: "2027-01-22", x: 46, y: 5, count: 1, temperature: 0.2 },
+  { date: "2027-01-28", x: 47, y: 4, count: 2, temperature: 0.4 },
+  { date: "2027-02-02", x: 48, y: 2, count: 1, temperature: 0.2 },
+  { date: "2027-02-04", x: 48, y: 4, count: 1, temperature: 0.2 },
+  { date: "2027-02-11", x: 49, y: 4, count: 3, temperature: 0.6 },
+  { date: "2027-02-18", x: 50, y: 4, count: 1, temperature: 0.2 },
+  { date: "2027-02-25", x: 51, y: 4, count: 1, temperature: 0.2 },
+]
+
+export const ExpiringLicensesMockData = new Map<string, MockExpiringLicense[]>([
+  [
+    "2026-03-02",
+    [{ id: "lic-1", name: null, key: "A9F3C-7B2E1-D04F8-3C6A2-V3" }],
+  ],
+  [
+    "2026-03-06",
+    [{ id: "lic-2", name: null, key: "E12B7-4D8F3-A6C91-0B5E4-V3" }],
+  ],
+  [
+    "2026-03-10",
+    [
+      { id: "lic-3", name: null, key: "C84D2-1F7A9-B3E60-5D2C8-V3" },
+      { id: "lic-4", name: null, key: "F0A61-9C3B7-2E8D4-7F1A5-V3" },
+    ],
+  ],
+  [
+    "2026-03-16",
+    [{ id: "lic-5", name: null, key: "B5E92-3A1D8-C7F04-6B9E3-V3" }],
+  ],
+  [
+    "2026-03-19",
+    [{ id: "lic-6", name: null, key: "D73C1-8F4A2-0B6E9-1D5C7-V3" }],
+  ],
+  [
+    "2026-03-25",
+    [
+      {
+        id: "lic-7",
+        name: "Blood Gulch",
+        key: "A2D84-6C0F3-9B7E1-4A8D2-V3",
+      },
+      { id: "lic-8", name: null, key: "E9B13-5D7C4-2F0A8-8E3B6-V3" },
+      { id: "lic-9", name: null, key: "C1F45-0A9E7-6D3B2-9C4F1-V3" },
+    ],
+  ],
+  [
+    "2026-03-30",
+    [{ id: "lic-10", name: null, key: "B6A28-4E1D9-7C5F3-2B0A6-V3" }],
+  ],
+  [
+    "2026-04-03",
+    [
+      { id: "lic-11", name: null, key: "D4C70-8B2F6-1A9E5-5D7C3-V3" },
+      { id: "lic-12", name: null, key: "F8E31-2C6A9-5B0D7-3F4E8-V3" },
+    ],
+  ],
+  [
+    "2026-04-08",
+    [{ id: "lic-13", name: null, key: "A0D52-7F3B1-9C8E4-6A2D0-V3" }],
+  ],
+  [
+    "2026-04-14",
+    [{ id: "lic-14", name: null, key: "C3B96-1D8F2-4A7E0-9C5B3-V3" }],
+  ],
+  [
+    "2026-04-18",
+    [
+      { id: "lic-15", name: null, key: "E7A04-5C2D8-8F1B6-0E9A7-V3" },
+      {
+        id: "lic-16",
+        name: "Lockout",
+        key: "B1F63-9A4E7-2D0C5-7B8F1-V3",
+      },
+      { id: "lic-17", name: null, key: "D5C82-3F9A0-6B4E1-1D7C5-V3" },
+    ],
+  ],
+  [
+    "2026-04-22",
+    [{ id: "lic-18", name: null, key: "A8E17-0C5D3-9F2B4-4A6E8-V3" }],
+  ],
+  [
+    "2026-04-28",
+    [
+      { id: "lic-19", name: null, key: "F2D49-6A8C1-3E7B5-8F0D2-V3" },
+      { id: "lic-20", name: null, key: "C6A73-4E1F8-0D9B2-5C3A6-V3" },
+    ],
+  ],
+  [
+    "2026-05-04",
+    [{ id: "lic-21", name: null, key: "B9F05-2D7C4-8A1E6-3B5F9-V3" }],
+  ],
+  [
+    "2026-05-09",
+    [{ id: "lic-22", name: null, key: "E4B28-1A6D9-7C0F3-9E2B4-V3" }],
+  ],
+  [
+    "2026-05-14",
+    [
+      {
+        id: "lic-23",
+        name: "Ascension",
+        key: "D0C91-5F3A7-2B8E4-6D1C0-V3",
+      },
+      { id: "lic-24", name: null, key: "A7E36-8C2D0-4F9B1-0A5E7-V3" },
+      { id: "lic-25", name: null, key: "F1B54-3D9A2-6C8E7-2F4B1-V3" },
+      { id: "lic-26", name: null, key: "C8D02-0A7F5-1B3E9-4C6D8-V3" },
+    ],
+  ],
+  [
+    "2026-05-19",
+    [{ id: "lic-27", name: null, key: "B3A69-6E4C1-9D2F7-7B0A3-V3" }],
+  ],
+  [
+    "2026-05-26",
+    [
+      { id: "lic-28", name: null, key: "E5F14-2B8D6-0A3C9-8E1F5-V3" },
+      { id: "lic-29", name: null, key: "D9C47-4F0A3-7E5B8-1D3C9-V3" },
+    ],
+  ],
+  [
+    "2026-05-29",
+    [{ id: "lic-30", name: null, key: "A3B82-6F1D9-0C7E4-5A9B3-V3" }],
+  ],
+  [
+    "2026-06-01",
+    [{ id: "lic-31", name: null, key: "C0E56-2A8F1-4D3B7-8C6E0-V3" }],
+  ],
+  [
+    "2026-06-05",
+    [
+      { id: "lic-32", name: null, key: "F7D14-9B0A3-1E5C8-3F2D7-V3" },
+      { id: "lic-33", name: null, key: "B4A97-1C6E2-8F0D5-2B3A9-V3" },
+    ],
+  ],
+  [
+    "2026-06-11",
+    [{ id: "lic-34", name: null, key: "E1C83-7D4F0-3A9B6-0E5C1-V3" }],
+  ],
+  [
+    "2026-06-17",
+    [
+      {
+        id: "lic-35",
+        name: "Zanzibar",
+        key: "D6F20-4B7A8-9C1E3-6D8F2-V3",
+      },
+      { id: "lic-36", name: null, key: "A5B74-0E3D1-7F2C9-4A6B5-V3" },
+      { id: "lic-37", name: null, key: "C9E41-3A5F7-6B0D2-1C8E4-V3" },
+    ],
+  ],
+  [
+    "2026-06-25",
+    [{ id: "lic-38", name: null, key: "F4D68-8B1C3-2E7A0-9F3D6-V3" }],
+  ],
+  [
+    "2026-06-29",
+    [{ id: "lic-39", name: null, key: "B2F95-5D0A4-1C6E8-7B4F2-V3" }],
+  ],
+  [
+    "2026-07-02",
+    [
+      { id: "lic-40", name: null, key: "E8A37-0C9D5-4F1B2-3E7A8-V3" },
+      { id: "lic-41", name: null, key: "D1C60-6F2B9-8A4E3-5D0C1-V3" },
+    ],
+  ],
+  [
+    "2026-07-08",
+    [{ id: "lic-42", name: null, key: "A4F93-7C1B6-2E0D8-6A3F4-V3" }],
+  ],
+  [
+    "2026-07-13",
+    [
+      {
+        id: "lic-43",
+        name: "Guardian",
+        key: "C7E20-0D5A4-9B8F1-3C6E7-V3",
+      },
+      { id: "lic-44", name: null, key: "F3B58-4A9D2-1C7E6-8F0B3-V3" },
+      { id: "lic-45", name: null, key: "B0D71-6E3C9-5A4F2-2B9D0-V3" },
+      { id: "lic-46", name: null, key: "E6A84-1F7B3-4D2C0-9E5A6-V3" },
+      { id: "lic-47", name: null, key: "D2C96-8B0F5-3A1E7-0D4C2-V3" },
+    ],
+  ],
+  [
+    "2026-07-17",
+    [{ id: "lic-48", name: null, key: "A1F37-5C8D4-7B6E0-4A2F1-V3" }],
+  ],
+  [
+    "2026-07-23",
+    [
+      { id: "lic-49", name: null, key: "C4E69-2D0A7-8F3B5-1C7E4-V3" },
+      { id: "lic-50", name: null, key: "F9B12-3A6D8-0C5E4-6F8B9-V3" },
+    ],
+  ],
+  [
+    "2026-07-28",
+    [{ id: "lic-51", name: null, key: "B7D45-9E1C2-6A0F3-5B8D7-V3" }],
+  ],
+  [
+    "2026-08-03",
+    [{ id: "lic-52", name: null, key: "E0A78-4F3B1-2D9C6-3E0A7-V3" }],
+  ],
+  [
+    "2026-08-05",
+    [
+      { id: "lic-53", name: null, key: "D8C03-1B5F9-4A7E2-7D3C8-V3" },
+      { id: "lic-54", name: null, key: "A6E50-0C2D7-9F4B1-8A6E5-V3" },
+    ],
+  ],
+  [
+    "2026-08-12",
+    [{ id: "lic-55", name: null, key: "C2B84-6D9A3-1E0F7-4C2B8-V3" }],
+  ],
+  [
+    "2026-08-20",
+    [
+      {
+        id: "lic-56",
+        name: "Sandtrap",
+        key: "F5D17-8A4C0-3B6E9-0F5D1-V3",
+      },
+      { id: "lic-57", name: null, key: "B8A42-2E7F5-5C1D3-9B8A4-V3" },
+      { id: "lic-58", name: null, key: "E3F96-7B0A1-4D8C2-6E3F9-V3" },
+    ],
+  ],
+  [
+    "2026-08-27",
+    [{ id: "lic-59", name: null, key: "D0E53-3C6B8-8A2F4-1D0E5-V3" }],
+  ],
+  [
+    "2026-09-02",
+    [{ id: "lic-60", name: null, key: "A7C81-5F4D9-0B3E6-2A7C8-V3" }],
+  ],
+  [
+    "2026-09-07",
+    [
+      { id: "lic-61", name: null, key: "C1D24-9A8F0-6E5B7-5C1D2-V3" },
+      { id: "lic-62", name: null, key: "F6B59-0D3A4-2C7E1-8F6B5-V3" },
+    ],
+  ],
+  [
+    "2026-09-15",
+    [
+      { id: "lic-63", name: null, key: "B4E97-4C0F2-1A6D8-3B4E9-V3" },
+      {
+        id: "lic-64",
+        name: "Snowbound",
+        key: "E9A30-7F1B6-5D4C3-0E9A3-V3",
+      },
+      { id: "lic-65", name: null, key: "D3F62-1B8A5-9C0E7-7D3F6-V3" },
+    ],
+  ],
+  [
+    "2026-09-21",
+    [{ id: "lic-66", name: null, key: "A0C85-6E2D1-4F9B3-4A0C8-V3" }],
+  ],
+  [
+    "2026-09-25",
+    [{ id: "lic-67", name: null, key: "C5B18-2A7F4-0D3E9-9C5B1-V3" }],
+  ],
+  [
+    "2026-10-01",
+    [
+      { id: "lic-68", name: null, key: "F2E43-8D6C0-7A1B5-2F2E4-V3" },
+      { id: "lic-69", name: null, key: "B9D76-3F0A2-1C8E4-6B9D7-V3" },
+    ],
+  ],
+  [
+    "2026-10-07",
+    [{ id: "lic-70", name: null, key: "E4A01-5B9F7-3D2C6-1E4A0-V3" }],
+  ],
+  [
+    "2026-10-13",
+    [{ id: "lic-71", name: null, key: "D7C34-0A3E8-6F5B1-8D7C3-V3" }],
+  ],
+  [
+    "2026-10-20",
+    [
+      { id: "lic-72", name: null, key: "A3F67-4D1C9-2B8E0-5A3F6-V3" },
+      { id: "lic-73", name: null, key: "C6E90-9B4A2-5D7F3-0C6E9-V3" },
+      {
+        id: "lic-74",
+        name: null,
+        key: "F0B25-1C8D6-4A3E7-3F0B2-V3",
+      },
+      { id: "lic-75", name: null, key: "B5D48-7E2F1-0C6A9-4B5D4-V3" },
+    ],
+  ],
+  [
+    "2026-10-29",
+    [{ id: "lic-76", name: null, key: "E8A73-2F5B0-9D1C4-7E8A7-V3" }],
+  ],
+  [
+    "2026-11-03",
+    [{ id: "lic-77", name: null, key: "D1F06-6A3E8-3B9C5-2D1F0-V3" }],
+  ],
+  [
+    "2026-11-09",
+    [
+      { id: "lic-78", name: null, key: "A4C39-0D7F2-8E1B4-9A4C3-V3" },
+      { id: "lic-79", name: null, key: "C9E64-5B0A7-1F3D6-6C9E6-V3" },
+    ],
+  ],
+  [
+    "2026-11-16",
+    [
+      { id: "lic-80", name: null, key: "F3B97-3A2D5-4C0E8-1F3B9-V3" },
+      { id: "lic-81", name: null, key: "B6D20-8E9C1-7A4F3-0B6D2-V3" },
+      { id: "lic-82", name: null, key: "E0A53-1F6B4-5D7C9-3E0A5-V3" },
+    ],
+  ],
+  [
+    "2026-11-20",
+    [{ id: "lic-83", name: null, key: "D5C86-4B1E7-2A8F0-8D5C8-V3" }],
+  ],
+  [
+    "2026-11-25",
+    [{ id: "lic-84", name: null, key: "A8F19-7C4D3-0B2E6-5A8F1-V3" }],
+  ],
+  [
+    "2026-12-03",
+    [{ id: "lic-85", name: null, key: "C2B40-6E8A9-3F5D1-4C2B4-V3" }],
+  ],
+  [
+    "2026-12-09",
+    [
+      { id: "lic-86", name: null, key: "F7E75-2D1C4-9A0B8-7F7E7-V3" },
+      { id: "lic-87", name: null, key: "B0D08-5A6F2-1C3E7-2B0D0-V3" },
+    ],
+  ],
+  [
+    "2026-12-15",
+    [{ id: "lic-88", name: null, key: "E3A31-0F9B6-4D2C5-9E3A3-V3" }],
+  ],
+  [
+    "2026-12-22",
+    [
+      { id: "lic-89", name: null, key: "D6C64-3B7E0-8A1F9-0D6C6-V3" },
+      {
+        id: "lic-90",
+        name: "Midship",
+        key: "A9F97-4C0D3-2E5B4-3A9F9-V3",
+      },
+      { id: "lic-91", name: null, key: "C4B20-1E3A6-6F8D7-6C4B2-V3" },
+    ],
+  ],
+  [
+    "2026-12-30",
+    [{ id: "lic-92", name: null, key: "F1E53-8D2C9-5A4B0-1F1E5-V3" }],
+  ],
+  [
+    "2027-01-05",
+    [{ id: "lic-93", name: null, key: "B8D86-6A0F5-3C7E1-4B8D8-V3" }],
+  ],
+  [
+    "2027-01-11",
+    [
+      { id: "lic-94", name: null, key: "E5A19-2F4B8-0D1C3-7E5A1-V3" },
+      { id: "lic-95", name: null, key: "D0C42-9B7E6-4A8F2-2D0C4-V3" },
+    ],
+  ],
+  [
+    "2027-01-16",
+    [{ id: "lic-96", name: null, key: "A3F75-3C1D0-7E6B9-5A3F7-V3" }],
+  ],
+  [
+    "2027-01-22",
+    [{ id: "lic-97", name: null, key: "C6B08-0E5A4-1F3D7-8C6B0-V3" }],
+  ],
+  [
+    "2027-01-28",
+    [
+      { id: "lic-98", name: null, key: "F9E31-4D8C2-6A0B5-3F9E3-V3" },
+      { id: "lic-99", name: null, key: "B2D64-7A3F1-9C5E8-0B2D6-V3" },
+    ],
+  ],
+  [
+    "2027-02-02",
+    [{ id: "lic-100", name: null, key: "E4A97-1F0B6-2D7C3-9E4A9-V3" }],
+  ],
+  [
+    "2027-02-04",
+    [{ id: "lic-101", name: null, key: "D7C20-5B4E8-3A9F1-4D7C2-V3" }],
+  ],
+  [
+    "2027-02-11",
+    [
+      { id: "lic-102", name: null, key: "A0F53-8C2D7-6E1B0-1A0F5-V3" },
+      { id: "lic-103", name: null, key: "C3B86-4E7A9-0F5D2-6C3B8-V3" },
+      { id: "lic-104", name: null, key: "F6E19-1D0C4-5A3B7-3F6E1-V3" },
+    ],
+  ],
+  [
+    "2027-02-18",
+    [{ id: "lic-105", name: null, key: "B9D42-3A6F5-8C2E1-8B9D4-V3" }],
+  ],
+  [
+    "2027-02-25",
+    [{ id: "lic-106", name: null, key: "E2A75-6F1B0-4D9C3-5E2A7-V3" }],
+  ],
+])

--- a/src/pages/app/dashboard.tsx
+++ b/src/pages/app/dashboard.tsx
@@ -1,7 +1,14 @@
-export default function App() {
+import PageHeader from "@/components/page-header"
+import * as Chart from "@/components/chart"
+
+export default function Dashboard() {
   return (
-    <div className="mt-8 flex flex-col items-center justify-center space-y-8">
-      <h1>Hello from "/app/dashboard"!</h1>
-    </div>
+    <section>
+      <PageHeader title="Metrics" />
+
+      <div className="space-y-6 p-4 md:p-6">
+        <Chart.LicenseExpirationHeatmap />
+      </div>
+    </section>
   )
 }


### PR DESCRIPTION
Adds the license expiration heatmap chart with a dynamic popover for each date that has expiring licenses.

Hovered cells show a tooltip that lerps between cells and is influenced by the cursor position:

https://github.com/user-attachments/assets/ce75ed1b-7579-450f-83b7-90d52786a8cc

When cells are selected (clicked), cells open to expand a list of expired licenses on the selected date:
<img width="900" alt="image" src="https://github.com/user-attachments/assets/6d0b5455-67e9-4e6c-94b2-1d8ada325662" />