### PR TITLE
Update durations to use seconds based on gregorian year

### DIFF
--- a/src/components/duration-input.tsx
+++ b/src/components/duration-input.tsx
@@ -22,8 +22,8 @@ const SecondsPerMinute = 60
 const SecondsPerHour = 3600
 const SecondsPerDay = 86400
 const SecondsPerWeek = 604800
-const SecondsPerMonth = 2592000
-const SecondsPerYear = 31536000
+const SecondsPerMonth = 2629746
+const SecondsPerYear = 31556952
 
 type Unit = { key: string; label: string; seconds: number | null }
 


### PR DESCRIPTION
The old UI used the wrong value for a 1-year duration (`31536000`, or 365 days). When doing time arithmetic, Rails interprets durations using calendar constants, where a year is `31556952` seconds (which is the average Gregorian year). Because of this, `31536000` was decomposed into mixed units, 11 months, 4 weeks, and 2 days plus some change, which produced incorrect expiry times based on the license's created timestamp, i.e. it'd be off by a couple days.

The fix was to update the UI to use `31556952` for a year so Rails interprets it correctly as `1.year`. Longer term, durations will likely move to ISO8601 format (e.g. `P1Y`) to avoid these ambiguities. This PR applies the same fix to Portal, and also fixes the month duration, since it needs to be 1 Gregorian year / 12.

Ref: https://discord.com/channels/1101524251040829450/1101524251040829453/1482024332203917313