### PR TITLE
Fix uninteractive toast within dialog context

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -5,16 +5,23 @@ export const Toaster = (props: ToasterProps) => {
   const { theme = "system" } = useTheme()
 
   return (
-    <Sonner
-      theme={theme as ToasterProps["theme"]}
-      toastOptions={{
-        classNames: {
-          toast: "flex w-full justify-center",
-        },
-      }}
-      className="toaster group"
-      position="top-center"
-      {...props}
-    />
+    <div
+      // NB(ezekg) we may be within a dialog context and we don't want
+      //           any "clicked outside" events to propagate up
+      onPointerDown={(e) => e.stopPropagation()}
+      onPointerUp={(e) => e.stopPropagation()}
+    >
+      <Sonner
+        theme={theme as ToasterProps["theme"]}
+        toastOptions={{
+          classNames: {
+            toast: "flex w-full justify-center pointer-events-auto",
+          },
+        }}
+        className="toaster group"
+        position="top-center"
+        {...props}
+      />
+    </div>
   )
 }


### PR DESCRIPTION
Closes #33. Enables pointer events to make the toast interactive, and stops propagation of pointer down/up events so that closing a toast doesn't unexpectedly also close any open dialog context.