### PR TITLE
Add horizontal table scrolling

### DIFF
--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -1,15 +1,21 @@
-import { useState, useEffect, useRef } from "react"
+import {
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useMemo,
+  useCallback,
+} from "react"
 import {
   flexRender,
   SortingState,
   useReactTable,
   getCoreRowModel,
   getSortedRowModel,
-  getPaginationRowModel,
 } from "@tanstack/react-table"
 
+import { Button } from "@/components/ui/button"
 import {
-  Table,
   TableHeader,
   TableHead,
   TableRow,
@@ -17,7 +23,13 @@ import {
   TableCell,
 } from "@/components/ui/table"
 
-import { ChevronUp, ChevronDown, ChevronsUpDown } from "lucide-react"
+import {
+  ChevronUp,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsUpDown,
+} from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { TableColumns, TableResource } from "@/lib/tables"
@@ -33,7 +45,7 @@ type DataTableProps<T extends TableResource> = {
   table: DataTableState
   columns: TableColumns<T>
   onRowClick?: (row: T) => void
-  hideOnMobile?: string[]
+  staticColumns?: number
   pageCount: number
   isLoading?: boolean
   className?: string
@@ -44,12 +56,14 @@ export default function DataTable<T extends TableResource>({
   table,
   columns,
   onRowClick,
-  hideOnMobile = [],
+  staticColumns = 1,
   pageCount,
   isLoading = false,
   className,
 }: DataTableProps<T>): React.ReactElement {
   const isMobile = useMobile()
+
+  const [sorting, setSorting] = useState<SortingState>([])
 
   // Track which pages have already animated so revisiting doesn't animate again
   const prevPageRef = useRef(table.page)
@@ -64,26 +78,19 @@ export default function DataTable<T extends TableResource>({
 
   const shouldAnimate = !animatedPagesRef.current.has(table.page)
 
-  // TODO(cazden) Refactor this with horizontal scroll (#47)
-  // Column visibility
-  const [sorting, setSorting] = useState<SortingState>([])
-  const [columnVisibility, setColumnVisibility] = useState<
-    Record<string, boolean>
-  >({})
+  // Horizontal scroll state
+  const [scrollIndex, setScrollIndex] = useState(0) // Which scrollable column we've scrolled past
+  const [availableWidth, setAvailableWidth] = useState(0) // Determine if columns overflow and how much to scroll
+  const containerRef = useRef<HTMLDivElement>(null) // For measuring available container width and observing resizes (e.g. sidebar toggle)
 
-  // Toggle column visibility based on mobile breakpoint
-  useEffect(() => {
-    const next: Record<string, boolean> = {}
-    hideOnMobile.forEach((k) => (next[String(k)] = !isMobile))
-    setColumnVisibility(next)
-  }, [isMobile, hideOnMobile])
+  const [columnWidths, setColumnWidths] = useState<number[]>([]) // Widths of each column for calculating scroll offsets
+  const headerCellRefs = useRef<(HTMLTableCellElement | null)[]>([]) // For measuring rendered header cell widths to determine column widths
 
   const tableInstance = useReactTable({
     data,
     columns,
     state: {
       sorting,
-      columnVisibility,
       pagination: { pageIndex: table.page - 1, pageSize: table.pageSize },
     },
     manualPagination: true,
@@ -97,15 +104,127 @@ export default function DataTable<T extends TableResource>({
       table.setPage(next.pageIndex + 1)
     },
     onSortingChange: setSorting,
-    onColumnVisibilityChange: setColumnVisibility,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    initialState: { pagination: { pageSize: table.pageSize } },
   })
 
+  const effectiveStaticColumns = isMobile ? 1 : Math.max(1, staticColumns)
+  const tableColumns = tableInstance.getVisibleFlatColumns()
+  const clampedStaticColumns = Math.min(
+    effectiveStaticColumns,
+    tableColumns.length,
+  )
+
+  // Column positions used to calculate how far to shift when scrolling
+  const columnOffsets = useMemo(() => {
+    const offsets = [0]
+    for (let i = 0; i < columnWidths.length; i++) {
+      offsets.push(offsets[i] + columnWidths[i])
+    }
+    return offsets
+  }, [columnWidths])
+  const totalColumnsWidth = columnOffsets[columnWidths.length] ?? 0
+
+  // FIXME(cazden) Remove the +2 hack
+  const allColumnsVisible =
+    columnWidths.length === 0 || availableWidth + 2 >= totalColumnsWidth
+
+  const maxScrollOffset = Math.max(0, totalColumnsWidth - availableWidth)
+  const unclampedScrollOffset =
+    columnWidths.length > 0
+      ? (columnOffsets[clampedStaticColumns + scrollIndex] ??
+          columnOffsets[columnWidths.length] ??
+          0) - (columnOffsets[clampedStaticColumns] ?? 0)
+      : 0
+  const scrollOffset = Math.min(unclampedScrollOffset, maxScrollOffset)
+
+  const scrollableColumnCount = tableColumns.length - clampedStaticColumns
+
+  // Last static column gets scroll buttons in header
+  const lastStaticColumnId = tableColumns[clampedStaticColumns - 1]?.id ?? null
+
+  const canScrollLeft = scrollIndex > 0
+  const canScrollRight = !allColumnsVisible && scrollOffset < maxScrollOffset
+
+  // Reset horizontal scroll when changing pages
+  useEffect(() => {
+    setScrollIndex(0)
+  }, [table.page])
+
+  // Clamp scroll index if columns change and we have fewer columns to scroll through
+  useEffect(() => {
+    if (scrollIndex > scrollableColumnCount) {
+      setScrollIndex(scrollableColumnCount)
+    }
+  }, [scrollIndex, scrollableColumnCount])
+
+  // Read offset width from each header cell to get rendered widths
+  const measureColumns = useCallback(() => {
+    const widths = headerCellRefs.current
+      .slice(0, tableColumns.length)
+      .map((element) => element?.offsetWidth ?? 0)
+
+    if (widths.length > 0 && widths.some((w) => w > 0)) {
+      setColumnWidths(widths)
+    }
+  }, [tableColumns.length])
+
+  // Measure columns and container width on initial render to determine if scroll buttons are needed and how much to scroll
+  useLayoutEffect(() => {
+    measureColumns()
+
+    const container = containerRef.current
+    if (container) {
+      setAvailableWidth(container.getBoundingClientRect().width)
+    }
+  }, [
+    tableColumns.length,
+    data,
+    isMobile,
+    clampedStaticColumns,
+    measureColumns,
+  ])
+
+  // Measure on container resize (e.g. sidebar toggle)
+  useEffect(() => {
+    const container = containerRef.current
+
+    function measure() {
+      if (container) {
+        setAvailableWidth(container.getBoundingClientRect().width)
+      }
+
+      measureColumns()
+    }
+
+    measure()
+
+    const observer = new ResizeObserver(measure)
+    if (container) observer.observe(container)
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [data, table.page, measureColumns])
+
+  function getCellStyle(columnIndex: number): React.CSSProperties | undefined {
+    // Render static columns above scrollable so they don't get visually cut off when scrolling
+    if (columnIndex < clampedStaticColumns) {
+      return {
+        position: "relative",
+        zIndex: clampedStaticColumns - columnIndex + 1,
+      }
+    }
+
+    // Shift scrollable columns left
+    return {
+      transform: `translateX(-${scrollOffset}px)`,
+      transition: "transform 300ms ease",
+    }
+  }
+
   return (
-    <div className={cn("relative flex flex-1 flex-col", className)}>
+    <div className={cn("relative flex min-w-0 flex-1 flex-col", className)}>
       <Skeletons.Table
         className={cn(
           !isLoading && "absolute opacity-0 transition-opacity duration-500",
@@ -116,87 +235,157 @@ export default function DataTable<T extends TableResource>({
         className={cn(
           isLoading
             ? "absolute opacity-0"
-            : "flex min-h-0 flex-1 flex-col opacity-100 transition-opacity duration-200",
+            : "flex min-h-0 min-w-0 flex-1 flex-col opacity-100 transition-opacity duration-200",
         )}
       >
         <Motion.Slide
           direction={directionRef.current}
-          className="min-h-0 flex-1 px-4"
+          className="min-h-0 min-w-0 flex-1 px-2"
         >
-          <Table key={table.page}>
-            <TableHeader>
-              {tableInstance.getHeaderGroups().map((group) => (
-                <TableRow key={group.id} className="hover:bg-transparent">
-                  {group.headers.map((header) => {
-                    const canSort = header.column.getCanSort()
-                    const direction = header.column.getIsSorted()
+          <div
+            ref={containerRef}
+            className="relative overflow-hidden"
+            style={{ contain: "inline-size" }}
+          >
+            <div key={table.page} className="relative w-full">
+              <table className="min-w-full border-separate border-spacing-0 text-sm">
+                <TableHeader>
+                  {tableInstance.getHeaderGroups().map((group) => (
+                    <TableRow key={group.id}>
+                      {group.headers.map((header, columnIndex) => {
+                        const canSort = header.column.getCanSort()
+                        const direction = header.column.getIsSorted()
+                        const totalColumns = group.headers.length
 
-                    return (
-                      <TableHead
-                        key={header.id}
-                        onClick={header.column.getToggleSortingHandler()}
-                        className="text-sm select-none md:text-xs"
-                      >
-                        <div className="flex items-center gap-2">
-                          {flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
+                        return (
+                          <TableHead
+                            key={header.id}
+                            ref={(element) => {
+                              headerCellRefs.current[columnIndex] = element
+                            }}
+                            className={cn(
+                              "cursor-auto border-b border-accent bg-background text-sm select-none md:text-xs",
+                              columnIndex < totalColumns - 1 && "border-r",
+                            )}
+                            style={getCellStyle(columnIndex)}
+                          >
+                            <div className="flex items-center gap-2">
+                              {/* Sort button */}
+                              <Button
+                                variant="ghost"
+                                className={cn(
+                                  "flex h-6 items-center gap-2 rounded-sm px-1! text-xs",
+                                  canSort && "cursor-pointer",
+                                )}
+                                onClick={header.column.getToggleSortingHandler()}
+                              >
+                                {flexRender(
+                                  header.column.columnDef.header,
+                                  header.getContext(),
+                                )}
+                                {canSort &&
+                                  (!direction ? (
+                                    <ChevronsUpDown className="size-4 md:size-3" />
+                                  ) : direction === "asc" ? (
+                                    <ChevronUp className="size-4 text-brand-primary md:size-3" />
+                                  ) : (
+                                    <ChevronDown className="size-4 text-brand-primary md:size-3" />
+                                  ))}
+                              </Button>
+
+                              {/* Scroll buttons */}
+                              {header.column.id === lastStaticColumnId && (
+                                <div
+                                  className="ml-auto flex items-center gap-0.5"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-6 w-6"
+                                    disabled={!canScrollLeft}
+                                    onClick={() => setScrollIndex((i) => i - 1)}
+                                  >
+                                    <ChevronLeft className="h-3 w-3" />
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-6 w-6"
+                                    disabled={!canScrollRight}
+                                    onClick={() => setScrollIndex((i) => i + 1)}
+                                  >
+                                    <ChevronRight className="h-3 w-3" />
+                                  </Button>
+                                </div>
+                              )}
+                            </div>
+                          </TableHead>
+                        )
+                      })}
+                    </TableRow>
+                  ))}
+                </TableHeader>
+
+                <TableBody className="text-base md:text-sm">
+                  {tableInstance.getRowModel().rows.length ? (
+                    tableInstance.getRowModel().rows.map((row, index) => {
+                      const cells = row.getVisibleCells()
+                      return (
+                        <TableRow
+                          key={row.id}
+                          onClick={() => onRowClick?.(row.original)}
+                          className={cn(
+                            shouldAnimate &&
+                              "border-b-0 animate-in [animation-duration:500ms] fade-in fill-mode-backwards",
+                            onRowClick && "cursor-pointer",
                           )}
-                          {canSort &&
-                            (!direction ? (
-                              <ChevronsUpDown className="size-4 md:size-3" />
-                            ) : direction === "asc" ? (
-                              <ChevronUp className="size-4 text-brand-primary md:size-3" />
-                            ) : (
-                              <ChevronDown className="size-4 text-brand-primary md:size-3" />
-                            ))}
-                        </div>
-                      </TableHead>
-                    )
-                  })}
-                </TableRow>
-              ))}
-            </TableHeader>
-
-            <TableBody className="text-base md:text-sm">
-              {tableInstance.getRowModel().rows.length ? (
-                tableInstance.getRowModel().rows.map((row, index) => (
-                  <TableRow
-                    key={row.id}
-                    onClick={() => onRowClick?.(row.original)}
-                    className={cn(
-                      shouldAnimate &&
-                        "animate-in [animation-duration:500ms] fade-in fill-mode-backwards",
-                      onRowClick && "cursor-pointer",
-                    )}
-                    style={
-                      shouldAnimate
-                        ? { animationDelay: `${index * 30}ms` }
-                        : undefined
-                    }
-                  >
-                    {row.getVisibleCells().map((cell) => (
-                      <TableCell key={cell.id}>
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext(),
-                        )}
+                          style={
+                            shouldAnimate
+                              ? { animationDelay: `${index * 30}ms` }
+                              : undefined
+                          }
+                        >
+                          {cells.map((cell, columnIndex) => (
+                            <TableCell
+                              key={cell.id}
+                              className={cn(
+                                "border-b border-accent bg-background",
+                                columnIndex < cells.length - 1 && "border-r",
+                              )}
+                              style={getCellStyle(columnIndex)}
+                            >
+                              {flexRender(
+                                cell.column.columnDef.cell,
+                                cell.getContext(),
+                              )}
+                            </TableCell>
+                          ))}
+                        </TableRow>
+                      )
+                    })
+                  ) : (
+                    <TableRow className="pointer-events-none">
+                      <TableCell
+                        colSpan={tableColumns.length}
+                        className="h-24 text-center text-content-subdued"
+                      >
+                        Nothing here yet.
                       </TableCell>
-                    ))}
-                  </TableRow>
-                ))
-              ) : (
-                <TableRow className="pointer-events-none">
-                  <TableCell
-                    colSpan={tableInstance.getVisibleFlatColumns().length}
-                    className="h-24 text-center text-content-subdued"
-                  >
-                    Nothing here yet.
-                  </TableCell>
-                </TableRow>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </table>
+            </div>
+
+            {/* Gradient hint */}
+            <div
+              className={cn(
+                "pointer-events-none absolute inset-y-0 right-0 z-10 w-24 bg-gradient-to-l from-secondary/10 to-transparent transition-opacity duration-300",
+                canScrollRight ? "opacity-100" : "opacity-0",
               )}
-            </TableBody>
-          </Table>
+            />
+          </div>
         </Motion.Slide>
       </div>
     </div>

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -140,9 +140,6 @@ export default function DataTable<T extends TableResource>({
 
   const scrollableColumnCount = tableColumns.length - clampedStaticColumns
 
-  // Last static column gets scroll buttons in header
-  const lastStaticColumnId = tableColumns[clampedStaticColumns - 1]?.id ?? null
-
   const canScrollLeft = scrollIndex > 0
   const canScrollRight = !allColumnsVisible && scrollOffset < maxScrollOffset
 
@@ -150,13 +147,6 @@ export default function DataTable<T extends TableResource>({
   useEffect(() => {
     setScrollIndex(0)
   }, [table.page])
-
-  // Clamp scroll index if columns change and we have fewer columns to scroll through
-  useEffect(() => {
-    if (scrollIndex > scrollableColumnCount) {
-      setScrollIndex(scrollableColumnCount)
-    }
-  }, [scrollIndex, scrollableColumnCount])
 
   // Read offset width from each header cell to get rendered widths
   const measureColumns = useCallback(() => {
@@ -196,8 +186,6 @@ export default function DataTable<T extends TableResource>({
 
       measureColumns()
     }
-
-    measure()
 
     const observer = new ResizeObserver(measure)
     if (container) observer.observe(container)
@@ -255,7 +243,6 @@ export default function DataTable<T extends TableResource>({
                       {group.headers.map((header, columnIndex) => {
                         const canSort = header.column.getCanSort()
                         const direction = header.column.getIsSorted()
-                        const totalColumns = group.headers.length
 
                         return (
                           <TableHead
@@ -265,7 +252,8 @@ export default function DataTable<T extends TableResource>({
                             }}
                             className={cn(
                               "cursor-auto border-b border-accent bg-background text-sm select-none md:text-xs",
-                              columnIndex < totalColumns - 1 && "border-r",
+                              columnIndex < group.headers.length - 1 &&
+                                "border-r",
                               columnIndex === clampedStaticColumns - 1 &&
                                 "after:pointer-events-none after:absolute after:inset-y-0 after:left-full after:w-6 after:bg-gradient-to-r after:from-secondary/5 after:to-transparent after:transition-opacity after:duration-300 after:md:w-24",
                               columnIndex === clampedStaticColumns - 1 &&
@@ -300,7 +288,7 @@ export default function DataTable<T extends TableResource>({
                               </Button>
 
                               {/* Scroll buttons */}
-                              {header.column.id === lastStaticColumnId && (
+                              {columnIndex === clampedStaticColumns - 1 && (
                                 <div
                                   className="ml-auto flex items-center gap-0.5"
                                   onClick={(e) => e.stopPropagation()}
@@ -310,7 +298,9 @@ export default function DataTable<T extends TableResource>({
                                     size="icon"
                                     className="h-6 w-6"
                                     disabled={!canScrollLeft}
-                                    onClick={() => setScrollIndex((i) => i - 1)}
+                                    onClick={() =>
+                                      setScrollIndex((i) => Math.max(i - 1, 0))
+                                    }
                                   >
                                     <ChevronLeft className="h-3 w-3" />
                                   </Button>
@@ -319,7 +309,11 @@ export default function DataTable<T extends TableResource>({
                                     size="icon"
                                     className="h-6 w-6"
                                     disabled={!canScrollRight}
-                                    onClick={() => setScrollIndex((i) => i + 1)}
+                                    onClick={() =>
+                                      setScrollIndex((i) =>
+                                        Math.min(i + 1, scrollableColumnCount),
+                                      )
+                                    }
                                   >
                                     <ChevronRight className="h-3 w-3" />
                                   </Button>

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -178,11 +178,11 @@ export default function DataTable<T extends TableResource>({
       setAvailableWidth(container.getBoundingClientRect().width)
     }
   }, [
-    tableColumns.length,
     data,
     isMobile,
-    clampedStaticColumns,
     measureColumns,
+    tableColumns.length,
+    clampedStaticColumns,
   ])
 
   // Measure on container resize (e.g. sidebar toggle)
@@ -207,7 +207,7 @@ export default function DataTable<T extends TableResource>({
     }
   }, [data, table.page, measureColumns])
 
-  function getCellStyle(columnIndex: number): React.CSSProperties | undefined {
+  function getCellStyle(columnIndex: number): React.CSSProperties {
     // Render static columns above scrollable so they don't get visually cut off when scrolling
     if (columnIndex < clampedStaticColumns) {
       return {
@@ -266,6 +266,12 @@ export default function DataTable<T extends TableResource>({
                             className={cn(
                               "cursor-auto border-b border-accent bg-background text-sm select-none md:text-xs",
                               columnIndex < totalColumns - 1 && "border-r",
+                              columnIndex === clampedStaticColumns - 1 &&
+                                "after:pointer-events-none after:absolute after:inset-y-0 after:left-full after:w-6 after:bg-gradient-to-r after:from-secondary/5 after:to-transparent after:transition-opacity after:duration-300 after:md:w-24",
+                              columnIndex === clampedStaticColumns - 1 &&
+                                (canScrollLeft
+                                  ? "after:opacity-100"
+                                  : "after:opacity-0"),
                             )}
                             style={getCellStyle(columnIndex)}
                           >
@@ -352,6 +358,12 @@ export default function DataTable<T extends TableResource>({
                               className={cn(
                                 "border-b border-accent bg-background",
                                 columnIndex < cells.length - 1 && "border-r",
+                                columnIndex === clampedStaticColumns - 1 &&
+                                  "after:pointer-events-none after:absolute after:inset-y-0 after:left-full after:w-6 after:bg-gradient-to-r after:from-secondary/5 after:to-transparent after:transition-opacity after:duration-300 after:md:w-24",
+                                columnIndex === clampedStaticColumns - 1 &&
+                                  (canScrollLeft
+                                    ? "after:opacity-100"
+                                    : "after:opacity-0"),
                               )}
                               style={getCellStyle(columnIndex)}
                             >
@@ -381,7 +393,7 @@ export default function DataTable<T extends TableResource>({
             {/* Gradient hint */}
             <div
               className={cn(
-                "pointer-events-none absolute inset-y-0 right-0 z-10 w-24 bg-gradient-to-l from-secondary/10 to-transparent transition-opacity duration-300",
+                "pointer-events-none absolute inset-y-0 right-0 z-10 w-6 bg-gradient-to-l from-secondary/5 to-transparent transition-opacity duration-300 md:w-24",
                 canScrollRight ? "opacity-100" : "opacity-0",
               )}
             />

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -65,6 +65,11 @@ export default function DataTable<T extends TableResource>({
 
   const [sorting, setSorting] = useState<SortingState>([])
 
+  // Horizontal scroll state
+  const [scrollIndex, setScrollIndex] = useState(0) // Which scrollable column we've scrolled past
+  const [availableWidth, setAvailableWidth] = useState(0) // Determine if columns overflow and how much to scroll
+  const containerRef = useRef<HTMLDivElement>(null) // For measuring available container width and observing resizes (e.g. sidebar toggle)
+
   // Track which pages have already animated so revisiting doesn't animate again
   const prevPageRef = useRef(table.page)
   const directionRef = useRef<1 | -1>(1)
@@ -74,14 +79,12 @@ export default function DataTable<T extends TableResource>({
     directionRef.current = table.page > prevPageRef.current ? 1 : -1
     animatedPagesRef.current.add(prevPageRef.current)
     prevPageRef.current = table.page
+
+    // Reset horizontal scroll when changing pages
+    setScrollIndex(0)
   }
 
   const shouldAnimate = !animatedPagesRef.current.has(table.page)
-
-  // Horizontal scroll state
-  const [scrollIndex, setScrollIndex] = useState(0) // Which scrollable column we've scrolled past
-  const [availableWidth, setAvailableWidth] = useState(0) // Determine if columns overflow and how much to scroll
-  const containerRef = useRef<HTMLDivElement>(null) // For measuring available container width and observing resizes (e.g. sidebar toggle)
 
   const [columnWidths, setColumnWidths] = useState<number[]>([]) // Widths of each column for calculating scroll offsets
   const headerCellRefs = useRef<(HTMLTableCellElement | null)[]>([]) // For measuring rendered header cell widths to determine column widths
@@ -142,11 +145,6 @@ export default function DataTable<T extends TableResource>({
 
   const canScrollLeft = scrollIndex > 0
   const canScrollRight = !allColumnsVisible && scrollOffset < maxScrollOffset
-
-  // Reset horizontal scroll when changing pages
-  useEffect(() => {
-    setScrollIndex(0)
-  }, [table.page])
 
   // Read offset width from each header cell to get rendered widths
   const measureColumns = useCallback(() => {

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -342,6 +342,7 @@ export default function DataTable<T extends TableResource>({
                           key={row.id}
                           onClick={() => onRowClick?.(row.original)}
                           className={cn(
+                            "group/row",
                             shouldAnimate &&
                               "border-b-0 animate-in [animation-duration:500ms] fade-in fill-mode-backwards",
                             onRowClick && "cursor-pointer",
@@ -356,7 +357,7 @@ export default function DataTable<T extends TableResource>({
                             <TableCell
                               key={cell.id}
                               className={cn(
-                                "border-b border-accent bg-background",
+                                "border-b border-accent bg-background group-hover/row:bg-accent",
                                 columnIndex < cells.length - 1 && "border-r",
                                 columnIndex === clampedStaticColumns - 1 &&
                                   "after:pointer-events-none after:absolute after:inset-y-0 after:left-full after:w-6 after:bg-gradient-to-r after:from-secondary/5 after:to-transparent after:transition-opacity after:duration-300 after:md:w-24",

--- a/src/components/environments/view/list.tsx
+++ b/src/components/environments/view/list.tsx
@@ -39,7 +39,6 @@ export default function EnvironmentsList({
         pageCount={totalPages}
         isLoading={isLoading}
         onRowClick={onViewDetails}
-        hideOnMobile={["attributes.isolationStrategy"]}
       />
 
       <PageFooter className="border-none">

--- a/src/hooks/use-data-table.ts
+++ b/src/hooks/use-data-table.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react"
+import { useState } from "react"
 import { useMobile } from "@/hooks/use-mobile"
 
 export type DataTableState = {
@@ -11,9 +11,7 @@ export function useDataTable(): DataTableState {
   const isMobile = useMobile()
   const [page, setPage] = useState(1)
 
-  const pageSize = useMemo(() => {
-    return isMobile ? 15 : 20
-  }, [isMobile])
+  const pageSize = isMobile ? 15 : 20
 
   return { page, setPage, pageSize }
 }

--- a/src/pages/app/component/list.tsx
+++ b/src/pages/app/component/list.tsx
@@ -57,12 +57,6 @@ export default function ComponentsList() {
           columns={columns}
           pageCount={totalPages}
           isLoading={componentsLoading}
-          hideOnMobile={[
-            "relationships.machine",
-            "relationships.license",
-            "attributes.created",
-            "attributes.updated",
-          ]}
           onRowClick={(component) => navigateToResource(component)}
         />
       </ScrollArea>

--- a/src/pages/app/entitlement/list.tsx
+++ b/src/pages/app/entitlement/list.tsx
@@ -56,13 +56,6 @@ export default function EntitlementsList() {
           columns={columns}
           pageCount={totalPages}
           isLoading={entitlementsLoading}
-          hideOnMobile={[
-            "attributes.id",
-            "attributes.code",
-            "attributes.url",
-            "attributes.created",
-            "attributes.updated",
-          ]}
           onRowClick={(entitlement) => navigateToResource(entitlement)}
         />
       </ScrollArea>

--- a/src/pages/app/group/list.tsx
+++ b/src/pages/app/group/list.tsx
@@ -56,13 +56,6 @@ export default function GroupsList() {
           columns={columns}
           pageCount={totalPages}
           isLoading={groupsLoading}
-          hideOnMobile={[
-            "id",
-            "attributes.maxUsers",
-            "attributes.maxLicenses",
-            "attributes.maxMachines",
-            "attributes.created",
-          ]}
           onRowClick={(group) => navigateToResource(group)}
         />
       </ScrollArea>

--- a/src/pages/app/license/list.tsx
+++ b/src/pages/app/license/list.tsx
@@ -15,7 +15,7 @@ import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
-import { ScrollArea } from "@radix-ui/react-scroll-area"
+import { ScrollArea } from "@/components/ui/scroll-area"
 
 export default function LicensesList() {
   const table = useDataTable()
@@ -57,13 +57,6 @@ export default function LicensesList() {
           columns={columns}
           pageCount={totalPages}
           isLoading={licensesLoading}
-          hideOnMobile={[
-            "attributes.key",
-            "relationships.policy",
-            "relationships.product",
-            "attributes.expiry",
-            "attributes.created",
-          ]}
           onRowClick={(license) => navigateToResource(license)}
         />
       </ScrollArea>

--- a/src/pages/app/machine/list.tsx
+++ b/src/pages/app/machine/list.tsx
@@ -57,12 +57,6 @@ export default function MachinesList() {
           columns={columns}
           pageCount={totalPages}
           isLoading={machinesLoading}
-          hideOnMobile={[
-            "relationships.license",
-            "relationships.product",
-            "attributes.created",
-            "attributes.updated",
-          ]}
           onRowClick={(machine) => navigateToResource(machine)}
         />
       </ScrollArea>

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -57,12 +57,6 @@ export default function PoliciesList() {
           columns={columns}
           pageCount={totalPages}
           isLoading={policiesLoading}
-          hideOnMobile={[
-            "attributes.id",
-            "attributes.url",
-            "attributes.created",
-            "attributes.updated",
-          ]}
           onRowClick={(policy) => navigateToResource(policy)}
         />
       </ScrollArea>

--- a/src/pages/app/process/list.tsx
+++ b/src/pages/app/process/list.tsx
@@ -57,13 +57,6 @@ export default function ProcessesList() {
           columns={columns}
           pageCount={totalPages}
           isLoading={processesLoading}
-          hideOnMobile={[
-            "relationships.machine",
-            "relationships.license",
-            "relationships.product",
-            "attributes.created",
-            "attributes.updated",
-          ]}
           onRowClick={(process) => navigateToResource(process)}
         />
       </ScrollArea>

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -56,12 +56,6 @@ export default function ProductsList() {
           columns={columns}
           pageCount={totalPages}
           isLoading={productsLoading}
-          hideOnMobile={[
-            "attributes.id",
-            "attributes.url",
-            "attributes.created",
-            "attributes.updated",
-          ]}
           onRowClick={(product) => navigateToResource(product)}
         />
       </ScrollArea>

--- a/src/pages/app/user/list.tsx
+++ b/src/pages/app/user/list.tsx
@@ -53,12 +53,6 @@ export default function UsersList() {
           columns={columns}
           pageCount={totalPages}
           isLoading={usersLoading}
-          hideOnMobile={[
-            "attributes.fullName",
-            "attributes.role",
-            "attributes.created",
-            "attributes.updated",
-          ]}
           onRowClick={(user) => navigateToResource(user)}
         />
       </ScrollArea>


### PR DESCRIPTION
Adds horizontal scrolling for tables that exceed screen width, which replaces existing functionality of conditionally showing columns via `hideOnMobile`. This allows us to endlessly expand tables with columns to display more than just a few resource attributes.

Closes #47.

Table with no overflow (not much change except column borders and disabled scroll buttons):
<img width="700" src="https://github.com/user-attachments/assets/8e75956f-175d-4158-8937-24194f073c26" />

Start of table with overflow (narrowed the above table just to showcase scroll):
<img width="700" src="https://github.com/user-attachments/assets/55e4cf7b-35be-4a97-9998-df7138a5df1a" />

End of table:
<img width="700" src="https://github.com/user-attachments/assets/e7703968-8bcd-4836-a850-db681be91540" />