### PR TITLE
Add search query for forms instead of list hooks

### DIFF
--- a/src/components/components/form/fields.tsx
+++ b/src/components/components/form/fields.tsx
@@ -227,7 +227,7 @@ function MachineIdField({
             tooltip={descriptions.machine}
           >
             <SearchSelect
-              resource="machine"
+              resource="machines"
               value={field.value}
               onChange={(value) => field.onChange(value)}
               options={machines}

--- a/src/components/machines/form/fields.tsx
+++ b/src/components/machines/form/fields.tsx
@@ -311,7 +311,7 @@ function LicenseIdField({
             tooltip={descriptions.license}
           >
             <SearchSelect
-              resource="license"
+              resource="licenses"
               value={field.value}
               onChange={(value) => field.onChange(value)}
               options={licenses}
@@ -640,7 +640,7 @@ function GroupIdField({
             optional
           >
             <SearchSelect
-              resource="group"
+              resource="groups"
               value={field.value}
               onChange={(value) => field.onChange(value)}
               options={groups}
@@ -680,7 +680,7 @@ function OwnerIdField({
             optional
           >
             <SearchSelect
-              resource="user"
+              resource="users"
               value={field.value}
               onChange={(value) => field.onChange(value)}
               options={users}

--- a/src/components/processes/form/fields.tsx
+++ b/src/components/processes/form/fields.tsx
@@ -207,7 +207,7 @@ function MachineIdField({
             tooltip={descriptions.machine}
           >
             <SearchSelect
-              resource="machine"
+              resource="machines"
               value={field.value}
               onChange={(value) => field.onChange(value)}
               options={machines}

--- a/src/components/search-select.tsx
+++ b/src/components/search-select.tsx
@@ -58,7 +58,7 @@ const resourceConfigs: Record<ResourceType, ResourceConfig> = {
       </span>
     ),
     searchQuery: (term) => ({
-      query: { name: term, key: term },
+      query: { id: term, name: term, key: term },
       op: "OR",
     }),
   },
@@ -76,7 +76,10 @@ const resourceConfigs: Record<ResourceType, ResourceConfig> = {
         />
       </span>
     ),
-    searchQuery: (term) => ({ query: { name: term } }),
+    searchQuery: (term) => ({
+      query: { id: term, name: term },
+      op: "OR",
+    }),
   },
   users: {
     getLabel: getUserLabel as (option: BaseOption) => string,
@@ -93,7 +96,7 @@ const resourceConfigs: Record<ResourceType, ResourceConfig> = {
       </span>
     ),
     searchQuery: (term) => ({
-      query: { email: term, fullName: term },
+      query: { id: term, email: term, fullName: term },
       op: "OR",
     }),
   },
@@ -112,7 +115,7 @@ const resourceConfigs: Record<ResourceType, ResourceConfig> = {
       </span>
     ),
     searchQuery: (term) => ({
-      query: { name: term, fingerprint: term },
+      query: { id: term, name: term, fingerprint: term },
       op: "OR",
     }),
   },

--- a/src/components/search-select.tsx
+++ b/src/components/search-select.tsx
@@ -21,22 +21,29 @@ import { truncator, TruncateStyle } from "@/lib/truncate"
 
 import * as keygen from "@/keygen"
 
+import { useSearch } from "@/queries/search"
+
+import * as Loading from "@/components/loading"
 import GoToButton from "@/components/go-to-button"
 
 type BaseOption = { id: string }
 type NamedOption = BaseOption & { attributes: { name: string } }
 
-type ResourceType = "license" | "group" | "user" | "machine"
+type ResourceType = "licenses" | "groups" | "users" | "machines"
 
 interface ResourceConfig {
   getLabel: (option: BaseOption) => string
   placeholder: string
   searchPlaceholder: string
   emptyMessage: React.ReactElement
+  searchQuery: (term: string) => {
+    query: Record<string, string>
+    op?: "AND" | "OR"
+  }
 }
 
 const resourceConfigs: Record<ResourceType, ResourceConfig> = {
-  license: {
+  licenses: {
     getLabel: getLicenseLabel as (option: BaseOption) => string,
     placeholder: "Select a license...",
     searchPlaceholder: "Search by ID or name...",
@@ -50,8 +57,12 @@ const resourceConfigs: Record<ResourceType, ResourceConfig> = {
         />
       </span>
     ),
+    searchQuery: (term) => ({
+      query: { name: term, key: term },
+      op: "OR",
+    }),
   },
-  group: {
+  groups: {
     getLabel: getGroupLabel as (option: BaseOption) => string,
     placeholder: "Select a group...",
     searchPlaceholder: "Search by ID or name...",
@@ -65,8 +76,9 @@ const resourceConfigs: Record<ResourceType, ResourceConfig> = {
         />
       </span>
     ),
+    searchQuery: (term) => ({ query: { name: term } }),
   },
-  user: {
+  users: {
     getLabel: getUserLabel as (option: BaseOption) => string,
     placeholder: "Select an owner...",
     searchPlaceholder: "Search by ID or email...",
@@ -80,8 +92,12 @@ const resourceConfigs: Record<ResourceType, ResourceConfig> = {
         />
       </span>
     ),
+    searchQuery: (term) => ({
+      query: { email: term, fullName: term },
+      op: "OR",
+    }),
   },
-  machine: {
+  machines: {
     getLabel: getMachineLabel as (option: BaseOption) => string,
     placeholder: "Select a machine...",
     searchPlaceholder: "Search by ID, name, or fingerprint...",
@@ -95,6 +111,10 @@ const resourceConfigs: Record<ResourceType, ResourceConfig> = {
         />
       </span>
     ),
+    searchQuery: (term) => ({
+      query: { name: term, fingerprint: term },
+      op: "OR",
+    }),
   },
 }
 
@@ -156,6 +176,29 @@ export default function SearchSelect<T extends BaseOption>({
   const [open, setOpen] = useState(false)
 
   const inputRef = useRef<HTMLInputElement>(null)
+  const labelRef = useRef(new Map<string, string>())
+
+  const [searchType, searchQuery, searchOp] = useMemo<
+    [ResourceType | null, Record<string, string>, ("AND" | "OR") | undefined]
+  >(() => {
+    if (!config || !resource || query.length < 3) {
+      return [null, {}, undefined]
+    }
+    const search = config.searchQuery(query)
+    return [resource, search.query, search.op]
+  }, [config, resource, query])
+
+  const { data: searchData, isFetching: isSearching } = useSearch(
+    searchType,
+    searchQuery,
+    searchOp,
+  )
+
+  if (searchData) {
+    for (const item of searchData) {
+      labelRef.current.set(item.id, getLabel(item))
+    }
+  }
 
   const format = useMemo(
     () =>
@@ -164,20 +207,28 @@ export default function SearchSelect<T extends BaseOption>({
   )
 
   const labelMap = useMemo(
-    () => new Map(options.map((o) => [o.id, getLabel(o)])),
+    () => new Map(options.map((option) => [option.id, getLabel(option)])),
     [options, getLabel],
   )
 
   const visibleOptions = useMemo(() => {
+    if (searchType != null && searchData) {
+      return searchData
+    }
+
+    if (!query) return options
+
     const lowerQuery = query.toLowerCase()
     return options.filter(
       (option) =>
         getLabel(option).toLowerCase().includes(lowerQuery) ||
         option.id.toLowerCase().includes(lowerQuery),
     )
-  }, [query, options, getLabel])
+  }, [searchType, searchData, query, options, getLabel])
 
-  const selectedLabel = value ? labelMap.get(value) : null
+  const selectedLabel = value
+    ? (labelMap.get(value) ?? labelRef.current.get(value) ?? null)
+    : null
   const displayLabel = selectedLabel
     ? format
       ? format(selectedLabel)
@@ -250,7 +301,11 @@ export default function SearchSelect<T extends BaseOption>({
                 </CommandItem>
               )}
 
-              {visibleOptions.length > 0 ? (
+              {isSearching ? (
+                <div className="flex w-full justify-center py-4">
+                  <Loading.Dots className="bg-content-subdued!" />
+                </div>
+              ) : visibleOptions.length > 0 ? (
                 visibleOptions.map((option) => {
                   const label = getLabel(option)
                   const displayOptionLabel = format ? format(label) : label

--- a/src/components/users/form/fields.tsx
+++ b/src/components/users/form/fields.tsx
@@ -515,7 +515,7 @@ function GroupIdField({
             optional
           >
             <SearchSelect
-              resource="group"
+              resource="groups"
               value={field.value}
               onChange={(value) => field.onChange(value)}
               options={groups}

--- a/src/keygen/index.ts
+++ b/src/keygen/index.ts
@@ -45,3 +45,6 @@ export { users }
 
 import { logout } from "./logout"
 export { logout }
+
+import { search } from "./search"
+export { search }

--- a/src/keygen/search.ts
+++ b/src/keygen/search.ts
@@ -1,0 +1,28 @@
+import config from "@/keygen/config"
+import client from "@/keygen/client"
+import { type APIResponse, type AnyResource } from "@/types/api"
+
+config.validate()
+
+interface SearchProps {
+  type: "users" | "licenses" | "machines" | "groups"
+  query: Record<string, string>
+  op?: "AND" | "OR"
+}
+
+export async function search({
+  type,
+  query,
+  op,
+}: SearchProps): Promise<APIResponse<AnyResource[]>> {
+  return await client.request(`/accounts/${config.id}/search`, {
+    method: "POST",
+    body: JSON.stringify({
+      meta: {
+        type,
+        ...(op ? { op } : {}),
+        query,
+      },
+    }),
+  })
+}

--- a/src/queries/search.ts
+++ b/src/queries/search.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { useEnvironment } from "@/hooks/use-environment"
+
+import * as keygen from "@/keygen"
+
+export function useSearch(
+  type: "users" | "licenses" | "machines" | "groups" | null,
+  query: Record<string, string>,
+  op?: "AND" | "OR",
+) {
+  const { code } = useEnvironment()
+  const enabled =
+    type != null && Object.values(query).some((v) => v.length >= 3)
+
+  return useQuery({
+    queryKey: ["search", type, query, { environment: code }],
+    queryFn: () =>
+      keygen
+        .search({ type: type!, query, op })
+        .then((response) => response.data ?? []),
+    enabled,
+  })
+}


### PR DESCRIPTION
Closes #63. Adds a search query hook and setup for the `/search` endpoint, allowing users to filter things like relationship dropdowns in forms.