### PR TITLE
Fix form values bypassing zod transforms on submit

### DIFF
--- a/src/components/components/form/create.tsx
+++ b/src/components/components/form/create.tsx
@@ -36,13 +36,15 @@ export default function CreateComponentForm({
   const createComponent = useCreateComponent()
   const navigateToResource = useResourceNavigate()
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    const component = await createComponent.mutateAsync(values)
-    toast({ message: "Component created", variant: "success" })
-    onOpenChange(false)
-    await navigateToResource(component)
-  }, [form, createComponent, navigateToResource, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Components.CreateValues) => {
+      const component = await createComponent.mutateAsync(values)
+      toast({ message: "Component created", variant: "success" })
+      onOpenChange(false)
+      await navigateToResource(component)
+    },
+    [createComponent, navigateToResource, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/components/form/edit.tsx
+++ b/src/components/components/form/edit.tsx
@@ -37,12 +37,14 @@ export default function EditComponentForm({
     },
   })
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    await updateComponent.mutateAsync(values)
-    toast({ message: "Component updated", variant: "success" })
-    onOpenChange(false)
-  }, [form, updateComponent, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Components.UpdateValues) => {
+      await updateComponent.mutateAsync(values)
+      toast({ message: "Component updated", variant: "success" })
+      onOpenChange(false)
+    },
+    [updateComponent, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/entitlements/form/create.tsx
+++ b/src/components/entitlements/form/create.tsx
@@ -35,13 +35,15 @@ export default function CreateEntitlementForm({
   const createEntitlement = useCreateEntitlement()
   const navigateToResource = useResourceNavigate()
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    const entitlement = await createEntitlement.mutateAsync(values)
-    toast({ message: "Entitlement created", variant: "success" })
-    onOpenChange(false)
-    await navigateToResource(entitlement)
-  }, [form, createEntitlement, navigateToResource, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Entitlements.CreateValues) => {
+      const entitlement = await createEntitlement.mutateAsync(values)
+      toast({ message: "Entitlement created", variant: "success" })
+      onOpenChange(false)
+      await navigateToResource(entitlement)
+    },
+    [createEntitlement, navigateToResource, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/entitlements/form/edit.tsx
+++ b/src/components/entitlements/form/edit.tsx
@@ -38,12 +38,14 @@ export default function EditEntitlementForm({
     },
   })
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    await updateEntitlement.mutateAsync(values)
-    toast({ message: "Entitlement updated", variant: "success" })
-    onOpenChange(false)
-  }, [form, updateEntitlement, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Entitlements.UpdateValues) => {
+      await updateEntitlement.mutateAsync(values)
+      toast({ message: "Entitlement updated", variant: "success" })
+      onOpenChange(false)
+    },
+    [updateEntitlement, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/environments/form/create.tsx
+++ b/src/components/environments/form/create.tsx
@@ -43,12 +43,14 @@ export default function CreateEnvironmentForm({
     name: "isolationStrategy",
   })
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    await createEnvironment.mutateAsync(values)
-    toast({ message: "Environment created", variant: "success" })
-    onOpenChange(false)
-  }, [form, createEnvironment, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Environments.CreateValues) => {
+      await createEnvironment.mutateAsync(values)
+      toast({ message: "Environment created", variant: "success" })
+      onOpenChange(false)
+    },
+    [createEnvironment, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog

--- a/src/components/environments/form/edit.tsx
+++ b/src/components/environments/form/edit.tsx
@@ -37,12 +37,14 @@ export default function EditEnvironmentForm({
     },
   })
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    await updateEnvironment.mutateAsync(values)
-    toast({ message: "Environment updated", variant: "success" })
-    onOpenChange(false)
-  }, [form, updateEnvironment, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Environments.UpdateValues) => {
+      await updateEnvironment.mutateAsync(values)
+      toast({ message: "Environment updated", variant: "success" })
+      onOpenChange(false)
+    },
+    [updateEnvironment, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog

--- a/src/components/forms/layout/sheet.tsx
+++ b/src/components/forms/layout/sheet.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from "react"
-import { useFormContext } from "react-hook-form"
+import { useFormContext, type FieldValues } from "react-hook-form"
 
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -11,9 +11,9 @@ import { handleFormError } from "@/lib/form-errors"
 
 import * as Loading from "@/components/loading"
 
-interface FormsContentSheetProps {
+interface FormsContentSheetProps<T extends FieldValues = FieldValues> {
   title: string
-  onSubmit: () => void | Promise<void>
+  onSubmit: (data: T) => void | Promise<void>
   onCancel: () => void
   errorMessage?: string
   submitLabel?: string
@@ -24,7 +24,7 @@ interface FormsContentSheetProps {
   className?: string
 }
 
-export default function FormsContentSheet({
+export default function FormsContentSheet<T extends FieldValues = FieldValues>({
   title,
   onSubmit,
   onCancel,
@@ -35,24 +35,23 @@ export default function FormsContentSheet({
   fullscreen = false,
   children,
   className,
-}: FormsContentSheetProps) {
+}: FormsContentSheetProps<T>) {
   const form = useFormContext()
 
   const handleSubmit = useCallback(async () => {
-    const valid = await form.trigger()
-    if (!valid) return
-
-    try {
-      await onSubmit()
-    } catch (error) {
-      if (errorMessage && error instanceof APIError) {
-        await handleFormError({
-          form,
-          apiError: error,
-          toastMessage: errorMessage,
-        })
+    await form.handleSubmit(async (data) => {
+      try {
+        await onSubmit(data as T)
+      } catch (error) {
+        if (errorMessage && error instanceof APIError) {
+          await handleFormError({
+            form,
+            apiError: error,
+            toastMessage: errorMessage,
+          })
+        }
       }
-    }
+    })()
   }, [onSubmit, errorMessage, form])
   return (
     <div

--- a/src/components/forms/layout/wizard.tsx
+++ b/src/components/forms/layout/wizard.tsx
@@ -1,5 +1,5 @@
 import { Children, isValidElement, useCallback, useMemo, useState } from "react"
-import { useFormContext } from "react-hook-form"
+import { useFormContext, type FieldValues } from "react-hook-form"
 
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -30,11 +30,11 @@ interface StepDefinition {
   element: React.ReactNode
 }
 
-interface FormsContentWizardProps {
+interface FormsContentWizardProps<T extends FieldValues = FieldValues> {
   variant?: WizardVariant
   title?: string
   description?: React.ReactNode
-  onSubmit: () => void | Promise<void>
+  onSubmit: (data: T) => void | Promise<void>
   onBack: () => void
   onCancel?: () => void
   errorMessage?: string
@@ -72,7 +72,9 @@ function getStepsFromChildren(children: React.ReactNode): StepDefinition[] {
   return steps
 }
 
-export default function FormsContentWizard({
+export default function FormsContentWizard<
+  T extends FieldValues = FieldValues,
+>({
   variant = "default",
   title,
   description,
@@ -86,7 +88,7 @@ export default function FormsContentWizard({
   isPending = false,
   children,
   className,
-}: FormsContentWizardProps) {
+}: FormsContentWizardProps<T>) {
   const form = useFormContext()
   const steps = useMemo(() => getStepsFromChildren(children), [children])
 
@@ -109,8 +111,8 @@ export default function FormsContentWizard({
 
   const next = useCallback(async () => {
     if (currentStep?.fields?.length) {
-      const ok = await form.trigger(currentStep.fields)
-      if (!ok) return
+      const valid = await form.trigger(currentStep.fields)
+      if (!valid) return
     }
 
     if (currentStep) {
@@ -122,33 +124,39 @@ export default function FormsContentWizard({
     }
 
     if (isLast) {
-      const valid = await form.trigger()
-
-      // Catch schema errors
-      if (!valid) {
-        await handleFormError({
-          form,
-          steps: steps.map((step) => ({ key: step.id, fields: step.fields })),
-          goToStep: goToIndex,
-          toastMessage: errorMessage ?? "",
-        })
-        return
-      }
-
-      try {
-        await onSubmit()
-      } catch (error) {
-        // Catch API errors
-        if (errorMessage && error instanceof APIError) {
+      await form.handleSubmit(
+        async (data) => {
+          try {
+            await onSubmit(data as T)
+          } catch (error) {
+            // Catch API errors
+            if (errorMessage && error instanceof APIError) {
+              await handleFormError({
+                form,
+                steps: steps.map((step) => ({
+                  key: step.id,
+                  fields: step.fields,
+                })),
+                goToStep: goToIndex,
+                toastMessage: errorMessage ?? "",
+                apiError: error,
+              })
+            }
+          }
+        },
+        async () => {
+          // Catch schema errors
           await handleFormError({
             form,
-            steps: steps.map((step) => ({ key: step.id, fields: step.fields })),
+            steps: steps.map((step) => ({
+              key: step.id,
+              fields: step.fields,
+            })),
             goToStep: goToIndex,
             toastMessage: errorMessage ?? "",
-            apiError: error,
           })
-        }
-      }
+        },
+      )()
     } else {
       goTo(currentIndex + 1)
     }

--- a/src/components/groups/form/create.tsx
+++ b/src/components/groups/form/create.tsx
@@ -37,13 +37,15 @@ export default function CreateGroupForm({
   const createGroup = useCreateGroup()
   const navigateToResource = useResourceNavigate()
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    const group = await createGroup.mutateAsync(values)
-    toast({ message: "Group created", variant: "success" })
-    onOpenChange(false)
-    await navigateToResource(group)
-  }, [form, createGroup, navigateToResource, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Groups.CreateValues) => {
+      const group = await createGroup.mutateAsync(values)
+      toast({ message: "Group created", variant: "success" })
+      onOpenChange(false)
+      await navigateToResource(group)
+    },
+    [createGroup, navigateToResource, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/groups/form/edit.tsx
+++ b/src/components/groups/form/edit.tsx
@@ -41,12 +41,14 @@ export default function EditGroupForm({
     },
   })
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    await updateGroup.mutateAsync(values)
-    toast({ message: "Group updated", variant: "success" })
-    onOpenChange(false)
-  }, [form, updateGroup, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Groups.UpdateValues) => {
+      await updateGroup.mutateAsync(values)
+      toast({ message: "Group updated", variant: "success" })
+      onOpenChange(false)
+    },
+    [updateGroup, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/licenses/form/create.tsx
+++ b/src/components/licenses/form/create.tsx
@@ -52,13 +52,15 @@ export default function CreateLicenseForm({
     [policies, selectedPolicyId],
   )
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    const license = await createLicense.mutateAsync(values)
-    toast({ message: "License created", variant: "success" })
-    onOpenChange(false)
-    await navigateToResource(license)
-  }, [form, createLicense, navigateToResource, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Licenses.CreateValues) => {
+      const license = await createLicense.mutateAsync(values)
+      toast({ message: "License created", variant: "success" })
+      onOpenChange(false)
+      await navigateToResource(license)
+    },
+    [createLicense, navigateToResource, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/licenses/form/edit.tsx
+++ b/src/components/licenses/form/edit.tsx
@@ -51,12 +51,14 @@ export default function EditLicenseForm({
     },
   })
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    await updateLicense.mutateAsync(values)
-    toast({ message: "License updated", variant: "success" })
-    onOpenChange(false)
-  }, [form, updateLicense, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Licenses.UpdateValues) => {
+      await updateLicense.mutateAsync(values)
+      toast({ message: "License updated", variant: "success" })
+      onOpenChange(false)
+    },
+    [updateLicense, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/machines/form/create.tsx
+++ b/src/components/machines/form/create.tsx
@@ -44,13 +44,15 @@ export default function CreateMachineForm({
   const createMachine = useCreateMachine()
   const navigateToResource = useResourceNavigate()
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    const machine = await createMachine.mutateAsync(values)
-    toast({ message: "Machine activated", variant: "success" })
-    onOpenChange(false)
-    await navigateToResource(machine)
-  }, [form, createMachine, navigateToResource, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Machines.CreateValues) => {
+      const machine = await createMachine.mutateAsync(values)
+      toast({ message: "Machine activated", variant: "success" })
+      onOpenChange(false)
+      await navigateToResource(machine)
+    },
+    [createMachine, navigateToResource, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/machines/form/edit.tsx
+++ b/src/components/machines/form/edit.tsx
@@ -45,12 +45,14 @@ export default function EditMachineForm({
     },
   })
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    await updateMachine.mutateAsync(values)
-    toast({ message: "Machine updated", variant: "success" })
-    onOpenChange(false)
-  }, [form, updateMachine, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Machines.UpdateValues) => {
+      await updateMachine.mutateAsync(values)
+      toast({ message: "Machine updated", variant: "success" })
+      onOpenChange(false)
+    },
+    [updateMachine, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/policies/form/create.tsx
+++ b/src/components/policies/form/create.tsx
@@ -182,10 +182,12 @@ export default function CreatePolicyForm({
     [form, createPolicy, navigateToResource, createEntitlement, onOpenChange],
   )
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    await handleCreatePolicy(values)
-  }, [form, handleCreatePolicy])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Policies.CreateValues) => {
+      await handleCreatePolicy(values)
+    },
+    [handleCreatePolicy],
+  )
 
   const handleOpenChange = useCallback(
     (value: boolean) => {
@@ -521,7 +523,7 @@ interface TemplatesFormProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   selection: PolicyTemplateSelection
-  onSubmit: () => void
+  onSubmit: (data: Schemas.Policies.CreateValues) => void | Promise<void>
   onBack: () => void
   isPending: boolean
   errorMessage?: string
@@ -883,7 +885,7 @@ interface ScratchFormProps {
   form: UseFormReturn<Schemas.Policies.CreateValues>
   open: boolean
   onOpenChange: (open: boolean) => void
-  onSubmit: () => void
+  onSubmit: (data: Schemas.Policies.CreateValues) => void | Promise<void>
   onBack: () => void
   isPending: boolean
   errorMessage?: string

--- a/src/components/policies/form/duplicate.tsx
+++ b/src/components/policies/form/duplicate.tsx
@@ -67,58 +67,60 @@ export default function DuplicatePolicyForm({
     values: defaultValues,
   })
 
-  const handleSubmit = useCallback(async () => {
-    if (!policy) return
-    const values = form.getValues()
+  const handleSubmit = useCallback(
+    async (values: Schemas.Policies.CreateValues) => {
+      if (!policy) return
 
-    const attachIds = values.entitlements?.attach ?? []
-    const toCreate = values.entitlements?.create ?? []
-    const [createdEntitlements, errors] = await settleMutations<Entitlement>(
-      toCreate.map((attrs) => createEntitlement.mutateAsync(attrs)),
-    )
-    const entitlementIds = Array.from(
-      new Set([...attachIds, ...createdEntitlements.map((e) => e.id)]),
-    )
+      const attachIds = values.entitlements?.attach ?? []
+      const toCreate = values.entitlements?.create ?? []
+      const [createdEntitlements, errors] = await settleMutations<Entitlement>(
+        toCreate.map((attrs) => createEntitlement.mutateAsync(attrs)),
+      )
+      const entitlementIds = Array.from(
+        new Set([...attachIds, ...createdEntitlements.map((e) => e.id)]),
+      )
 
-    if (errors.length > 0) {
-      const nextAttach = [...entitlementIds]
-      const nextCreate = errors.map(({ index }) => toCreate[index])
-      form.setValue("entitlements.attach", nextAttach)
-      form.setValue("entitlements.create", nextCreate)
-      errors.forEach((error, index) => {
-        let message = ""
-        if (error.reason.code === EntitlementErrorCode.CodeTaken) {
-          message = "Code already exists"
-        } else {
-          message = "Field is invalid"
-        }
-        form.setError(`entitlements.create.${index}.code`, {
-          type: "validate",
-          message,
+      if (errors.length > 0) {
+        const nextAttach = [...entitlementIds]
+        const nextCreate = errors.map(({ index }) => toCreate[index])
+        form.setValue("entitlements.attach", nextAttach)
+        form.setValue("entitlements.create", nextCreate)
+        errors.forEach((error, index) => {
+          let message = ""
+          if (error.reason.code === EntitlementErrorCode.CodeTaken) {
+            message = "Code already exists"
+          } else {
+            message = "Field is invalid"
+          }
+          form.setError(`entitlements.create.${index}.code`, {
+            type: "validate",
+            message,
+          })
         })
-      })
-      toast({ message: "Failed to create entitlement(s)", variant: "error" })
-      return
-    }
+        toast({ message: "Failed to create entitlement(s)", variant: "error" })
+        return
+      }
 
-    const created = await createPolicy.mutateAsync({
-      ...values,
-      entitlements: { attach: entitlementIds, create: [] },
-    })
-    if (entitlementIds.length > 0)
-      await attachEntitlements.mutateAsync(entitlementIds)
-    toast({ message: "Policy created", variant: "success" })
-    onOpenChange(false)
-    await navigateToResource(created)
-  }, [
-    form,
-    policy,
-    createPolicy,
-    createEntitlement,
-    attachEntitlements,
-    navigateToResource,
-    onOpenChange,
-  ])
+      const created = await createPolicy.mutateAsync({
+        ...values,
+        entitlements: { attach: entitlementIds, create: [] },
+      })
+      if (entitlementIds.length > 0)
+        await attachEntitlements.mutateAsync(entitlementIds)
+      toast({ message: "Policy created", variant: "success" })
+      onOpenChange(false)
+      await navigateToResource(created)
+    },
+    [
+      form,
+      policy,
+      createPolicy,
+      createEntitlement,
+      attachEntitlements,
+      navigateToResource,
+      onOpenChange,
+    ],
+  )
 
   if (policyLoading) {
     return (

--- a/src/components/policies/form/edit.tsx
+++ b/src/components/policies/form/edit.tsx
@@ -58,63 +58,65 @@ export default function EditPolicyForm({
       : undefined,
   })
 
-  const handleSubmit = useCallback(async () => {
-    if (!policy) return
-    const values = form.getValues()
+  const handleSubmit = useCallback(
+    async (values: Schemas.Policies.UpdateValues) => {
+      if (!policy) return
 
-    const attachIds = values.entitlements?.attach ?? []
-    const toCreate = values.entitlements?.create ?? []
-    const [entitlements, errors] = await settleMutations<Entitlement>(
-      toCreate.map((attrs) => createEntitlement.mutateAsync(attrs)),
-    )
-    const entitlementIds = Array.from(
-      new Set([...attachIds, ...entitlements.map((e) => e.id)]),
-    )
+      const attachIds = values.entitlements?.attach ?? []
+      const toCreate = values.entitlements?.create ?? []
+      const [entitlements, errors] = await settleMutations<Entitlement>(
+        toCreate.map((attrs) => createEntitlement.mutateAsync(attrs)),
+      )
+      const entitlementIds = Array.from(
+        new Set([...attachIds, ...entitlements.map((e) => e.id)]),
+      )
 
-    if (errors.length > 0) {
-      const nextAttach = [...entitlementIds]
-      const nextCreate = errors.map(({ index }) => toCreate[index])
-      form.setValue("entitlements.attach", nextAttach)
-      form.setValue("entitlements.create", nextCreate)
-      errors.forEach((error, index) => {
-        let message = ""
-        if (error.reason.code === EntitlementErrorCode.CodeTaken) {
-          message = "Code already exists"
-        } else {
-          message = "Field is invalid"
-        }
-        form.setError(`entitlements.create.${index}.code`, {
-          type: "validate",
-          message,
+      if (errors.length > 0) {
+        const nextAttach = [...entitlementIds]
+        const nextCreate = errors.map(({ index }) => toCreate[index])
+        form.setValue("entitlements.attach", nextAttach)
+        form.setValue("entitlements.create", nextCreate)
+        errors.forEach((error, index) => {
+          let message = ""
+          if (error.reason.code === EntitlementErrorCode.CodeTaken) {
+            message = "Code already exists"
+          } else {
+            message = "Field is invalid"
+          }
+          form.setError(`entitlements.create.${index}.code`, {
+            type: "validate",
+            message,
+          })
         })
+        toast({ message: "Failed to create entitlement(s)", variant: "error" })
+        return
+      }
+
+      const currentIds = currentEntitlements.map((e) => e.id)
+      const newIds = entitlementIds
+      const toAttach = newIds.filter((id) => !currentIds.includes(id))
+      const toDetach = currentIds.filter((id) => !newIds.includes(id))
+
+      if (toDetach.length > 0) await detachEntitlements.mutateAsync(toDetach)
+      if (toAttach.length > 0) await attachEntitlements.mutateAsync(toAttach)
+      await updatePolicy.mutateAsync({
+        ...values,
+        entitlements: { attach: entitlementIds, create: [] },
       })
-      toast({ message: "Failed to create entitlement(s)", variant: "error" })
-      return
-    }
-
-    const currentIds = currentEntitlements.map((e) => e.id)
-    const newIds = entitlementIds
-    const toAttach = newIds.filter((id) => !currentIds.includes(id))
-    const toDetach = currentIds.filter((id) => !newIds.includes(id))
-
-    if (toDetach.length > 0) await detachEntitlements.mutateAsync(toDetach)
-    if (toAttach.length > 0) await attachEntitlements.mutateAsync(toAttach)
-    await updatePolicy.mutateAsync({
-      ...values,
-      entitlements: { attach: entitlementIds, create: [] },
-    })
-    toast({ message: "Policy updated", variant: "success" })
-    onOpenChange(false)
-  }, [
-    form,
-    policy,
-    onOpenChange,
-    updatePolicy,
-    currentEntitlements,
-    attachEntitlements,
-    detachEntitlements,
-    createEntitlement,
-  ])
+      toast({ message: "Policy updated", variant: "success" })
+      onOpenChange(false)
+    },
+    [
+      form,
+      policy,
+      onOpenChange,
+      updatePolicy,
+      currentEntitlements,
+      attachEntitlements,
+      detachEntitlements,
+      createEntitlement,
+    ],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange} fullscreen>

--- a/src/components/processes/form/create.tsx
+++ b/src/components/processes/form/create.tsx
@@ -35,13 +35,15 @@ export default function CreateProcessForm({
   const createProcess = useCreateProcess()
   const navigateToResource = useResourceNavigate()
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    const process = await createProcess.mutateAsync(values)
-    toast({ message: "Process spawned", variant: "success" })
-    onOpenChange(false)
-    await navigateToResource(process)
-  }, [form, createProcess, navigateToResource, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Processes.CreateValues) => {
+      const process = await createProcess.mutateAsync(values)
+      toast({ message: "Process spawned", variant: "success" })
+      onOpenChange(false)
+      await navigateToResource(process)
+    },
+    [createProcess, navigateToResource, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/processes/form/edit.tsx
+++ b/src/components/processes/form/edit.tsx
@@ -35,12 +35,14 @@ export default function EditProcessForm({
     },
   })
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    await updateProcess.mutateAsync(values)
-    toast({ message: "Process updated", variant: "success" })
-    onOpenChange(false)
-  }, [form, updateProcess, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Processes.UpdateValues) => {
+      await updateProcess.mutateAsync(values)
+      toast({ message: "Process updated", variant: "success" })
+      onOpenChange(false)
+    },
+    [updateProcess, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/products/form/create.tsx
+++ b/src/components/products/form/create.tsx
@@ -50,13 +50,15 @@ export default function CreateProductForm({
     name: "distributionStrategy",
   })
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    const product = await createProduct.mutateAsync(values)
-    toast({ message: "Product created", variant: "success" })
-    onOpenChange(false)
-    await navigateToResource(product)
-  }, [form, createProduct, navigateToResource, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Products.CreateValues) => {
+      const product = await createProduct.mutateAsync(values)
+      toast({ message: "Product created", variant: "success" })
+      onOpenChange(false)
+      await navigateToResource(product)
+    },
+    [createProduct, navigateToResource, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/products/form/edit.tsx
+++ b/src/components/products/form/edit.tsx
@@ -46,12 +46,14 @@ export default function EditProductForm({
     },
   })
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    await updateProduct.mutateAsync(values)
-    toast({ message: "Product updated", variant: "success" })
-    onOpenChange(false)
-  }, [form, updateProduct, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Products.UpdateValues) => {
+      await updateProduct.mutateAsync(values)
+      toast({ message: "Product updated", variant: "success" })
+      onOpenChange(false)
+    },
+    [updateProduct, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/users/form/create.tsx
+++ b/src/components/users/form/create.tsx
@@ -43,13 +43,15 @@ export default function CreateUserForm({
   const createUser = useCreateUser()
   const navigateToResource = useResourceNavigate()
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    const user = await createUser.mutateAsync(values)
-    toast({ message: "User created", variant: "success" })
-    onOpenChange(false)
-    await navigateToResource(user)
-  }, [form, createUser, navigateToResource, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Users.CreateValues) => {
+      const user = await createUser.mutateAsync(values)
+      toast({ message: "User created", variant: "success" })
+      onOpenChange(false)
+      await navigateToResource(user)
+    },
+    [createUser, navigateToResource, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/users/form/edit.tsx
+++ b/src/components/users/form/edit.tsx
@@ -43,12 +43,14 @@ export default function EditUserForm({
     },
   })
 
-  const handleSubmit = useCallback(async () => {
-    const values = form.getValues()
-    await updateUser.mutateAsync(values)
-    toast({ message: "User updated", variant: "success" })
-    onOpenChange(false)
-  }, [form, updateUser, onOpenChange])
+  const handleSubmit = useCallback(
+    async (values: Schemas.Users.UpdateValues) => {
+      await updateUser.mutateAsync(values)
+      toast({ message: "User updated", variant: "success" })
+      onOpenChange(false)
+    },
+    [updateUser, onOpenChange],
+  )
 
   return (
     <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>


### PR DESCRIPTION
Issue stemming from #56 with how the form submit handlers were passing values to the API. `form.getValues()` doesn't apply schema transformations, so when we try to coerce values like an empty string to `null` through our Zod schemas, `form.getValues()` doesn't run those transformations, so empty strings get sent to the API and it rejects and points to the form field with that error message, making some forms impossible to submit.

With this PR, the Wizard and Sheet form layouts now use `form.handleSubmit()` instead of `form.trigger()`and `form.getValues()`. Difference is `handleSubmit()` runs Zod for all the schema transforms/coercions, then passes that data to each form's `onSubmit`, so every form's submit handler now gets the transformed values as a parameter rather than raw values from `getValues()`.

Got missed in the aforementioned PR because we only transform a small handful of fields that the user doesn't set, so I didn't do enough testing, i.e. `key` in licenses gets sent as `""` instead of `null` when the user doesn't set a value, therefore falsely requiring the field despite it being marked as optional and the API auto-generating the key when left null.
