### PR TITLE
Fix lag when opening policy edit dialog

### DIFF
--- a/src/components/policies/form/edit.tsx
+++ b/src/components/policies/form/edit.tsx
@@ -184,7 +184,11 @@ export default function EditPolicyForm({
 
           <Forms.Section.Columns>
             <Forms.Section.Column>
-              <Policies.Form.Fields schema="edit" mode={PolicyMode.Edit} include={["metadata"]} />
+              <Policies.Form.Fields
+                schema="edit"
+                mode={PolicyMode.Edit}
+                include={["metadata"]}
+              />
             </Forms.Section.Column>
             <Forms.Section.Column>
               <Policies.Form.Fields

--- a/src/components/policies/form/edit.tsx
+++ b/src/components/policies/form/edit.tsx
@@ -20,6 +20,8 @@ import * as Schemas from "@/schemas"
 
 import { settleCreateEntitlements } from "@/lib/entitlements"
 
+import { PolicyMode } from "@/types/policies"
+
 import * as Forms from "@/components/forms"
 import * as Policies from "@/components/policies"
 import { Separator } from "@/components/ui/separator"
@@ -124,6 +126,7 @@ export default function EditPolicyForm({
             <Forms.Section.Column>
               <Policies.Form.Fields
                 schema="edit"
+                mode={PolicyMode.Edit}
                 include={[
                   "authenticationStrategy",
                   "checkInInterval",
@@ -150,6 +153,7 @@ export default function EditPolicyForm({
             <Forms.Section.Column>
               <Policies.Form.Fields
                 schema="edit"
+                mode={PolicyMode.Edit}
                 include={[
                   "maxUses",
                   "maxUsers",
@@ -180,11 +184,12 @@ export default function EditPolicyForm({
 
           <Forms.Section.Columns>
             <Forms.Section.Column>
-              <Policies.Form.Fields schema="edit" include={["metadata"]} />
+              <Policies.Form.Fields schema="edit" mode={PolicyMode.Edit} include={["metadata"]} />
             </Forms.Section.Column>
             <Forms.Section.Column>
               <Policies.Form.Fields
                 schema="edit"
+                mode={PolicyMode.Edit}
                 include={["entitlements.attach", "entitlements.create"]}
               />
             </Forms.Section.Column>

--- a/src/components/policies/form/fields.tsx
+++ b/src/components/policies/form/fields.tsx
@@ -170,6 +170,7 @@ export default function PoliciesFormFields({
                 autoFocus={autoFocus === "checkInInterval"}
                 fieldVariant={fieldVariant}
                 descriptions={descriptions}
+                mode={mode}
               />
             )
           case "checkInIntervalCount":
@@ -206,6 +207,7 @@ export default function PoliciesFormFields({
                 autoFocus={autoFocus === "duration"}
                 fieldVariant={fieldVariant}
                 descriptions={descriptions}
+                mode={mode}
               />
             )
           case "entitlements.attach":
@@ -447,6 +449,7 @@ export default function PoliciesFormFields({
                 autoFocus={autoFocus === "requireHeartbeat"}
                 fieldVariant={fieldVariant}
                 descriptions={descriptions}
+                mode={mode}
               />
             )
           case "requireMachineScope":
@@ -716,10 +719,12 @@ function DurationField({
   autoFocus,
   fieldVariant = "row",
   descriptions,
+  mode = PolicyMode.Create,
 }: {
   autoFocus?: boolean
   fieldVariant?: FieldVariant
   descriptions: Descriptions
+  mode?: PolicyMode
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
@@ -737,7 +742,20 @@ function DurationField({
             <FormControl>
               <DurationInput
                 value={field.value}
-                onChange={field.onChange}
+                onChange={(value) => {
+                  if (mode === PolicyMode.Create && value === null) {
+                    form.reset({
+                      ...form.getValues(),
+                      duration: value,
+                      expirationStrategy: undefined,
+                      expirationBasis: undefined,
+                      renewalBasis: undefined,
+                      transferStrategy: undefined,
+                    })
+                  } else {
+                    field.onChange(value)
+                  }
+                }}
                 units={["unlimited", "days", "weeks", "months", "years"]}
                 autoFocus={autoFocus}
               />
@@ -946,10 +964,12 @@ function RequireHeartbeatField({
   autoFocus,
   fieldVariant = "row",
   descriptions,
+  mode = PolicyMode.Create,
 }: {
   autoFocus?: boolean
   fieldVariant?: FieldVariant
   descriptions: Descriptions
+  mode?: PolicyMode
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
@@ -970,7 +990,18 @@ function RequireHeartbeatField({
               }
               onValueChange={(value) => {
                 const newValue = value === "" ? undefined : value === "true"
-                field.onChange(newValue)
+                if (mode === PolicyMode.Create && !newValue) {
+                  form.reset({
+                    ...form.getValues(),
+                    requireHeartbeat: newValue,
+                    heartbeatDuration: undefined,
+                    heartbeatCullStrategy: undefined,
+                    heartbeatBasis: undefined,
+                    heartbeatResurrectionStrategy: undefined,
+                  })
+                } else {
+                  field.onChange(newValue)
+                }
               }}
             >
               <FormControl>
@@ -1923,10 +1954,12 @@ function CheckInIntervalField({
   autoFocus,
   fieldVariant = "row",
   descriptions,
+  mode = PolicyMode.Create,
 }: {
   autoFocus?: boolean
   fieldVariant?: FieldVariant
   descriptions: Descriptions
+  mode?: PolicyMode
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
@@ -1943,7 +1976,17 @@ function CheckInIntervalField({
           >
             <NullableSelect<CheckInInterval>
               value={field.value}
-              onChange={field.onChange}
+              onChange={(value) => {
+                if (mode === PolicyMode.Create && value === null) {
+                  form.reset({
+                    ...form.getValues(),
+                    checkInInterval: value,
+                    checkInIntervalCount: undefined,
+                  })
+                } else {
+                  field.onChange(value)
+                }
+              }}
               invalid={!!fieldState.error}
               autoFocus={autoFocus}
             >

--- a/src/components/policies/form/fields.tsx
+++ b/src/components/policies/form/fields.tsx
@@ -60,6 +60,8 @@ import * as Search from "@/components/search"
 import KeyValueInput from "@/components/key-value-input"
 import NullableSelect from "@/components/nullable-select"
 import DurationInput from "@/components/duration-input"
+import { useDeferredMount } from "@/hooks/use-deferred-mount"
+
 type Descriptions = typeof PolicyFormFieldDescriptions
 
 const HeartbeatPresets = [
@@ -151,7 +153,7 @@ export default function PoliciesFormFields({
     : IncludeDefaultFields.filter((field) => !exclude.includes(field))
 
   return (
-    <>
+    <div className="space-y-4">
       {fields.map((field) => {
         switch (field) {
           case "authenticationStrategy":
@@ -521,7 +523,7 @@ export default function PoliciesFormFields({
             return null
         }
       })}
-    </>
+    </div>
   )
 }
 
@@ -537,6 +539,16 @@ function NameField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-28 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -590,7 +602,8 @@ function ProductField({
   const form = useFormContext<Schemas.Policies.AllValues>()
   const { data: products = [], isLoading: productsLoading } = useListProducts()
 
-  if (productsLoading) {
+  const ready = useDeferredMount()
+  if (!ready || productsLoading) {
     return (
       <div className="space-y-2">
         <Skeleton className="h-5 w-48 rounded-sm" />
@@ -638,6 +651,16 @@ function AuthenticationStrategyField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-64 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -689,6 +712,23 @@ function MetadataField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+  const values = form.getValues()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-5 w-48 rounded-sm" />
+        {Object.keys(values['metadata']!).map((key) => (
+          <div key={key} className="flex space-x-2">
+            <Skeleton className="h-9 w-1/2 rounded-sm" />
+            <Skeleton className="h-9 w-1/2 rounded-sm" />
+          </div>
+        ))}
+        <Skeleton className="h-8 w-48" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -727,6 +767,19 @@ function DurationField({
   mode?: PolicyMode
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-32 rounded-sm" />
+        <div className="flex space-x-2">
+          <Skeleton className="h-9 w-32 rounded-sm" />
+          <Skeleton className="h-9 w-14 rounded-sm" />
+        </div>
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -783,6 +836,16 @@ function ExpirationStrategyField({
   const duration = useWatch<Schemas.Policies.AllValues>({ name: "duration" })
   const isDisabled = disabled || !duration
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-44 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -830,6 +893,16 @@ function ExpirationBasisField({
   const form = useFormContext<Schemas.Policies.AllValues>()
   const duration = useWatch<Schemas.Policies.AllValues>({ name: "duration" })
   const isDisabled = disabled || !duration
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-36 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -879,6 +952,16 @@ function RenewalBasisField({
   const duration = useWatch<Schemas.Policies.AllValues>({ name: "duration" })
   const isDisabled = disabled || !duration
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-32 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -927,6 +1010,16 @@ function TransferStrategyField({
   const duration = useWatch<Schemas.Policies.AllValues>({ name: "duration" })
   const isDisabled = disabled || !duration
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-36 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -972,6 +1065,16 @@ function RequireHeartbeatField({
   mode?: PolicyMode
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-40 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -1039,6 +1142,19 @@ function HeartbeatDurationField({
   })
   const isDisabled = disabled || !requireHeartbeat
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-32 rounded-sm" />
+        <div className="flex space-x-2">
+          <Skeleton className="h-9 w-26 rounded-sm" />
+          <Skeleton className="h-9 w-20 rounded-sm" />
+        </div>
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -1084,6 +1200,16 @@ function HeartbeatBasisField({
     name: "requireHeartbeat",
   })
   const isDisabled = disabled || !requireHeartbeat
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-36 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -1135,6 +1261,16 @@ function HeartbeatCullStrategyField({
   })
   const isDisabled = disabled || !requireHeartbeat
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -1185,6 +1321,16 @@ function HeartbeatResurrectionStrategyField({
   })
   const isDisabled = disabled || !requireHeartbeat
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-64 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -1229,6 +1375,16 @@ function MaxMachinesField({
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-28 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -1268,6 +1424,16 @@ function MachineUniquenessStrategyField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-56 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -1311,6 +1477,16 @@ function MachineMatchingStrategyField({
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-52 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -1352,6 +1528,16 @@ function ComponentUniquenessStrategyField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-60 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -1395,6 +1581,16 @@ function ComponentMatchingStrategyField({
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-56 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -1436,6 +1632,16 @@ function OverageStrategyField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-36 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -1479,6 +1685,16 @@ function MachineLeasingStrategyField({
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -1519,6 +1735,16 @@ function RequireChecksumScopeField({
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-44 rounded-sm" />
+        <Skeleton className="h-5 w-5 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -1553,6 +1779,16 @@ function RequireComponentsScopeField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-52 rounded-sm" />
+        <Skeleton className="h-5 w-5 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -1589,6 +1825,16 @@ function RequireFingerprintScopeField({
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-48 rounded-sm" />
+        <Skeleton className="h-5 w-5 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -1623,6 +1869,16 @@ function RequireMachineScopeField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-40 rounded-sm" />
+        <Skeleton className="h-5 w-5 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -1659,6 +1915,16 @@ function RequirePolicyScopeField({
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-36 rounded-sm" />
+        <Skeleton className="h-5 w-5 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -1693,6 +1959,16 @@ function RequireProductScopeField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-40 rounded-sm" />
+        <Skeleton className="h-5 w-5 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -1729,6 +2005,16 @@ function RequireUserScopeField({
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-36 rounded-sm" />
+        <Skeleton className="h-5 w-5 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -1763,6 +2049,16 @@ function RequireVersionScopeField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-40 rounded-sm" />
+        <Skeleton className="h-5 w-5 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -1800,6 +2096,16 @@ function MaxProcessesField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-32 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -1841,6 +2147,16 @@ function MaxUsersField({
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-24 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -1881,6 +2197,16 @@ function MaxUsesField({
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-20 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -1920,6 +2246,16 @@ function MaxCoresField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-24 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -1962,6 +2298,16 @@ function CheckInIntervalField({
   mode?: PolicyMode
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-40 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -2020,6 +2366,16 @@ function CheckInIntervalCountField({
     name: "checkInInterval",
   })
   const isDisabled = disabled || !checkInInterval
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -2083,6 +2439,16 @@ function ProcessLeasingStrategyField({
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-48 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -2123,6 +2489,16 @@ function StrictField({
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-16 rounded-sm" />
+        <Skeleton className="h-5 w-5 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -2157,6 +2533,16 @@ function FloatingField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-20 rounded-sm" />
+        <Skeleton className="h-5 w-5 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -2193,6 +2579,16 @@ function ProtectedField({
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-24 rounded-sm" />
+        <Skeleton className="h-5 w-5 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -2227,6 +2623,16 @@ function UsePoolField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-20 rounded-sm" />
+        <Skeleton className="h-5 w-5 rounded-sm" />
+      </div>
+    )
+  }
 
   return (
     <FormField
@@ -2263,6 +2669,16 @@ function RequireCheckInField({
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="w-full flex justify-between">
+        <Skeleton className="h-5 w-36 rounded-sm" />
+        <Skeleton className="h-5 w-5 rounded-sm" />
+      </div>
+    )
+  }
+
   return (
     <FormField
       control={form.control}
@@ -2294,11 +2710,12 @@ function AttachEntitlementsField() {
   const { data: entitlements = [], isLoading: entitlementsLoading } =
     useListEntitlements()
 
-  if (entitlementsLoading) {
+  const ready = useDeferredMount()
+  if (!ready || entitlementsLoading) {
     return (
       <div className="space-y-2">
         <Skeleton className="h-5 w-48 rounded-sm" />
-        <Skeleton className="h-8 w-3/4" />
+        <Skeleton className="h-8 w-full" />
       </div>
     )
   }
@@ -2333,6 +2750,16 @@ function CreateEntitlementsField() {
     control: form.control,
     name: "entitlements.create",
   })
+
+  const ready = useDeferredMount()
+  if (!ready) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-5 w-32 rounded-sm" />
+        <Skeleton className="h-8 w-48" />
+      </div>
+    )
+  }
 
   return (
     <div className="mt-4 space-y-3">

--- a/src/components/policies/form/fields.tsx
+++ b/src/components/policies/form/fields.tsx
@@ -543,9 +543,9 @@ function NameField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between md:flex">
         <Skeleton className="h-5 w-28 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -655,9 +655,9 @@ function AuthenticationStrategyField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-64 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -712,14 +712,14 @@ function MetadataField({
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
-  const values = form.getValues()
+  const { metadata } = form.getValues()
 
   const ready = useDeferredMount()
   if (!ready) {
     return (
       <div className="space-y-2">
         <Skeleton className="h-5 w-48 rounded-sm" />
-        {Object.keys(values['metadata']!).map((key) => (
+        {Object.keys(metadata!).map((key) => (
           <div key={key} className="flex space-x-2">
             <Skeleton className="h-9 w-1/2 rounded-sm" />
             <Skeleton className="h-9 w-1/2 rounded-sm" />
@@ -771,11 +771,11 @@ function DurationField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-32 rounded-sm" />
         <div className="flex space-x-2">
-          <Skeleton className="h-9 w-32 rounded-sm" />
-          <Skeleton className="h-9 w-14 rounded-sm" />
+          <Skeleton className="h-9 w-full rounded-sm md:w-32" />
+          <Skeleton className="h-9 w-20 rounded-sm md:w-14" />
         </div>
       </div>
     )
@@ -839,9 +839,9 @@ function ExpirationStrategyField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-44 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -897,9 +897,9 @@ function ExpirationBasisField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-36 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -955,9 +955,9 @@ function RenewalBasisField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-32 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -1013,9 +1013,9 @@ function TransferStrategyField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-36 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -1069,7 +1069,7 @@ function RequireHeartbeatField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="flex w-full justify-between">
         <Skeleton className="h-5 w-40 rounded-sm" />
         <Skeleton className="h-9 w-48 rounded-sm" />
       </div>
@@ -1145,11 +1145,11 @@ function HeartbeatDurationField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-32 rounded-sm" />
         <div className="flex space-x-2">
-          <Skeleton className="h-9 w-26 rounded-sm" />
-          <Skeleton className="h-9 w-20 rounded-sm" />
+          <Skeleton className="h-9 w-full rounded-sm md:w-26" />
+          <Skeleton className="h-9 w-26 rounded-sm md:w-20" />
         </div>
       </div>
     )
@@ -1204,9 +1204,9 @@ function HeartbeatBasisField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-36 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -1264,9 +1264,9 @@ function HeartbeatCullStrategyField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-48 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -1324,9 +1324,9 @@ function HeartbeatResurrectionStrategyField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-64 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -1378,9 +1378,9 @@ function MaxMachinesField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-28 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -1428,9 +1428,9 @@ function MachineUniquenessStrategyField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-56 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -1480,9 +1480,9 @@ function MachineMatchingStrategyField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-52 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -1532,9 +1532,9 @@ function ComponentUniquenessStrategyField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-60 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -1584,9 +1584,9 @@ function ComponentMatchingStrategyField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-56 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -1636,9 +1636,9 @@ function OverageStrategyField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-36 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -1688,9 +1688,9 @@ function MachineLeasingStrategyField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-48 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -1738,7 +1738,7 @@ function RequireChecksumScopeField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="flex w-full justify-between">
         <Skeleton className="h-5 w-44 rounded-sm" />
         <Skeleton className="h-5 w-5 rounded-sm" />
       </div>
@@ -1783,7 +1783,7 @@ function RequireComponentsScopeField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="flex w-full justify-between">
         <Skeleton className="h-5 w-52 rounded-sm" />
         <Skeleton className="h-5 w-5 rounded-sm" />
       </div>
@@ -1828,7 +1828,7 @@ function RequireFingerprintScopeField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="flex w-full justify-between">
         <Skeleton className="h-5 w-48 rounded-sm" />
         <Skeleton className="h-5 w-5 rounded-sm" />
       </div>
@@ -1873,7 +1873,7 @@ function RequireMachineScopeField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="flex w-full justify-between">
         <Skeleton className="h-5 w-40 rounded-sm" />
         <Skeleton className="h-5 w-5 rounded-sm" />
       </div>
@@ -1918,7 +1918,7 @@ function RequirePolicyScopeField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="flex w-full justify-between">
         <Skeleton className="h-5 w-36 rounded-sm" />
         <Skeleton className="h-5 w-5 rounded-sm" />
       </div>
@@ -1963,7 +1963,7 @@ function RequireProductScopeField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="flex w-full justify-between">
         <Skeleton className="h-5 w-40 rounded-sm" />
         <Skeleton className="h-5 w-5 rounded-sm" />
       </div>
@@ -2008,7 +2008,7 @@ function RequireUserScopeField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="flex w-full justify-between">
         <Skeleton className="h-5 w-36 rounded-sm" />
         <Skeleton className="h-5 w-5 rounded-sm" />
       </div>
@@ -2053,7 +2053,7 @@ function RequireVersionScopeField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="flex w-full justify-between">
         <Skeleton className="h-5 w-40 rounded-sm" />
         <Skeleton className="h-5 w-5 rounded-sm" />
       </div>
@@ -2100,9 +2100,9 @@ function MaxProcessesField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-32 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -2150,9 +2150,9 @@ function MaxUsersField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-24 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -2200,9 +2200,9 @@ function MaxUsesField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-20 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -2250,9 +2250,9 @@ function MaxCoresField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-24 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -2302,9 +2302,9 @@ function CheckInIntervalField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-40 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -2370,9 +2370,9 @@ function CheckInIntervalCountField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-48 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -2442,9 +2442,9 @@ function ProcessLeasingStrategyField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="w-full justify-between space-y-2 md:flex">
         <Skeleton className="h-5 w-48 rounded-sm" />
-        <Skeleton className="h-9 w-48 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
       </div>
     )
   }
@@ -2492,7 +2492,7 @@ function StrictField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="flex w-full justify-between">
         <Skeleton className="h-5 w-16 rounded-sm" />
         <Skeleton className="h-5 w-5 rounded-sm" />
       </div>
@@ -2537,7 +2537,7 @@ function FloatingField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="flex w-full justify-between">
         <Skeleton className="h-5 w-20 rounded-sm" />
         <Skeleton className="h-5 w-5 rounded-sm" />
       </div>
@@ -2582,7 +2582,7 @@ function ProtectedField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="flex w-full justify-between">
         <Skeleton className="h-5 w-24 rounded-sm" />
         <Skeleton className="h-5 w-5 rounded-sm" />
       </div>
@@ -2627,7 +2627,7 @@ function UsePoolField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="flex w-full justify-between">
         <Skeleton className="h-5 w-20 rounded-sm" />
         <Skeleton className="h-5 w-5 rounded-sm" />
       </div>
@@ -2672,7 +2672,7 @@ function RequireCheckInField({
   const ready = useDeferredMount()
   if (!ready) {
     return (
-      <div className="w-full flex justify-between">
+      <div className="flex w-full justify-between">
         <Skeleton className="h-5 w-36 rounded-sm" />
         <Skeleton className="h-5 w-5 rounded-sm" />
       </div>

--- a/src/components/policies/form/fields.tsx
+++ b/src/components/policies/form/fields.tsx
@@ -170,7 +170,6 @@ export default function PoliciesFormFields({
                 autoFocus={autoFocus === "checkInInterval"}
                 fieldVariant={fieldVariant}
                 descriptions={descriptions}
-                mode={mode}
               />
             )
           case "checkInIntervalCount":
@@ -207,7 +206,6 @@ export default function PoliciesFormFields({
                 autoFocus={autoFocus === "duration"}
                 fieldVariant={fieldVariant}
                 descriptions={descriptions}
-                mode={mode}
               />
             )
           case "entitlements.attach":
@@ -449,7 +447,6 @@ export default function PoliciesFormFields({
                 autoFocus={autoFocus === "requireHeartbeat"}
                 fieldVariant={fieldVariant}
                 descriptions={descriptions}
-                mode={mode}
               />
             )
           case "requireMachineScope":
@@ -719,12 +716,10 @@ function DurationField({
   autoFocus,
   fieldVariant = "row",
   descriptions,
-  mode = PolicyMode.Create,
 }: {
   autoFocus?: boolean
   fieldVariant?: FieldVariant
   descriptions: Descriptions
-  mode?: PolicyMode
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
@@ -742,15 +737,7 @@ function DurationField({
             <FormControl>
               <DurationInput
                 value={field.value}
-                onChange={(value) => {
-                  field.onChange(value)
-                  if (mode === PolicyMode.Create && value === null) {
-                    form.resetField("expirationStrategy")
-                    form.resetField("expirationBasis")
-                    form.resetField("renewalBasis")
-                    form.resetField("transferStrategy")
-                  }
-                }}
+                onChange={field.onChange}
                 units={["unlimited", "days", "weeks", "months", "years"]}
                 autoFocus={autoFocus}
               />
@@ -959,12 +946,10 @@ function RequireHeartbeatField({
   autoFocus,
   fieldVariant = "row",
   descriptions,
-  mode = PolicyMode.Create,
 }: {
   autoFocus?: boolean
   fieldVariant?: FieldVariant
   descriptions: Descriptions
-  mode?: PolicyMode
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
@@ -986,12 +971,6 @@ function RequireHeartbeatField({
               onValueChange={(value) => {
                 const newValue = value === "" ? undefined : value === "true"
                 field.onChange(newValue)
-                if (mode === PolicyMode.Create && !newValue) {
-                  form.resetField("heartbeatDuration")
-                  form.resetField("heartbeatCullStrategy")
-                  form.resetField("heartbeatBasis")
-                  form.resetField("heartbeatResurrectionStrategy")
-                }
               }}
             >
               <FormControl>
@@ -1944,12 +1923,10 @@ function CheckInIntervalField({
   autoFocus,
   fieldVariant = "row",
   descriptions,
-  mode = PolicyMode.Create,
 }: {
   autoFocus?: boolean
   fieldVariant?: FieldVariant
   descriptions: Descriptions
-  mode?: PolicyMode
 }) {
   const form = useFormContext<Schemas.Policies.AllValues>()
 
@@ -1966,12 +1943,7 @@ function CheckInIntervalField({
           >
             <NullableSelect<CheckInInterval>
               value={field.value}
-              onChange={(value) => {
-                field.onChange(value)
-                if (mode === PolicyMode.Create && value === null) {
-                  form.resetField("checkInIntervalCount")
-                }
-              }}
+              onChange={field.onChange}
               invalid={!!fieldState.error}
               autoFocus={autoFocus}
             >

--- a/src/hooks/use-deferred-mount.ts
+++ b/src/hooks/use-deferred-mount.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react"
+
+interface UseDeferredMountProps {
+  delay?: number
+}
+
+// this hook can be used to improve performance when mounting a large number
+// of components, e.g. the policy edit form's fields.
+export function useDeferredMount({ delay = 500 }: UseDeferredMountProps = {}) {
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    let frame: number
+
+    const timeout = setTimeout(() => {
+      frame = requestAnimationFrame(() => setReady(true))
+    }, delay)
+
+    return () => {
+      clearTimeout(timeout)
+      cancelAnimationFrame(frame)
+    }
+  }, [delay])
+
+  return ready
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,14 @@ import { routeTree } from "./routeTree.gen"
 
 import * as Page from "@/pages/index"
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5, // don't refetch if data is < 5m old
+      refetchOnWindowFocus: false, // disable refetch on refocus
+    },
+  },
+})
 
 const router = createRouter({
   routeTree,


### PR DESCRIPTION
This includes a few optimizations:

1. Reduced the frequency at which React Query refetches data. Previously, data was always refetched, e.g. on tab refocus, or page transition, etc. Most relevant is that this would result in a couple superfluous requests for a policy's relationships when opening the edit dialog. Now data is only "stale" after 5 minutes (which we can keep an eye on and adjust later if needed), so navigating from policy list -> details -> edit should use data we already have.
3. Consolidated form field resets into one bulk `form.reset()` operation vs individual `form.resetField()` calls, which each individually trigger a state change and a re-render of all form fields. This was very apparent when typing into the duration input field, or clearing it via a backspace. With the bulk reset, only a single state change and re-render occurs.
4. Added a `useDeferredMount()` hook, which allows us to defer mounting of a component until an animation frame is available. This, with the addition of some new skeleton fields, reduces the amount of perceivable lag when opening the policy edit dialog. There's still a small amount of jitter, but I think that may be due to the animation.