### PR TITLE
Add server-side pagination to list pages

### DIFF
--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -1,15 +1,13 @@
-import { useState, useEffect } from "react"
-
+import { useState, useEffect, useRef, useLayoutEffect } from "react"
 import {
   flexRender,
-  getCoreRowModel,
-  getPaginationRowModel,
-  getSortedRowModel,
   SortingState,
   useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  getPaginationRowModel,
 } from "@tanstack/react-table"
 
-import { Button } from "@/components/ui/button"
 import {
   Table,
   TableHeader,
@@ -19,154 +17,227 @@ import {
   TableCell,
 } from "@/components/ui/table"
 
-import {
-  ChevronLeft,
-  ChevronRight,
-  ChevronDown,
-  ChevronUp,
-  ChevronsUpDown,
-} from "lucide-react"
+import { ChevronUp, ChevronDown, ChevronsUpDown } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-
-import { useMobile } from "@/hooks/use-mobile"
-
 import { TableColumns, TableResource } from "@/lib/tables"
 
-export type DataTableProps<T extends TableResource> = {
+import { useMobile } from "@/hooks/use-mobile"
+import { DataTableState } from "@/hooks/use-data-table"
+
+import * as Motion from "@/components/motion"
+import * as Skeletons from "@/components/skeletons"
+
+type DataTableProps<T extends TableResource> = {
   data: T[]
+  table: DataTableState
   columns: TableColumns<T>
   onRowClick?: (row: T) => void
   hideOnMobile?: string[]
-  pageSize?: number
-  includePagination?: boolean
+  pageCount: number
+  isLoading?: boolean
   className?: string
 }
 
 export default function DataTable<T extends TableResource>({
   data,
+  table,
   columns,
   onRowClick,
   hideOnMobile = [],
-  pageSize = 10,
-  includePagination = true,
+  pageCount,
+  isLoading = false,
   className,
 }: DataTableProps<T>): React.ReactElement {
   const isMobile = useMobile()
+
+  const headerRef = useRef<HTMLTableSectionElement>(null)
+  const firstRowRef = useRef<HTMLTableRowElement>(null)
+  const lastMeasurementRef = useRef({ rowHeight: 0, headerHeight: 0 })
+
+  // Update page size based on available height so table fills container
+  useLayoutEffect(() => {
+    if (!table.onMeasure) return
+
+    const row = firstRowRef.current
+    if (!row) return
+
+    let rowHeight = row.offsetHeight
+
+    // TODO(cazden) Refactor this garbage; adds compensation for header border so height is accurate when only initial row is available
+    if (data.length === 1 && headerRef.current?.firstElementChild) {
+      const headerRow = headerRef.current.firstElementChild as HTMLElement
+      rowHeight +=
+        parseFloat(getComputedStyle(headerRow).borderBottomWidth) || 0
+    }
+
+    const headerHeight = headerRef.current?.offsetHeight ?? 0
+
+    // Skip if no changes
+    if (
+      lastMeasurementRef.current.rowHeight === rowHeight &&
+      lastMeasurementRef.current.headerHeight === headerHeight
+    )
+      return
+
+    lastMeasurementRef.current = { rowHeight, headerHeight }
+    table.onMeasure({ rowHeight, headerHeight })
+  }, [isLoading, data.length, isMobile, table])
+
+  // Track which pages have already animated so revisiting doesn't animate again
+  const prevPageRef = useRef(table.page)
+  const directionRef = useRef<1 | -1>(1)
+  const animatedPagesRef = useRef(new Set<number>())
+
+  if (table.page !== prevPageRef.current) {
+    directionRef.current = table.page > prevPageRef.current ? 1 : -1
+    animatedPagesRef.current.add(prevPageRef.current)
+    prevPageRef.current = table.page
+  }
+
+  const shouldAnimate = !animatedPagesRef.current.has(table.page)
+
+  // TODO(cazden) Refactor this with horizontal scroll (#47)
+  // Column visibility
   const [sorting, setSorting] = useState<SortingState>([])
   const [columnVisibility, setColumnVisibility] = useState<
     Record<string, boolean>
   >({})
 
+  // Toggle column visibility based on mobile breakpoint
   useEffect(() => {
     const next: Record<string, boolean> = {}
     hideOnMobile.forEach((k) => (next[String(k)] = !isMobile))
     setColumnVisibility(next)
   }, [isMobile, hideOnMobile])
 
-  const table = useReactTable({
+  const tableInstance = useReactTable({
     data,
     columns,
-    state: { sorting, columnVisibility },
+    state: {
+      sorting,
+      columnVisibility,
+      pagination: { pageIndex: table.page - 1, pageSize: table.pageSize },
+    },
+    manualPagination: true,
+    pageCount,
+    onPaginationChange: (updater) => {
+      const current = {
+        pageIndex: table.page - 1,
+        pageSize: table.pageSize,
+      }
+      const next = typeof updater === "function" ? updater(current) : updater
+      table.setPage(next.pageIndex + 1)
+    },
     onSortingChange: setSorting,
     onColumnVisibilityChange: setColumnVisibility,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    initialState: { pagination: { pageSize } },
+    initialState: { pagination: { pageSize: table.pageSize } },
   })
 
   return (
-    <div className={cn("px-4", className)}>
-      <Table>
-        <TableHeader>
-          {table.getHeaderGroups().map((group) => (
-            <TableRow key={group.id} className="hover:bg-transparent">
-              {group.headers.map((header) => {
-                const canSort = header.column.getCanSort()
-                const direction = header.column.getIsSorted()
+    <div
+      ref={table.containerRef}
+      className={cn("relative flex flex-1 flex-col", className)}
+    >
+      <Skeletons.Table
+        className={cn(
+          !isLoading && "absolute opacity-0 transition-opacity duration-500",
+        )}
+      />
 
-                return (
-                  <TableHead
-                    key={header.id}
-                    onClick={header.column.getToggleSortingHandler()}
-                    className="text-sm select-none md:text-xs"
+      {/* FIXME(cazden) isMeasured never converges if data.length is 0 from API response, so this div remains hidden.
+      e.g. processes table doesn't transition unless we spawn a process. Need to make sure isMeasured always converges. */}
+      <div
+        className={cn(
+          isLoading || !table.isMeasured
+            ? "absolute opacity-0"
+            : "flex min-h-0 flex-1 flex-col opacity-100 transition-opacity delay-50 duration-200",
+        )}
+      >
+        <Motion.Slide
+          direction={directionRef.current}
+          className="min-h-0 flex-1 px-4"
+        >
+          <Table key={table.page}>
+            <TableHeader ref={headerRef}>
+              {tableInstance.getHeaderGroups().map((group) => (
+                <TableRow key={group.id} className="hover:bg-transparent">
+                  {group.headers.map((header) => {
+                    const canSort = header.column.getCanSort()
+                    const direction = header.column.getIsSorted()
+
+                    return (
+                      <TableHead
+                        key={header.id}
+                        onClick={header.column.getToggleSortingHandler()}
+                        className="text-sm select-none md:text-xs"
+                      >
+                        <div className="flex items-center gap-2">
+                          {flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                          {canSort &&
+                            (!direction ? (
+                              <ChevronsUpDown className="size-4 md:size-3" />
+                            ) : direction === "asc" ? (
+                              <ChevronUp className="size-4 text-brand-primary md:size-3" />
+                            ) : (
+                              <ChevronDown className="size-4 text-brand-primary md:size-3" />
+                            ))}
+                        </div>
+                      </TableHead>
+                    )
+                  })}
+                </TableRow>
+              ))}
+            </TableHeader>
+
+            <TableBody className="text-base md:text-sm">
+              {tableInstance.getRowModel().rows.length ? (
+                tableInstance.getRowModel().rows.map((row, index) => (
+                  <TableRow
+                    key={row.id}
+                    ref={index === 0 ? firstRowRef : undefined}
+                    onClick={() => onRowClick?.(row.original)}
+                    className={cn(
+                      shouldAnimate &&
+                        "animate-in [animation-duration:500ms] fade-in fill-mode-backwards",
+                      onRowClick && "cursor-pointer",
+                    )}
+                    style={
+                      shouldAnimate
+                        ? { animationDelay: `${index * 30}ms` }
+                        : undefined
+                    }
                   >
-                    <div className="flex items-center gap-2">
-                      {flexRender(
-                        header.column.columnDef.header,
-                        header.getContext(),
-                      )}
-                      {canSort &&
-                        (!direction ? (
-                          <ChevronsUpDown className="size-4 md:size-3" />
-                        ) : direction === "asc" ? (
-                          <ChevronUp className="size-4 text-brand-primary md:size-3" />
-                        ) : (
-                          <ChevronDown className="size-4 text-brand-primary md:size-3" />
-                        ))}
-                    </div>
-                  </TableHead>
-                )
-              })}
-            </TableRow>
-          ))}
-        </TableHeader>
-
-        <TableBody className="text-base md:text-sm">
-          {table.getRowModel().rows.length ? (
-            table.getRowModel().rows.map((row) => (
-              <TableRow
-                key={row.id}
-                onClick={() => onRowClick?.(row.original)}
-                className={onRowClick ? "cursor-pointer" : undefined}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow className="pointer-events-none">
+                  <TableCell
+                    colSpan={tableInstance.getVisibleFlatColumns().length}
+                    className="h-24 text-center text-content-subdued"
+                  >
+                    Nothing here yet.
                   </TableCell>
-                ))}
-              </TableRow>
-            ))
-          ) : (
-            <TableRow className="pointer-events-none">
-              <TableCell
-                colSpan={table.getVisibleFlatColumns().length}
-                className="h-24 text-center text-content-subdued"
-              >
-                Nothing here yet.
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-      </Table>
-
-      {includePagination && table.getRowModel().rows.length > 0 && (
-        <div className="flex items-center justify-end space-x-4 p-4">
-          <span className="text-sm text-muted-foreground">
-            Page {table.getState().pagination.pageIndex + 1} of{" "}
-            {table.getPageCount()}
-          </span>
-          <div className="flex items-center space-x-2">
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-            >
-              <ChevronRight className="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
-      )}
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </Motion.Slide>
+      </div>
     </div>
   )
 }

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useLayoutEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import {
   flexRender,
   SortingState,
@@ -50,39 +50,6 @@ export default function DataTable<T extends TableResource>({
   className,
 }: DataTableProps<T>): React.ReactElement {
   const isMobile = useMobile()
-
-  const headerRef = useRef<HTMLTableSectionElement>(null)
-  const firstRowRef = useRef<HTMLTableRowElement>(null)
-  const lastMeasurementRef = useRef({ rowHeight: 0, headerHeight: 0 })
-
-  // Update page size based on available height so table fills container
-  useLayoutEffect(() => {
-    if (!table.onMeasure) return
-
-    const row = firstRowRef.current
-    if (!row) return
-
-    let rowHeight = row.offsetHeight
-
-    // TODO(cazden) Refactor this garbage; adds compensation for header border so height is accurate when only initial row is available
-    if (data.length === 1 && headerRef.current?.firstElementChild) {
-      const headerRow = headerRef.current.firstElementChild as HTMLElement
-      rowHeight +=
-        parseFloat(getComputedStyle(headerRow).borderBottomWidth) || 0
-    }
-
-    const headerHeight = headerRef.current?.offsetHeight ?? 0
-
-    // Skip if no changes
-    if (
-      lastMeasurementRef.current.rowHeight === rowHeight &&
-      lastMeasurementRef.current.headerHeight === headerHeight
-    )
-      return
-
-    lastMeasurementRef.current = { rowHeight, headerHeight }
-    table.onMeasure({ rowHeight, headerHeight })
-  }, [isLoading, data.length, isMobile, table])
 
   // Track which pages have already animated so revisiting doesn't animate again
   const prevPageRef = useRef(table.page)
@@ -138,23 +105,18 @@ export default function DataTable<T extends TableResource>({
   })
 
   return (
-    <div
-      ref={table.containerRef}
-      className={cn("relative flex flex-1 flex-col", className)}
-    >
+    <div className={cn("relative flex flex-1 flex-col", className)}>
       <Skeletons.Table
         className={cn(
           !isLoading && "absolute opacity-0 transition-opacity duration-500",
         )}
       />
 
-      {/* FIXME(cazden) isMeasured never converges if data.length is 0 from API response, so this div remains hidden.
-      e.g. processes table doesn't transition unless we spawn a process. Need to make sure isMeasured always converges. */}
       <div
         className={cn(
-          isLoading || !table.isMeasured
+          isLoading
             ? "absolute opacity-0"
-            : "flex min-h-0 flex-1 flex-col opacity-100 transition-opacity delay-50 duration-200",
+            : "flex min-h-0 flex-1 flex-col opacity-100 transition-opacity duration-200",
         )}
       >
         <Motion.Slide
@@ -162,7 +124,7 @@ export default function DataTable<T extends TableResource>({
           className="min-h-0 flex-1 px-4"
         >
           <Table key={table.page}>
-            <TableHeader ref={headerRef}>
+            <TableHeader>
               {tableInstance.getHeaderGroups().map((group) => (
                 <TableRow key={group.id} className="hover:bg-transparent">
                   {group.headers.map((header) => {
@@ -201,7 +163,6 @@ export default function DataTable<T extends TableResource>({
                 tableInstance.getRowModel().rows.map((row, index) => (
                   <TableRow
                     key={row.id}
-                    ref={index === 0 ? firstRowRef : undefined}
                     onClick={() => onRowClick?.(row.original)}
                     className={cn(
                       shouldAnimate &&

--- a/src/components/environments/modal-manager.tsx
+++ b/src/components/environments/modal-manager.tsx
@@ -37,7 +37,7 @@ export default function EnvironmentsModalManager({
   return (
     <AnimatePresence mode="wait">
       <Dialog open={open} onOpenChange={onClose}>
-        <DialogContent className="flex flex-col justify-between p-0 transition-all duration-300 md:min-w-[700px]">
+        <DialogContent className="flex min-h-screen min-w-screen flex-col justify-start rounded-none p-0 transition-all duration-300 md:min-h-auto md:min-w-[700px] md:rounded-md">
           {mode === EnvironmentMode.View && (
             <View.Modal
               selectedEnvironment={selectedEnvironment}

--- a/src/components/environments/view/list.tsx
+++ b/src/components/environments/view/list.tsx
@@ -47,7 +47,7 @@ export default function EnvironmentsList({
           page={table.page}
           pageCount={totalPages}
           onPageChange={table.setPage}
-          isLoading={isLoading || !table.isMeasured}
+          isLoading={isLoading}
         />
       </PageFooter>
     </div>

--- a/src/components/environments/view/list.tsx
+++ b/src/components/environments/view/list.tsx
@@ -3,9 +3,11 @@ import { Environment } from "@/types/environments"
 import { useListEnvironments } from "@/queries/environments"
 
 import { useEnvironmentTableColumns } from "@/hooks/use-environment-table-columns"
+import { useDataTable } from "@/hooks/use-data-table"
 
 import DataTable from "@/components/data-table"
-import * as Skeletons from "@/components/skeletons"
+import Pagination from "@/components/pagination"
+import PageFooter from "@/components/page-footer"
 
 interface EnvironmentsListProps {
   onViewDetails: (environment: Environment) => void
@@ -14,26 +16,40 @@ interface EnvironmentsListProps {
 export default function EnvironmentsList({
   onViewDetails,
 }: EnvironmentsListProps) {
-  const { data: environments = [], isLoading } = useListEnvironments()
+  const table = useDataTable()
   const columns = useEnvironmentTableColumns()
 
+  const {
+    data: environments,
+    links,
+    isLoading,
+  } = useListEnvironments({
+    page: table.page,
+    pageSize: table.pageSize,
+  })
+
+  const totalPages = links?.meta?.pages ?? 1
+
   return (
-    <>
-      {environments && environments.length > 0 ? (
-        <DataTable
-          data={environments}
-          columns={columns}
-          onRowClick={onViewDetails}
-          hideOnMobile={["attributes.isolationStrategy"]}
-          includePagination={false}
+    <div className="flex h-[60vh] flex-col md:h-[40vh]">
+      <DataTable
+        data={environments}
+        table={table}
+        columns={columns}
+        pageCount={totalPages}
+        isLoading={isLoading}
+        onRowClick={onViewDetails}
+        hideOnMobile={["attributes.isolationStrategy"]}
+      />
+
+      <PageFooter>
+        <Pagination
+          page={table.page}
+          pageCount={totalPages}
+          onPageChange={table.setPage}
+          isLoading={isLoading || !table.isMeasured}
         />
-      ) : isLoading ? (
-        <Skeletons.Table />
-      ) : (
-        <p className="my-8 text-center text-sm text-content-subdued">
-          Looks empty. Create an environment to get started.
-        </p>
-      )}
-    </>
+      </PageFooter>
+    </div>
   )
 }

--- a/src/components/environments/view/list.tsx
+++ b/src/components/environments/view/list.tsx
@@ -2,8 +2,8 @@ import { Environment } from "@/types/environments"
 
 import { useListEnvironments } from "@/queries/environments"
 
-import { useEnvironmentTableColumns } from "@/hooks/use-environment-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
+import { useEnvironmentTableColumns } from "@/hooks/use-environment-table-columns"
 
 import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
@@ -25,13 +25,13 @@ export default function EnvironmentsList({
     isLoading,
   } = useListEnvironments({
     page: table.page,
-    pageSize: table.pageSize,
+    pageSize: 15, // Ignore hook value since we're in a dialog
   })
 
   const totalPages = links?.meta?.pages ?? 1
 
   return (
-    <div className="flex h-[60vh] flex-col md:h-[40vh]">
+    <>
       <DataTable
         data={environments}
         table={table}
@@ -42,7 +42,7 @@ export default function EnvironmentsList({
         hideOnMobile={["attributes.isolationStrategy"]}
       />
 
-      <PageFooter>
+      <PageFooter className="border-none">
         <Pagination
           page={table.page}
           pageCount={totalPages}
@@ -50,6 +50,6 @@ export default function EnvironmentsList({
           isLoading={isLoading}
         />
       </PageFooter>
-    </div>
+    </>
   )
 }

--- a/src/components/environments/view/modal.tsx
+++ b/src/components/environments/view/modal.tsx
@@ -111,7 +111,7 @@ export default function EnvironmentsViewModal({
         </DialogTitle>
       </DialogHeader>
 
-      <ScrollArea className="h-[60vh] md:h-[40vh]">
+      <ScrollArea className="h-[calc(100vh-8rem)] md:h-[40vh]">
         <Motion.Slide direction={direction}>
           {view === EnvironmentView.List ? (
             <EnvironmentsList

--- a/src/components/page-footer.tsx
+++ b/src/components/page-footer.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@/lib/utils"
+
+interface PageFooterProps {
+  className?: string
+  children: React.ReactNode
+}
+
+export default function PageFooter({
+  className,
+  children,
+}: PageFooterProps): React.ReactNode {
+  return (
+    <footer
+      className={cn("flex items-center justify-end gap-4 p-4", className)}
+    >
+      {children}
+    </footer>
+  )
+}

--- a/src/components/page-footer.tsx
+++ b/src/components/page-footer.tsx
@@ -11,7 +11,10 @@ export default function PageFooter({
 }: PageFooterProps): React.ReactNode {
   return (
     <footer
-      className={cn("flex items-center justify-end gap-4 p-4", className)}
+      className={cn(
+        "flex items-center justify-end gap-4 border-t border-accent p-4",
+        className,
+      )}
     >
       {children}
     </footer>

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -1,0 +1,55 @@
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { ChevronLeft, ChevronRight } from "lucide-react"
+
+interface PaginationProps {
+  page: number
+  pageCount: number
+  onPageChange: (page: number) => void
+  isLoading?: boolean
+}
+
+export default function Pagination({
+  page,
+  pageCount,
+  onPageChange,
+  isLoading = false,
+}: PaginationProps) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-5 w-24 rounded-sm" />
+        <Skeleton className="h-8 w-8 rounded-md" />
+        <Skeleton className="h-8 w-8 rounded-md" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-muted-foreground">
+        Page {page} of {pageCount}
+      </span>
+
+      <Button
+        variant="outline"
+        size="icon"
+        className="h-8 w-8"
+        onClick={() => onPageChange(page - 1)}
+        disabled={page <= 1}
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </Button>
+
+      <Button
+        variant="outline"
+        size="icon"
+        className="h-8 w-8"
+        onClick={() => onPageChange(page + 1)}
+        disabled={page >= pageCount}
+      >
+        <ChevronRight className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}

--- a/src/components/skeletons/table.tsx
+++ b/src/components/skeletons/table.tsx
@@ -1,16 +1,26 @@
 import { Skeleton } from "@/components/ui/skeleton"
 
-export default function SkeletonTable(): React.ReactElement {
+import { cn } from "@/lib/utils"
+
+interface SkeletonTableProps {
+  className?: string
+}
+
+export default function SkeletonTable({
+  className,
+}: SkeletonTableProps): React.ReactNode {
   return (
-    <div className="flex w-full flex-col justify-center space-y-4 p-4 md:pr-12">
-      <Skeleton className="mb-4 h-6 w-full" />
+    <div
+      className={cn(
+        "flex w-full flex-col justify-center space-y-4 p-4 md:pr-12",
+        className,
+      )}
+    >
+      <Skeleton className="mb-4 h-6 w-full rounded-sm" />
       <Skeleton className="ml-4 h-8 w-3/4" />
       <Skeleton className="ml-4 h-8 w-1/2" />
       <Skeleton className="ml-4 h-8 w-1/4" />
       <Skeleton className="ml-4 h-8 w-1/3" />
-      <div className="flex w-full justify-end">
-        <Skeleton className="h-8 w-36" />
-      </div>
     </div>
   )
 }

--- a/src/components/skeletons/table.tsx
+++ b/src/components/skeletons/table.tsx
@@ -10,17 +10,14 @@ export default function SkeletonTable({
   className,
 }: SkeletonTableProps): React.ReactNode {
   return (
-    <div
-      className={cn(
-        "flex w-full flex-col justify-center space-y-4 p-4 md:pr-12",
-        className,
-      )}
-    >
+    <div className={cn("w-full flex-1 px-4 py-2 md:pr-12", className)}>
       <Skeleton className="mb-4 h-6 w-full rounded-sm" />
-      <Skeleton className="ml-4 h-8 w-3/4" />
-      <Skeleton className="ml-4 h-8 w-1/2" />
-      <Skeleton className="ml-4 h-8 w-1/4" />
-      <Skeleton className="ml-4 h-8 w-1/3" />
+      <div className="flex w-full flex-col justify-center space-y-4 px-2">
+        <Skeleton className="ml-4 h-8 w-3/4" />
+        <Skeleton className="ml-4 h-8 w-1/2" />
+        <Skeleton className="ml-4 h-8 w-1/4" />
+        <Skeleton className="ml-4 h-8 w-1/3" />
+      </div>
     </div>
   )
 }

--- a/src/hooks/use-data-table.ts
+++ b/src/hooks/use-data-table.ts
@@ -1,78 +1,19 @@
-import {
-  useRef,
-  useState,
-  useEffect,
-  useCallback,
-  useLayoutEffect,
-  RefObject,
-} from "react"
-
-const MaxPageSize = 100 // API limit
+import { useState, useMemo } from "react"
+import { useMobile } from "@/hooks/use-mobile"
 
 export type DataTableState = {
   page: number
-  pageSize: number
-  isMeasured: boolean
-  containerRef: RefObject<HTMLDivElement | null>
-  onMeasure: (measurements: { rowHeight: number; headerHeight: number }) => void
   setPage: (page: number) => void
+  pageSize: number
 }
 
-// Companion hook for DataTable that handles pagination and container measurement
 export function useDataTable(): DataTableState {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const [pageSize, setPageSize] = useState(1)
+  const isMobile = useMobile()
   const [page, setPage] = useState(1)
-  const [isMeasured, setIsMeasured] = useState(false)
-  const pageSizeRef = useRef(1)
-  const measurementsRef = useRef<{
-    rowHeight: number
-    headerHeight: number
-  } | null>(null)
 
-  // Calculate how many rows fit in the container from measured row height and header height
-  const recalculate = useCallback(() => {
-    const container = containerRef.current
-    const measurements = measurementsRef.current
-    if (!container || !measurements || measurements.rowHeight === 0) return
+  const pageSize = useMemo(() => {
+    return isMobile ? 15 : 20
+  }, [isMobile])
 
-    const available = container.clientHeight - measurements.headerHeight
-    const next = Math.max(
-      1,
-      Math.min(MaxPageSize, Math.floor(available / measurements.rowHeight)),
-    )
-
-    if (pageSizeRef.current !== next) {
-      pageSizeRef.current = next
-      setPageSize(next)
-    } else {
-      setIsMeasured(true)
-    }
-  }, [])
-
-  // Callback passed to DataTable to get row and header measurements
-  const onMeasure = useCallback(
-    (measurements: { rowHeight: number; headerHeight: number }) => {
-      measurementsRef.current = measurements
-      recalculate()
-    },
-    [recalculate],
-  )
-
-  // Recalculate on container resize
-  useLayoutEffect(() => {
-    const container = containerRef.current
-    if (!container) return
-
-    recalculate()
-
-    const observer = new ResizeObserver(() => recalculate())
-    observer.observe(container)
-    return () => observer.disconnect()
-  }, [recalculate])
-
-  // Reset to first page when page size changes (e.g. container resize)
-  useEffect(() => setPage(1), [pageSize])
-
-  return { page, pageSize, isMeasured, onMeasure, setPage, containerRef }
+  return { page, setPage, pageSize }
 }

--- a/src/hooks/use-data-table.ts
+++ b/src/hooks/use-data-table.ts
@@ -1,0 +1,78 @@
+import {
+  useRef,
+  useState,
+  useEffect,
+  useCallback,
+  useLayoutEffect,
+  RefObject,
+} from "react"
+
+const MaxPageSize = 100 // API limit
+
+export type DataTableState = {
+  page: number
+  pageSize: number
+  isMeasured: boolean
+  containerRef: RefObject<HTMLDivElement | null>
+  onMeasure: (measurements: { rowHeight: number; headerHeight: number }) => void
+  setPage: (page: number) => void
+}
+
+// Companion hook for DataTable that handles pagination and container measurement
+export function useDataTable(): DataTableState {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [pageSize, setPageSize] = useState(1)
+  const [page, setPage] = useState(1)
+  const [isMeasured, setIsMeasured] = useState(false)
+  const pageSizeRef = useRef(1)
+  const measurementsRef = useRef<{
+    rowHeight: number
+    headerHeight: number
+  } | null>(null)
+
+  // Calculate how many rows fit in the container from measured row height and header height
+  const recalculate = useCallback(() => {
+    const container = containerRef.current
+    const measurements = measurementsRef.current
+    if (!container || !measurements || measurements.rowHeight === 0) return
+
+    const available = container.clientHeight - measurements.headerHeight
+    const next = Math.max(
+      1,
+      Math.min(MaxPageSize, Math.floor(available / measurements.rowHeight)),
+    )
+
+    if (pageSizeRef.current !== next) {
+      pageSizeRef.current = next
+      setPageSize(next)
+    } else {
+      setIsMeasured(true)
+    }
+  }, [])
+
+  // Callback passed to DataTable to get row and header measurements
+  const onMeasure = useCallback(
+    (measurements: { rowHeight: number; headerHeight: number }) => {
+      measurementsRef.current = measurements
+      recalculate()
+    },
+    [recalculate],
+  )
+
+  // Recalculate on container resize
+  useLayoutEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    recalculate()
+
+    const observer = new ResizeObserver(() => recalculate())
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [recalculate])
+
+  // Reset to first page when page size changes (e.g. container resize)
+  useEffect(() => setPage(1), [pageSize])
+
+  return { page, pageSize, isMeasured, onMeasure, setPage, containerRef }
+}

--- a/src/pages/app/component/list.tsx
+++ b/src/pages/app/component/list.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { useComponentTableColumns } from "@/hooks/use-component-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
@@ -49,20 +50,22 @@ export default function ComponentsList() {
 
       <Components.Form.Create open={open} onOpenChange={setOpen} />
 
-      <DataTable<Component>
-        data={components}
-        table={table}
-        columns={columns}
-        pageCount={totalPages}
-        isLoading={componentsLoading}
-        hideOnMobile={[
-          "relationships.machine",
-          "relationships.license",
-          "attributes.created",
-          "attributes.updated",
-        ]}
-        onRowClick={(component) => navigateToResource(component)}
-      />
+      <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
+        <DataTable<Component>
+          data={components}
+          table={table}
+          columns={columns}
+          pageCount={totalPages}
+          isLoading={componentsLoading}
+          hideOnMobile={[
+            "relationships.machine",
+            "relationships.license",
+            "attributes.created",
+            "attributes.updated",
+          ]}
+          onRowClick={(component) => navigateToResource(component)}
+        />
+      </ScrollArea>
 
       <PageFooter>
         <Pagination

--- a/src/pages/app/component/list.tsx
+++ b/src/pages/app/component/list.tsx
@@ -3,27 +3,40 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 
 import { useComponentTableColumns } from "@/hooks/use-component-table-columns"
-
+import { useDataTable } from "@/hooks/use-data-table"
 import { Component } from "@/types/components"
+
 import { useListComponents } from "@/queries/components"
 
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
-import * as Skeletons from "@/components/skeletons"
 import * as Components from "@/components/components"
 import DataTable from "@/components/data-table"
+import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
+import PageFooter from "@/components/page-footer"
 
 export default function ComponentsList() {
-  const { data: components = [], isLoading: componentsLoading } =
-    useListComponents()
+  const table = useDataTable()
   const columns = useComponentTableColumns()
+
+  const {
+    data: components,
+    links,
+    isLoading: componentsLoading,
+  } = useListComponents({
+    page: table.page,
+    pageSize: table.pageSize,
+  })
+
+  const totalPages = links?.meta?.pages ?? 1
+
   const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
 
   return (
-    <section>
+    <section className="flex h-screen flex-col">
       <PageHeader title="Components">
         <Button
           size="sm"
@@ -36,21 +49,29 @@ export default function ComponentsList() {
 
       <Components.Form.Create open={open} onOpenChange={setOpen} />
 
-      {componentsLoading ? (
-        <Skeletons.Table />
-      ) : (
-        <DataTable<Component>
-          data={components}
-          columns={columns}
-          hideOnMobile={[
-            "relationships.machine",
-            "relationships.license",
-            "attributes.created",
-            "attributes.updated",
-          ]}
-          onRowClick={(component) => navigateToResource(component)}
+      <DataTable<Component>
+        data={components}
+        table={table}
+        columns={columns}
+        pageCount={totalPages}
+        isLoading={componentsLoading}
+        hideOnMobile={[
+          "relationships.machine",
+          "relationships.license",
+          "attributes.created",
+          "attributes.updated",
+        ]}
+        onRowClick={(component) => navigateToResource(component)}
+      />
+
+      <PageFooter>
+        <Pagination
+          page={table.page}
+          pageCount={totalPages}
+          onPageChange={table.setPage}
+          isLoading={componentsLoading || !table.isMeasured}
         />
-      )}
+      </PageFooter>
     </section>
   )
 }

--- a/src/pages/app/component/list.tsx
+++ b/src/pages/app/component/list.tsx
@@ -69,7 +69,7 @@ export default function ComponentsList() {
           page={table.page}
           pageCount={totalPages}
           onPageChange={table.setPage}
-          isLoading={componentsLoading || !table.isMeasured}
+          isLoading={componentsLoading}
         />
       </PageFooter>
     </section>

--- a/src/pages/app/entitlement/list.tsx
+++ b/src/pages/app/entitlement/list.tsx
@@ -69,7 +69,7 @@ export default function EntitlementsList() {
           page={table.page}
           pageCount={totalPages}
           onPageChange={table.setPage}
-          isLoading={entitlementsLoading || !table.isMeasured}
+          isLoading={entitlementsLoading}
         />
       </PageFooter>
     </section>

--- a/src/pages/app/entitlement/list.tsx
+++ b/src/pages/app/entitlement/list.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { useEntitlementTableColumns } from "@/hooks/use-entitlement-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
@@ -48,21 +49,23 @@ export default function EntitlementsList() {
         <Entitlements.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
 
-      <DataTable<Entitlement>
-        data={entitlements}
-        table={table}
-        columns={columns}
-        pageCount={totalPages}
-        isLoading={entitlementsLoading}
-        hideOnMobile={[
-          "attributes.id",
-          "attributes.code",
-          "attributes.url",
-          "attributes.created",
-          "attributes.updated",
-        ]}
-        onRowClick={(entitlement) => navigateToResource(entitlement)}
-      />
+      <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
+        <DataTable<Entitlement>
+          data={entitlements}
+          table={table}
+          columns={columns}
+          pageCount={totalPages}
+          isLoading={entitlementsLoading}
+          hideOnMobile={[
+            "attributes.id",
+            "attributes.code",
+            "attributes.url",
+            "attributes.created",
+            "attributes.updated",
+          ]}
+          onRowClick={(entitlement) => navigateToResource(entitlement)}
+        />
+      </ScrollArea>
 
       <PageFooter>
         <Pagination

--- a/src/pages/app/entitlement/list.tsx
+++ b/src/pages/app/entitlement/list.tsx
@@ -3,28 +3,40 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 
 import { useEntitlementTableColumns } from "@/hooks/use-entitlement-table-columns"
-
+import { useDataTable } from "@/hooks/use-data-table"
 import { Entitlement } from "@/types/entitlements"
 
 import { useListEntitlements } from "@/queries/entitlements"
 
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
-import * as Skeletons from "@/components/skeletons"
 import * as Entitlements from "@/components/entitlements"
 import DataTable from "@/components/data-table"
+import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
+import PageFooter from "@/components/page-footer"
 
 export default function EntitlementsList() {
-  const { data: entitlements = [], isLoading: entitlementsLoading } =
-    useListEntitlements()
+  const table = useDataTable()
   const columns = useEntitlementTableColumns()
+
+  const {
+    data: entitlements,
+    links,
+    isLoading: entitlementsLoading,
+  } = useListEntitlements({
+    page: table.page,
+    pageSize: table.pageSize,
+  })
+
+  const totalPages = links?.meta?.pages ?? 1
+
   const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
 
   return (
-    <section>
+    <section className="flex h-screen flex-col">
       <PageHeader title="Entitlements">
         <Button
           size="sm"
@@ -36,22 +48,30 @@ export default function EntitlementsList() {
         <Entitlements.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
 
-      {entitlementsLoading ? (
-        <Skeletons.Table />
-      ) : (
-        <DataTable<Entitlement>
-          data={entitlements}
-          columns={columns}
-          hideOnMobile={[
-            "attributes.id",
-            "attributes.code",
-            "attributes.url",
-            "attributes.created",
-            "attributes.updated",
-          ]}
-          onRowClick={(entitlement) => navigateToResource(entitlement)}
+      <DataTable<Entitlement>
+        data={entitlements}
+        table={table}
+        columns={columns}
+        pageCount={totalPages}
+        isLoading={entitlementsLoading}
+        hideOnMobile={[
+          "attributes.id",
+          "attributes.code",
+          "attributes.url",
+          "attributes.created",
+          "attributes.updated",
+        ]}
+        onRowClick={(entitlement) => navigateToResource(entitlement)}
+      />
+
+      <PageFooter>
+        <Pagination
+          page={table.page}
+          pageCount={totalPages}
+          onPageChange={table.setPage}
+          isLoading={entitlementsLoading || !table.isMeasured}
         />
-      )}
+      </PageFooter>
     </section>
   )
 }

--- a/src/pages/app/group/list.tsx
+++ b/src/pages/app/group/list.tsx
@@ -3,25 +3,40 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 
 import { useGroupTableColumns } from "@/hooks/use-group-table-columns"
-import { useListGroups } from "@/queries/groups"
+import { useDataTable } from "@/hooks/use-data-table"
 import { Group } from "@/types/groups"
+
+import { useListGroups } from "@/queries/groups"
 
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Groups from "@/components/groups"
-import * as Skeletons from "@/components/skeletons"
 import DataTable from "@/components/data-table"
+import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
+import PageFooter from "@/components/page-footer"
 
 export default function GroupsList() {
-  const { data: groups = [], isLoading: groupsLoading } = useListGroups()
+  const table = useDataTable()
   const columns = useGroupTableColumns()
+
+  const {
+    data: groups,
+    links,
+    isLoading: groupsLoading,
+  } = useListGroups({
+    page: table.page,
+    pageSize: table.pageSize,
+  })
+
+  const totalPages = links?.meta?.pages ?? 1
+
   const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
 
   return (
-    <section>
+    <section className="flex h-screen flex-col">
       <PageHeader title="Groups">
         <Button
           size="sm"
@@ -33,22 +48,30 @@ export default function GroupsList() {
         <Groups.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
 
-      {groupsLoading ? (
-        <Skeletons.Table />
-      ) : (
-        <DataTable<Group>
-          data={groups}
-          columns={columns}
-          hideOnMobile={[
-            "id",
-            "attributes.maxUsers",
-            "attributes.maxLicenses",
-            "attributes.maxMachines",
-            "attributes.created",
-          ]}
-          onRowClick={(group) => navigateToResource(group)}
+      <DataTable<Group>
+        data={groups}
+        table={table}
+        columns={columns}
+        pageCount={totalPages}
+        isLoading={groupsLoading}
+        hideOnMobile={[
+          "id",
+          "attributes.maxUsers",
+          "attributes.maxLicenses",
+          "attributes.maxMachines",
+          "attributes.created",
+        ]}
+        onRowClick={(group) => navigateToResource(group)}
+      />
+
+      <PageFooter>
+        <Pagination
+          page={table.page}
+          pageCount={totalPages}
+          onPageChange={table.setPage}
+          isLoading={groupsLoading || !table.isMeasured}
         />
-      )}
+      </PageFooter>
     </section>
   )
 }

--- a/src/pages/app/group/list.tsx
+++ b/src/pages/app/group/list.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { useGroupTableColumns } from "@/hooks/use-group-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
@@ -48,21 +49,23 @@ export default function GroupsList() {
         <Groups.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
 
-      <DataTable<Group>
-        data={groups}
-        table={table}
-        columns={columns}
-        pageCount={totalPages}
-        isLoading={groupsLoading}
-        hideOnMobile={[
-          "id",
-          "attributes.maxUsers",
-          "attributes.maxLicenses",
-          "attributes.maxMachines",
-          "attributes.created",
-        ]}
-        onRowClick={(group) => navigateToResource(group)}
-      />
+      <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
+        <DataTable<Group>
+          data={groups}
+          table={table}
+          columns={columns}
+          pageCount={totalPages}
+          isLoading={groupsLoading}
+          hideOnMobile={[
+            "id",
+            "attributes.maxUsers",
+            "attributes.maxLicenses",
+            "attributes.maxMachines",
+            "attributes.created",
+          ]}
+          onRowClick={(group) => navigateToResource(group)}
+        />
+      </ScrollArea>
 
       <PageFooter>
         <Pagination

--- a/src/pages/app/group/list.tsx
+++ b/src/pages/app/group/list.tsx
@@ -69,7 +69,7 @@ export default function GroupsList() {
           page={table.page}
           pageCount={totalPages}
           onPageChange={table.setPage}
-          isLoading={groupsLoading || !table.isMeasured}
+          isLoading={groupsLoading}
         />
       </PageFooter>
     </section>

--- a/src/pages/app/license/list.tsx
+++ b/src/pages/app/license/list.tsx
@@ -15,6 +15,7 @@ import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
+import { ScrollArea } from "@radix-ui/react-scroll-area"
 
 export default function LicensesList() {
   const table = useDataTable()
@@ -49,28 +50,30 @@ export default function LicensesList() {
 
       <Licenses.Form.Create open={open} onOpenChange={setOpen} />
 
-      <DataTable<License>
-        data={licenses}
-        table={table}
-        columns={columns}
-        pageCount={totalPages}
-        isLoading={licensesLoading}
-        hideOnMobile={[
-          "attributes.key",
-          "relationships.policy",
-          "relationships.product",
-          "attributes.expiry",
-          "attributes.created",
-        ]}
-        onRowClick={(license) => navigateToResource(license)}
-      />
+      <ScrollArea className="h-[calc(100vh-8rem)] overflow-auto">
+        <DataTable<License>
+          data={licenses}
+          table={table}
+          columns={columns}
+          pageCount={totalPages}
+          isLoading={licensesLoading}
+          hideOnMobile={[
+            "attributes.key",
+            "relationships.policy",
+            "relationships.product",
+            "attributes.expiry",
+            "attributes.created",
+          ]}
+          onRowClick={(license) => navigateToResource(license)}
+        />
+      </ScrollArea>
 
       <PageFooter>
         <Pagination
           page={table.page}
           pageCount={totalPages}
           onPageChange={table.setPage}
-          isLoading={licensesLoading || !table.isMeasured}
+          isLoading={licensesLoading}
         />
       </PageFooter>
     </section>

--- a/src/pages/app/license/list.tsx
+++ b/src/pages/app/license/list.tsx
@@ -3,6 +3,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 
 import { useLicenseTableColumns } from "@/hooks/use-license-table-columns"
+import { useDataTable } from "@/hooks/use-data-table"
 import { License } from "@/types/licenses"
 
 import { useListLicenses } from "@/queries/licenses"
@@ -10,19 +11,32 @@ import { useListLicenses } from "@/queries/licenses"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Licenses from "@/components/licenses"
-import * as Skeletons from "@/components/skeletons"
 import DataTable from "@/components/data-table"
+import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
+import PageFooter from "@/components/page-footer"
 
 export default function LicensesList() {
-  const { data: licenses = [], isLoading: licensesLoading } = useListLicenses()
+  const table = useDataTable()
   const columns = useLicenseTableColumns()
+
+  const {
+    data: licenses,
+    links,
+    isLoading: licensesLoading,
+  } = useListLicenses({
+    page: table.page,
+    pageSize: table.pageSize,
+  })
+
+  const totalPages = links?.meta?.pages ?? 1
+
   const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
 
   return (
-    <section>
+    <section className="flex h-screen flex-col">
       <PageHeader title="Licenses">
         <Button
           size="sm"
@@ -35,22 +49,30 @@ export default function LicensesList() {
 
       <Licenses.Form.Create open={open} onOpenChange={setOpen} />
 
-      {licensesLoading ? (
-        <Skeletons.Table />
-      ) : (
-        <DataTable<License>
-          data={licenses}
-          columns={columns}
-          hideOnMobile={[
-            "attributes.key",
-            "relationships.policy",
-            "relationships.product",
-            "attributes.expiry",
-            "attributes.created",
-          ]}
-          onRowClick={(license) => navigateToResource(license)}
+      <DataTable<License>
+        data={licenses}
+        table={table}
+        columns={columns}
+        pageCount={totalPages}
+        isLoading={licensesLoading}
+        hideOnMobile={[
+          "attributes.key",
+          "relationships.policy",
+          "relationships.product",
+          "attributes.expiry",
+          "attributes.created",
+        ]}
+        onRowClick={(license) => navigateToResource(license)}
+      />
+
+      <PageFooter>
+        <Pagination
+          page={table.page}
+          pageCount={totalPages}
+          onPageChange={table.setPage}
+          isLoading={licensesLoading || !table.isMeasured}
         />
-      )}
+      </PageFooter>
     </section>
   )
 }

--- a/src/pages/app/license/list.tsx
+++ b/src/pages/app/license/list.tsx
@@ -50,7 +50,7 @@ export default function LicensesList() {
 
       <Licenses.Form.Create open={open} onOpenChange={setOpen} />
 
-      <ScrollArea className="h-[calc(100vh-8rem)] overflow-auto">
+      <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<License>
           data={licenses}
           table={table}

--- a/src/pages/app/machine/list.tsx
+++ b/src/pages/app/machine/list.tsx
@@ -3,25 +3,40 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 
 import { useMachineTableColumns } from "@/hooks/use-machine-table-columns"
-import { useListMachines } from "@/queries/machines"
+import { useDataTable } from "@/hooks/use-data-table"
 import { Machine } from "@/types/machines"
+
+import { useListMachines } from "@/queries/machines"
 
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Machines from "@/components/machines"
-import * as Skeletons from "@/components/skeletons"
 import DataTable from "@/components/data-table"
+import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
+import PageFooter from "@/components/page-footer"
 
 export default function MachinesList() {
-  const { data: machines = [], isLoading: machinesLoading } = useListMachines()
+  const table = useDataTable()
   const columns = useMachineTableColumns()
+
+  const {
+    data: machines,
+    links,
+    isLoading: machinesLoading,
+  } = useListMachines({
+    page: table.page,
+    pageSize: table.pageSize,
+  })
+
+  const totalPages = links?.meta?.pages ?? 1
+
   const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
 
   return (
-    <section>
+    <section className="flex h-screen flex-col">
       <PageHeader title="Machines">
         <Button
           size="sm"
@@ -34,21 +49,29 @@ export default function MachinesList() {
 
       <Machines.Form.Create open={open} onOpenChange={setOpen} />
 
-      {machinesLoading ? (
-        <Skeletons.Table />
-      ) : (
-        <DataTable<Machine>
-          data={machines}
-          columns={columns}
-          hideOnMobile={[
-            "relationships.license",
-            "relationships.product",
-            "attributes.created",
-            "attributes.updated",
-          ]}
-          onRowClick={(machine) => navigateToResource(machine)}
+      <DataTable<Machine>
+        data={machines}
+        table={table}
+        columns={columns}
+        pageCount={totalPages}
+        isLoading={machinesLoading}
+        hideOnMobile={[
+          "relationships.license",
+          "relationships.product",
+          "attributes.created",
+          "attributes.updated",
+        ]}
+        onRowClick={(machine) => navigateToResource(machine)}
+      />
+
+      <PageFooter>
+        <Pagination
+          page={table.page}
+          pageCount={totalPages}
+          onPageChange={table.setPage}
+          isLoading={machinesLoading || !table.isMeasured}
         />
-      )}
+      </PageFooter>
     </section>
   )
 }

--- a/src/pages/app/machine/list.tsx
+++ b/src/pages/app/machine/list.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { useMachineTableColumns } from "@/hooks/use-machine-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
@@ -49,20 +50,22 @@ export default function MachinesList() {
 
       <Machines.Form.Create open={open} onOpenChange={setOpen} />
 
-      <DataTable<Machine>
-        data={machines}
-        table={table}
-        columns={columns}
-        pageCount={totalPages}
-        isLoading={machinesLoading}
-        hideOnMobile={[
-          "relationships.license",
-          "relationships.product",
-          "attributes.created",
-          "attributes.updated",
-        ]}
-        onRowClick={(machine) => navigateToResource(machine)}
-      />
+      <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
+        <DataTable<Machine>
+          data={machines}
+          table={table}
+          columns={columns}
+          pageCount={totalPages}
+          isLoading={machinesLoading}
+          hideOnMobile={[
+            "relationships.license",
+            "relationships.product",
+            "attributes.created",
+            "attributes.updated",
+          ]}
+          onRowClick={(machine) => navigateToResource(machine)}
+        />
+      </ScrollArea>
 
       <PageFooter>
         <Pagination

--- a/src/pages/app/machine/list.tsx
+++ b/src/pages/app/machine/list.tsx
@@ -69,7 +69,7 @@ export default function MachinesList() {
           page={table.page}
           pageCount={totalPages}
           onPageChange={table.setPage}
-          isLoading={machinesLoading || !table.isMeasured}
+          isLoading={machinesLoading}
         />
       </PageFooter>
     </section>

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { usePolicyTableColumns } from "@/hooks/use-policy-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
@@ -49,20 +50,22 @@ export default function PoliciesList() {
         <Policies.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
 
-      <DataTable<Policy>
-        data={policies}
-        table={table}
-        columns={columns}
-        pageCount={totalPages}
-        isLoading={policiesLoading}
-        hideOnMobile={[
-          "attributes.id",
-          "attributes.url",
-          "attributes.created",
-          "attributes.updated",
-        ]}
-        onRowClick={(policy) => navigateToResource(policy)}
-      />
+      <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
+        <DataTable<Policy>
+          data={policies}
+          table={table}
+          columns={columns}
+          pageCount={totalPages}
+          isLoading={policiesLoading}
+          hideOnMobile={[
+            "attributes.id",
+            "attributes.url",
+            "attributes.created",
+            "attributes.updated",
+          ]}
+          onRowClick={(policy) => navigateToResource(policy)}
+        />
+      </ScrollArea>
 
       <PageFooter>
         <Pagination

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -3,7 +3,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 
 import { usePolicyTableColumns } from "@/hooks/use-policy-table-columns"
-
+import { useDataTable } from "@/hooks/use-data-table"
 import { Policy } from "@/types/policies"
 
 import { useListPolicies } from "@/queries/policies"
@@ -11,19 +11,32 @@ import { useListPolicies } from "@/queries/policies"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Policies from "@/components/policies"
-import * as Skeletons from "@/components/skeletons"
 import DataTable from "@/components/data-table"
+import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
+import PageFooter from "@/components/page-footer"
 
 export default function PoliciesList() {
-  const { data: policies = [], isLoading: policiesLoading } = useListPolicies()
+  const table = useDataTable()
   const columns = usePolicyTableColumns()
+
+  const {
+    data: policies,
+    links,
+    isLoading: policiesLoading,
+  } = useListPolicies({
+    page: table.page,
+    pageSize: table.pageSize,
+  })
+
+  const totalPages = links?.meta?.pages ?? 1
+
   const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
 
   return (
-    <section>
+    <section className="flex h-screen flex-col">
       <PageHeader title="Policies">
         <Button
           size="sm"
@@ -36,21 +49,29 @@ export default function PoliciesList() {
         <Policies.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
 
-      {policiesLoading ? (
-        <Skeletons.Table />
-      ) : (
-        <DataTable<Policy>
-          data={policies}
-          columns={columns}
-          hideOnMobile={[
-            "attributes.id",
-            "attributes.url",
-            "attributes.created",
-            "attributes.updated",
-          ]}
-          onRowClick={(policy) => navigateToResource(policy)}
+      <DataTable<Policy>
+        data={policies}
+        table={table}
+        columns={columns}
+        pageCount={totalPages}
+        isLoading={policiesLoading}
+        hideOnMobile={[
+          "attributes.id",
+          "attributes.url",
+          "attributes.created",
+          "attributes.updated",
+        ]}
+        onRowClick={(policy) => navigateToResource(policy)}
+      />
+
+      <PageFooter>
+        <Pagination
+          page={table.page}
+          pageCount={totalPages}
+          onPageChange={table.setPage}
+          isLoading={policiesLoading || !table.isMeasured}
         />
-      )}
+      </PageFooter>
     </section>
   )
 }

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -69,7 +69,7 @@ export default function PoliciesList() {
           page={table.page}
           pageCount={totalPages}
           onPageChange={table.setPage}
-          isLoading={policiesLoading || !table.isMeasured}
+          isLoading={policiesLoading}
         />
       </PageFooter>
     </section>

--- a/src/pages/app/process/list.tsx
+++ b/src/pages/app/process/list.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { useProcessTableColumns } from "@/hooks/use-process-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
@@ -49,21 +50,23 @@ export default function ProcessesList() {
 
       <Processes.Form.Create open={open} onOpenChange={setOpen} />
 
-      <DataTable<Process>
-        data={processes}
-        table={table}
-        columns={columns}
-        pageCount={totalPages}
-        isLoading={processesLoading}
-        hideOnMobile={[
-          "relationships.machine",
-          "relationships.license",
-          "relationships.product",
-          "attributes.created",
-          "attributes.updated",
-        ]}
-        onRowClick={(process) => navigateToResource(process)}
-      />
+      <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
+        <DataTable<Process>
+          data={processes}
+          table={table}
+          columns={columns}
+          pageCount={totalPages}
+          isLoading={processesLoading}
+          hideOnMobile={[
+            "relationships.machine",
+            "relationships.license",
+            "relationships.product",
+            "attributes.created",
+            "attributes.updated",
+          ]}
+          onRowClick={(process) => navigateToResource(process)}
+        />
+      </ScrollArea>
 
       <PageFooter>
         <Pagination

--- a/src/pages/app/process/list.tsx
+++ b/src/pages/app/process/list.tsx
@@ -70,7 +70,7 @@ export default function ProcessesList() {
           page={table.page}
           pageCount={totalPages}
           onPageChange={table.setPage}
-          isLoading={processesLoading || !table.isMeasured}
+          isLoading={processesLoading}
         />
       </PageFooter>
     </section>

--- a/src/pages/app/process/list.tsx
+++ b/src/pages/app/process/list.tsx
@@ -3,27 +3,40 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 
 import { useProcessTableColumns } from "@/hooks/use-process-table-columns"
-
+import { useDataTable } from "@/hooks/use-data-table"
 import { Process } from "@/types/processes"
+
 import { useListProcesses } from "@/queries/processes"
 
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Processes from "@/components/processes"
-import * as Skeletons from "@/components/skeletons"
 import DataTable from "@/components/data-table"
+import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
+import PageFooter from "@/components/page-footer"
 
 export default function ProcessesList() {
-  const { data: processes = [], isLoading: processesLoading } =
-    useListProcesses()
+  const table = useDataTable()
   const columns = useProcessTableColumns()
+
+  const {
+    data: processes,
+    links,
+    isLoading: processesLoading,
+  } = useListProcesses({
+    page: table.page,
+    pageSize: table.pageSize,
+  })
+
+  const totalPages = links?.meta?.pages ?? 1
+
   const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
 
   return (
-    <section>
+    <section className="flex h-screen flex-col">
       <PageHeader title="Processes">
         <Button
           size="sm"
@@ -36,22 +49,30 @@ export default function ProcessesList() {
 
       <Processes.Form.Create open={open} onOpenChange={setOpen} />
 
-      {processesLoading ? (
-        <Skeletons.Table />
-      ) : (
-        <DataTable<Process>
-          data={processes}
-          columns={columns}
-          hideOnMobile={[
-            "relationships.machine",
-            "relationships.license",
-            "relationships.product",
-            "attributes.created",
-            "attributes.updated",
-          ]}
-          onRowClick={(process) => navigateToResource(process)}
+      <DataTable<Process>
+        data={processes}
+        table={table}
+        columns={columns}
+        pageCount={totalPages}
+        isLoading={processesLoading}
+        hideOnMobile={[
+          "relationships.machine",
+          "relationships.license",
+          "relationships.product",
+          "attributes.created",
+          "attributes.updated",
+        ]}
+        onRowClick={(process) => navigateToResource(process)}
+      />
+
+      <PageFooter>
+        <Pagination
+          page={table.page}
+          pageCount={totalPages}
+          onPageChange={table.setPage}
+          isLoading={processesLoading || !table.isMeasured}
         />
-      )}
+      </PageFooter>
     </section>
   )
 }

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { useProductTableColumns } from "@/hooks/use-product-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
@@ -48,20 +49,22 @@ export default function ProductsList() {
         <Products.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
 
-      <DataTable<Product>
-        data={products}
-        table={table}
-        columns={columns}
-        pageCount={totalPages}
-        isLoading={productsLoading}
-        hideOnMobile={[
-          "attributes.id",
-          "attributes.url",
-          "attributes.created",
-          "attributes.updated",
-        ]}
-        onRowClick={(product) => navigateToResource(product)}
-      />
+      <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
+        <DataTable<Product>
+          data={products}
+          table={table}
+          columns={columns}
+          pageCount={totalPages}
+          isLoading={productsLoading}
+          hideOnMobile={[
+            "attributes.id",
+            "attributes.url",
+            "attributes.created",
+            "attributes.updated",
+          ]}
+          onRowClick={(product) => navigateToResource(product)}
+        />
+      </ScrollArea>
 
       <PageFooter>
         <Pagination

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -68,7 +68,7 @@ export default function ProductsList() {
           page={table.page}
           pageCount={totalPages}
           onPageChange={table.setPage}
-          isLoading={productsLoading || !table.isMeasured}
+          isLoading={productsLoading}
         />
       </PageFooter>
     </section>

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -3,7 +3,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 
 import { useProductTableColumns } from "@/hooks/use-product-table-columns"
-
+import { useDataTable } from "@/hooks/use-data-table"
 import { Product } from "@/types/products"
 
 import { useListProducts } from "@/queries/products"
@@ -11,41 +11,66 @@ import { useListProducts } from "@/queries/products"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Products from "@/components/products"
-import * as Skeletons from "@/components/skeletons"
 import DataTable from "@/components/data-table"
+import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
+import PageFooter from "@/components/page-footer"
 
 export default function ProductsList() {
-  const { data: products = [], isLoading } = useListProducts()
+  const table = useDataTable()
   const columns = useProductTableColumns()
+
+  const {
+    data: products,
+    links,
+    isLoading: productsLoading,
+  } = useListProducts({
+    page: table.page,
+    pageSize: table.pageSize,
+  })
+
+  const totalPages = links?.meta?.pages ?? 1
+
   const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
 
   return (
-    <section>
+    <section className="flex h-screen flex-col">
       <PageHeader title="Products">
-        <Button size="sm" disabled={isLoading} onClick={() => setOpen(true)}>
+        <Button
+          size="sm"
+          disabled={productsLoading}
+          onClick={() => setOpen(true)}
+        >
           New Product
         </Button>
         <Products.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
 
-      {isLoading ? (
-        <Skeletons.Table />
-      ) : (
-        <DataTable<Product>
-          data={products}
-          columns={columns}
-          hideOnMobile={[
-            "attributes.id",
-            "attributes.url",
-            "attributes.created",
-            "attributes.updated",
-          ]}
-          onRowClick={(product) => navigateToResource(product)}
+      <DataTable<Product>
+        data={products}
+        table={table}
+        columns={columns}
+        pageCount={totalPages}
+        isLoading={productsLoading}
+        hideOnMobile={[
+          "attributes.id",
+          "attributes.url",
+          "attributes.created",
+          "attributes.updated",
+        ]}
+        onRowClick={(product) => navigateToResource(product)}
+      />
+
+      <PageFooter>
+        <Pagination
+          page={table.page}
+          pageCount={totalPages}
+          onPageChange={table.setPage}
+          isLoading={productsLoading || !table.isMeasured}
         />
-      )}
+      </PageFooter>
     </section>
   )
 }

--- a/src/pages/app/user/list.tsx
+++ b/src/pages/app/user/list.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { useUserTableColumns } from "@/hooks/use-user-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
@@ -45,20 +46,22 @@ export default function UsersList() {
 
       <Users.Form.Create open={open} onOpenChange={setOpen} />
 
-      <DataTable<User>
-        data={users}
-        table={table}
-        columns={columns}
-        pageCount={totalPages}
-        isLoading={usersLoading}
-        hideOnMobile={[
-          "attributes.fullName",
-          "attributes.role",
-          "attributes.created",
-          "attributes.updated",
-        ]}
-        onRowClick={(user) => navigateToResource(user)}
-      />
+      <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
+        <DataTable<User>
+          data={users}
+          table={table}
+          columns={columns}
+          pageCount={totalPages}
+          isLoading={usersLoading}
+          hideOnMobile={[
+            "attributes.fullName",
+            "attributes.role",
+            "attributes.created",
+            "attributes.updated",
+          ]}
+          onRowClick={(user) => navigateToResource(user)}
+        />
+      </ScrollArea>
 
       <PageFooter>
         <Pagination

--- a/src/pages/app/user/list.tsx
+++ b/src/pages/app/user/list.tsx
@@ -65,7 +65,7 @@ export default function UsersList() {
           page={table.page}
           pageCount={totalPages}
           onPageChange={table.setPage}
-          isLoading={usersLoading || !table.isMeasured}
+          isLoading={usersLoading}
         />
       </PageFooter>
     </section>

--- a/src/pages/app/user/list.tsx
+++ b/src/pages/app/user/list.tsx
@@ -3,25 +3,40 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 
 import { useUserTableColumns } from "@/hooks/use-user-table-columns"
-import { useListUsers } from "@/queries/users"
+import { useDataTable } from "@/hooks/use-data-table"
 import { User } from "@/types/users"
+
+import { useListUsers } from "@/queries/users"
 
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Users from "@/components/users"
-import * as Skeletons from "@/components/skeletons"
 import DataTable from "@/components/data-table"
+import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
+import PageFooter from "@/components/page-footer"
 
 export default function UsersList() {
-  const { data: users = [], isLoading: usersLoading } = useListUsers()
+  const table = useDataTable()
   const columns = useUserTableColumns()
+
+  const {
+    data: users,
+    links,
+    isLoading: usersLoading,
+  } = useListUsers({
+    page: table.page,
+    pageSize: table.pageSize,
+  })
+
+  const totalPages = links?.meta?.pages ?? 1
+
   const navigateToResource = useResourceNavigate()
 
   const [open, setOpen] = useState(false)
 
   return (
-    <section>
+    <section className="flex h-screen flex-col">
       <PageHeader title="Users">
         <Button size="sm" disabled={usersLoading} onClick={() => setOpen(true)}>
           New User
@@ -30,21 +45,29 @@ export default function UsersList() {
 
       <Users.Form.Create open={open} onOpenChange={setOpen} />
 
-      {usersLoading ? (
-        <Skeletons.Table />
-      ) : (
-        <DataTable<User>
-          data={users}
-          columns={columns}
-          hideOnMobile={[
-            "attributes.fullName",
-            "attributes.role",
-            "attributes.created",
-            "attributes.updated",
-          ]}
-          onRowClick={(user) => navigateToResource(user)}
+      <DataTable<User>
+        data={users}
+        table={table}
+        columns={columns}
+        pageCount={totalPages}
+        isLoading={usersLoading}
+        hideOnMobile={[
+          "attributes.fullName",
+          "attributes.role",
+          "attributes.created",
+          "attributes.updated",
+        ]}
+        onRowClick={(user) => navigateToResource(user)}
+      />
+
+      <PageFooter>
+        <Pagination
+          page={table.page}
+          pageCount={totalPages}
+          onPageChange={table.setPage}
+          isLoading={usersLoading || !table.isMeasured}
         />
-      )}
+      </PageFooter>
     </section>
   )
 }

--- a/src/queries/components.ts
+++ b/src/queries/components.ts
@@ -1,4 +1,9 @@
-import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query"
 
 import { useEnvironment } from "@/hooks/use-environment"
 
@@ -28,14 +33,30 @@ export function useGetComponent(componentId: string) {
   })
 }
 
-export function useListComponents() {
+export function useListComponents(params?: { page: number; pageSize: number }) {
   const { code } = useEnvironment()
 
-  return useQuery({
-    queryKey: ["components", { environment: code }],
-    queryFn: () =>
-      keygen.components.list({}).then((response) => response.data ?? []),
+  const query = useQuery({
+    queryKey: ["components", { environment: code, ...params }],
+    queryFn: async () => {
+      const response = await keygen.components.list(
+        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+      )
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response
+    },
+    placeholderData: params ? keepPreviousData : undefined,
   })
+
+  return {
+    ...query,
+    data: query.data?.data ?? [],
+    links: query.data?.links,
+  }
 }
 
 export function useCreateComponent() {

--- a/src/queries/entitlements.ts
+++ b/src/queries/entitlements.ts
@@ -1,4 +1,9 @@
-import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query"
 
 import { useEnvironment } from "@/hooks/use-environment"
 
@@ -28,14 +33,33 @@ export function useGetEntitlement(entitlementId: string) {
   })
 }
 
-export function useListEntitlements() {
+export function useListEntitlements(params?: {
+  page: number
+  pageSize: number
+}) {
   const { code } = useEnvironment()
 
-  return useQuery({
-    queryKey: ["entitlements", { environment: code }],
-    queryFn: () =>
-      keygen.entitlements.list({}).then((response) => response.data ?? []),
+  const query = useQuery({
+    queryKey: ["entitlements", { environment: code, ...params }],
+    queryFn: async () => {
+      const response = await keygen.entitlements.list(
+        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+      )
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response
+    },
+    placeholderData: params ? keepPreviousData : undefined,
   })
+
+  return {
+    ...query,
+    data: query.data?.data ?? [],
+    links: query.data?.links,
+  }
 }
 
 export function useCreateEntitlement() {

--- a/src/queries/environments.ts
+++ b/src/queries/environments.ts
@@ -1,4 +1,9 @@
-import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+import {
+  useQuery,
+  useQueryClient,
+  useMutation,
+  keepPreviousData,
+} from "@tanstack/react-query"
 
 import * as Schemas from "@/schemas"
 import { Environment } from "@/types/environments"
@@ -18,12 +23,31 @@ export function useGetEnvironment(environmentId: string) {
   })
 }
 
-export function useListEnvironments() {
-  return useQuery({
-    queryKey: ["environments"],
-    queryFn: () =>
-      keygen.environments.list({}).then((response) => response.data ?? []),
+export function useListEnvironments(params?: {
+  page: number
+  pageSize: number
+}) {
+  const query = useQuery({
+    queryKey: ["environments", { ...params }],
+    queryFn: async () => {
+      const response = await keygen.environments.list(
+        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+      )
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response
+    },
+    placeholderData: params ? keepPreviousData : undefined,
   })
+
+  return {
+    ...query,
+    data: query.data?.data ?? [],
+    links: query.data?.links,
+  }
 }
 
 export function useCreateEnvironment() {

--- a/src/queries/groups.ts
+++ b/src/queries/groups.ts
@@ -1,4 +1,9 @@
-import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query"
 
 import { useEnvironment } from "@/hooks/use-environment"
 
@@ -30,14 +35,30 @@ export function useGetGroup(groupId: string) {
   })
 }
 
-export function useListGroups() {
+export function useListGroups(params?: { page: number; pageSize: number }) {
   const { code } = useEnvironment()
 
-  return useQuery({
-    queryKey: ["groups", { environment: code }],
-    queryFn: () =>
-      keygen.groups.list({}).then((response) => response.data ?? []),
+  const query = useQuery({
+    queryKey: ["groups", { environment: code, ...params }],
+    queryFn: async () => {
+      const response = await keygen.groups.list(
+        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+      )
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response
+    },
+    placeholderData: params ? keepPreviousData : undefined,
   })
+
+  return {
+    ...query,
+    data: query.data?.data ?? [],
+    links: query.data?.links,
+  }
 }
 
 export function useCreateGroup() {

--- a/src/queries/licenses.ts
+++ b/src/queries/licenses.ts
@@ -1,4 +1,9 @@
-import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query"
 
 import { useEnvironment } from "@/hooks/use-environment"
 
@@ -29,14 +34,30 @@ export function useGetLicense(licenseId: string) {
   })
 }
 
-export function useListLicenses() {
+export function useListLicenses(params?: { page: number; pageSize: number }) {
   const { code } = useEnvironment()
 
-  return useQuery({
-    queryKey: ["licenses", { environment: code }],
-    queryFn: () =>
-      keygen.licenses.list({}).then((response) => response.data ?? []),
+  const query = useQuery({
+    queryKey: ["licenses", { environment: code, ...params }],
+    queryFn: async () => {
+      const response = await keygen.licenses.list(
+        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+      )
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response
+    },
+    placeholderData: params ? keepPreviousData : undefined,
   })
+
+  return {
+    ...query,
+    data: query.data?.data ?? [],
+    links: query.data?.links,
+  }
 }
 
 export function useCreateLicense() {
@@ -64,15 +85,14 @@ export function useCreateLicense() {
       return license
     },
 
-    onSuccess: (newLicense) => {
-      queryClient.setQueryData<License[]>(
-        ["licenses", { environment: code }],
-        (old) => (old ? [newLicense, ...old] : [newLicense]),
-      )
+    onSuccess: async (newLicense) => {
       queryClient.setQueryData(
         ["licenses", newLicense.id, { environment: code }],
         newLicense,
       )
+      await queryClient.invalidateQueries({
+        queryKey: ["licenses", { environment: code }],
+      })
     },
   })
 }

--- a/src/queries/machines.ts
+++ b/src/queries/machines.ts
@@ -1,4 +1,9 @@
-import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query"
 
 import { useEnvironment } from "@/hooks/use-environment"
 
@@ -29,14 +34,30 @@ export function useGetMachine(machineId: string) {
   })
 }
 
-export function useListMachines() {
+export function useListMachines(params?: { page: number; pageSize: number }) {
   const { code } = useEnvironment()
 
-  return useQuery({
-    queryKey: ["machines", { environment: code }],
-    queryFn: () =>
-      keygen.machines.list({}).then((response) => response.data ?? []),
+  const query = useQuery({
+    queryKey: ["machines", { environment: code, ...params }],
+    queryFn: async () => {
+      const response = await keygen.machines.list(
+        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+      )
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response
+    },
+    placeholderData: params ? keepPreviousData : undefined,
   })
+
+  return {
+    ...query,
+    data: query.data?.data ?? [],
+    links: query.data?.links,
+  }
 }
 
 export function useCreateMachine() {

--- a/src/queries/policies.ts
+++ b/src/queries/policies.ts
@@ -1,4 +1,9 @@
-import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query"
 
 import { useEnvironment } from "@/hooks/use-environment"
 
@@ -28,14 +33,30 @@ export function useGetPolicy(policyId: string) {
   })
 }
 
-export function useListPolicies() {
+export function useListPolicies(params?: { page: number; pageSize: number }) {
   const { code } = useEnvironment()
 
-  return useQuery({
-    queryKey: ["policies", { environment: code }],
-    queryFn: () =>
-      keygen.policies.list({}).then((response) => response.data ?? []),
+  const query = useQuery({
+    queryKey: ["policies", { environment: code, ...params }],
+    queryFn: async () => {
+      const response = await keygen.policies.list(
+        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+      )
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response
+    },
+    placeholderData: params ? keepPreviousData : undefined,
   })
+
+  return {
+    ...query,
+    data: query.data?.data ?? [],
+    links: query.data?.links,
+  }
 }
 
 export function useCreatePolicy() {

--- a/src/queries/processes.ts
+++ b/src/queries/processes.ts
@@ -1,4 +1,9 @@
-import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query"
 
 import { useEnvironment } from "@/hooks/use-environment"
 
@@ -28,14 +33,30 @@ export function useGetProcess(processId: string) {
   })
 }
 
-export function useListProcesses() {
+export function useListProcesses(params?: { page: number; pageSize: number }) {
   const { code } = useEnvironment()
 
-  return useQuery({
-    queryKey: ["processes", { environment: code }],
-    queryFn: () =>
-      keygen.processes.list({}).then((response) => response.data ?? []),
+  const query = useQuery({
+    queryKey: ["processes", { environment: code, ...params }],
+    queryFn: async () => {
+      const response = await keygen.processes.list(
+        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+      )
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response
+    },
+    placeholderData: params ? keepPreviousData : undefined,
   })
+
+  return {
+    ...query,
+    data: query.data?.data ?? [],
+    links: query.data?.links,
+  }
 }
 
 export function useCreateProcess() {

--- a/src/queries/products.ts
+++ b/src/queries/products.ts
@@ -1,4 +1,9 @@
-import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query"
 
 import { useEnvironment } from "@/hooks/use-environment"
 
@@ -27,14 +32,30 @@ export function useGetProduct(productId: string) {
   })
 }
 
-export function useListProducts() {
+export function useListProducts(params?: { page: number; pageSize: number }) {
   const { code } = useEnvironment()
 
-  return useQuery({
-    queryKey: ["products", { environment: code }],
-    queryFn: () =>
-      keygen.products.list({}).then((response) => response.data ?? []),
+  const query = useQuery({
+    queryKey: ["products", { environment: code, ...params }],
+    queryFn: async () => {
+      const response = await keygen.products.list(
+        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+      )
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response
+    },
+    placeholderData: params ? keepPreviousData : undefined,
   })
+
+  return {
+    ...query,
+    data: query.data?.data ?? [],
+    links: query.data?.links,
+  }
 }
 
 export function useCreateProduct() {

--- a/src/queries/users.ts
+++ b/src/queries/users.ts
@@ -1,4 +1,9 @@
-import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query"
 
 import { useEnvironment } from "@/hooks/use-environment"
 
@@ -28,14 +33,30 @@ export function useGetUser(userId: string) {
   })
 }
 
-export function useListUsers() {
+export function useListUsers(params?: { page: number; pageSize: number }) {
   const { code } = useEnvironment()
 
-  return useQuery({
-    queryKey: ["users", { environment: code }],
-    queryFn: () =>
-      keygen.users.list({}).then((response) => response.data ?? []),
+  const query = useQuery({
+    queryKey: ["users", { environment: code, ...params }],
+    queryFn: async () => {
+      const response = await keygen.users.list(
+        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+      )
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response
+    },
+    placeholderData: params ? keepPreviousData : undefined,
   })
+
+  return {
+    ...query,
+    data: query.data?.data ?? [],
+    links: query.data?.links,
+  }
 }
 
 export function useCreateUser() {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -60,6 +60,14 @@ export class APIError extends Error {
 export interface Link {
   related?: string | null
   self?: string | null
+  prev?: string | null
+  next?: string | null
+  first?: string | null
+  last?: string | null
+  meta?: {
+    pages?: number
+    count?: number
+  }
 }
 
 export interface Linkage<T extends string = string> {


### PR DESCRIPTION
Refactors pagination across all list pages from client-side to server-side ~~and dynamically calculates page size based on available container height/row height, so that lists fill the viewport regardless of screen size/mobile~~ *removed dynamic sizing in favor of static values*.

Also adds a `useDataTable` hook that manages page state, as well as a `Pagination` component for pagination buttons and `PageFooter` for layout, similar to `PageHeader`.

https://github.com/user-attachments/assets/fd20ec8a-dd86-4411-a3a6-d3d0fc4048ae