### PR TITLE
Add reset form on close

### DIFF
--- a/src/components/components/form/create.tsx
+++ b/src/components/components/form/create.tsx
@@ -2,8 +2,6 @@ import { useCallback } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 
-import { Form } from "@/components/ui/form"
-
 import * as Schemas from "@/schemas"
 import { useCreateComponent } from "@/queries/components"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
@@ -47,8 +45,8 @@ export default function CreateComponentForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
           onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
@@ -93,7 +91,7 @@ export default function CreateComponentForm({
             <DocumentationLink page="components" />
           </Forms.Section.Step>
         </Forms.Layout.Wizard>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/components/form/edit.tsx
+++ b/src/components/components/form/edit.tsx
@@ -3,7 +3,6 @@ import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useParams } from "@tanstack/react-router"
 
-import { Form } from "@/components/ui/form"
 import { Separator } from "@/components/ui/separator"
 
 import * as Schemas from "@/schemas"
@@ -47,8 +46,8 @@ export default function EditComponentForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing component"
           onCancel={() => onOpenChange(false)}
@@ -75,7 +74,7 @@ export default function EditComponentForm({
             fieldVariant="stacking"
           />
         </Forms.Layout.Sheet>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/entitlements/form/create.tsx
+++ b/src/components/entitlements/form/create.tsx
@@ -2,8 +2,6 @@ import { useCallback } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 
-import { Form } from "@/components/ui/form"
-
 import * as Schemas from "@/schemas"
 import { useCreateEntitlement } from "@/queries/entitlements"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
@@ -46,8 +44,8 @@ export default function CreateEntitlementForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
           onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
@@ -89,7 +87,7 @@ export default function CreateEntitlementForm({
             <DocumentationLink page="entitlements" />
           </Forms.Section.Step>
         </Forms.Layout.Wizard>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/entitlements/form/edit.tsx
+++ b/src/components/entitlements/form/edit.tsx
@@ -3,7 +3,6 @@ import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useParams } from "@tanstack/react-router"
 
-import { Form } from "@/components/ui/form"
 import { Separator } from "@/components/ui/separator"
 
 import * as Schemas from "@/schemas"
@@ -48,8 +47,8 @@ export default function EditEntitlementForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing entitlement"
           onCancel={() => onOpenChange(false)}
@@ -83,7 +82,7 @@ export default function EditEntitlementForm({
             fieldVariant="stacking"
           />
         </Forms.Layout.Sheet>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/environments/form/create.tsx
+++ b/src/components/environments/form/create.tsx
@@ -2,8 +2,6 @@ import { useCallback } from "react"
 import { useForm, useWatch } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 
-import { Form } from "@/components/ui/form"
-
 import * as Schemas from "@/schemas"
 import { IsolationStrategy } from "@/types/environments"
 
@@ -53,12 +51,12 @@ export default function CreateEnvironmentForm({
   )
 
   return (
-    <Forms.Container.Dialog
-      open={open}
-      onOpenChange={onOpenChange}
-      disableOverlay
-    >
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog
+        open={open}
+        onOpenChange={onOpenChange}
+        disableOverlay
+      >
         <Forms.Layout.Wizard
           onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
@@ -124,7 +122,7 @@ export default function CreateEnvironmentForm({
             <DocumentationLink page="environments" />
           </Forms.Section.Step>
         </Forms.Layout.Wizard>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/environments/form/edit.tsx
+++ b/src/components/environments/form/edit.tsx
@@ -2,8 +2,6 @@ import { useCallback } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 
-import { Form } from "@/components/ui/form"
-
 import * as Schemas from "@/schemas"
 import { Environment } from "@/types/environments"
 
@@ -47,12 +45,12 @@ export default function EditEnvironmentForm({
   )
 
   return (
-    <Forms.Container.Dialog
-      open={open}
-      onOpenChange={onOpenChange}
-      disableOverlay
-    >
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog
+        open={open}
+        onOpenChange={onOpenChange}
+        disableOverlay
+      >
         <Forms.Layout.Sheet
           title="Editing an existing environment"
           onCancel={() => onOpenChange(false)}
@@ -73,7 +71,7 @@ export default function EditEnvironmentForm({
 
           <DocumentationLink page="environments" className="mx-0" />
         </Forms.Layout.Sheet>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/forms/container/dialog.tsx
+++ b/src/components/forms/container/dialog.tsx
@@ -1,3 +1,6 @@
+import { useCallback } from "react"
+import { useFormContext } from "react-hook-form"
+
 import {
   Dialog,
   DialogContent,
@@ -30,8 +33,20 @@ export default function FormsContainerDialog({
   className,
 }: FormsContainerDialogProps) {
   const isMobile = useMobile()
+  const form = useFormContext()
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      onOpenChange(open)
+      if (!open) {
+        form.reset() // reset form when closed
+      }
+    },
+    [onOpenChange, form],
+  )
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         disableOverlay={disableOverlay}
         className={cn(

--- a/src/components/forms/index.ts
+++ b/src/components/forms/index.ts
@@ -3,4 +3,5 @@ import * as Field from "./field"
 import * as Layout from "./layout"
 import * as Section from "./section"
 
+export { default as Provider } from "./provider"
 export { Container, Field, Layout, Section }

--- a/src/components/forms/provider.tsx
+++ b/src/components/forms/provider.tsx
@@ -1,0 +1,17 @@
+import {
+  type FieldValues,
+  type UseFormReturn,
+  FormProvider,
+} from "react-hook-form"
+
+interface FormsProviderProps<T extends FieldValues = FieldValues> {
+  form: UseFormReturn<T>
+  children: React.ReactNode
+}
+
+export default function FormsProvider<T extends FieldValues = FieldValues>({
+  form,
+  children,
+}: FormsProviderProps<T>) {
+  return <FormProvider {...form}>{children}</FormProvider>
+}

--- a/src/components/groups/form/create.tsx
+++ b/src/components/groups/form/create.tsx
@@ -2,8 +2,6 @@ import { useCallback } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 
-import { Form } from "@/components/ui/form"
-
 import * as Schemas from "@/schemas"
 import { useCreateGroup } from "@/queries/groups"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
@@ -48,8 +46,8 @@ export default function CreateGroupForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
           description="Creating a new group"
           onBack={() => onOpenChange(false)}
@@ -105,7 +103,7 @@ export default function CreateGroupForm({
             <DocumentationLink page="groups" />
           </Forms.Section.Step>
         </Forms.Layout.Wizard>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/groups/form/edit.tsx
+++ b/src/components/groups/form/edit.tsx
@@ -3,7 +3,6 @@ import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useParams } from "@tanstack/react-router"
 
-import { Form } from "@/components/ui/form"
 import { Separator } from "@/components/ui/separator"
 
 import * as Schemas from "@/schemas"
@@ -51,8 +50,8 @@ export default function EditGroupForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing group"
           onCancel={() => onOpenChange(false)}
@@ -86,7 +85,7 @@ export default function EditGroupForm({
             fieldVariant="stacking"
           />
         </Forms.Layout.Sheet>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/licenses/form/check-out.tsx
+++ b/src/components/licenses/form/check-out.tsx
@@ -12,7 +12,6 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import {
-  Form,
   FormField,
   FormItem,
   FormControl,
@@ -115,7 +114,7 @@ export default function CheckOutLicenseForm({
   )
 
   return (
-    <>
+    <Forms.Provider form={form}>
       <Forms.Container.Overlay open={open} onOpenChange={handleOpenChange} />
 
       {!showResult && (
@@ -124,226 +123,225 @@ export default function CheckOutLicenseForm({
           onOpenChange={handleOpenChange}
           disableOverlay
         >
-          <Form {...form}>
-            <Forms.Layout.Wizard
-              onBack={() => handleOpenChange(false)}
-              onSubmit={() => form.handleSubmit(handleCheckOut)()}
-              isPending={checkOutLicense.isPending}
-              submitLabel="Checkout license"
-              description="Checking out a license"
+          <Forms.Layout.Wizard
+            // NB(ezekg) using raw open handler so we don't clear form on "back"
+            //           i.e. it's less explicit than "close" and we don't want
+            //           the user to lose form state on accidental close
+            onBack={() => onOpenChange(false)}
+            onSubmit={() => form.handleSubmit(handleCheckOut)()}
+            isPending={checkOutLicense.isPending}
+            submitLabel="Checkout license"
+            description="Checking out a license"
+          >
+            <Forms.Section.Step
+              crumb="Include relationships"
+              fields={["includeEnabled", "include"]}
             >
-              <Forms.Section.Step
-                crumb="Include relationships"
-                fields={["includeEnabled", "include"]}
-              >
-                <Forms.Section.Card title="Relationships">
-                  <FormField
-                    control={form.control}
-                    name="includeEnabled"
-                    render={({ field }) => (
-                      <FormItem>
-                        <Forms.Field.Header
-                          label="Include relationship data"
-                          variant="inline"
-                          tooltip="You can include additional relationship data in the license file, 
+              <Forms.Section.Card title="Relationships">
+                <FormField
+                  control={form.control}
+                  name="includeEnabled"
+                  render={({ field }) => (
+                    <FormItem>
+                      <Forms.Field.Header
+                        label="Include relationship data"
+                        variant="inline"
+                        tooltip="You can include additional relationship data in the license file,
                                   such as a license's entitlements, or its product.
                                   This data will be embedded into the license file and can be decoded for offline use."
-                        >
-                          <FormControl>
-                            <Checkbox
-                              checked={!!field.value}
-                              onCheckedChange={(value) => {
-                                field.onChange(!!value)
-                                if (!value) {
-                                  form.resetField("include")
-                                }
-                              }}
-                            />
-                          </FormControl>
-                        </Forms.Field.Header>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="include"
-                    render={({ field }) => (
-                      <FormItem>
-                        <Forms.Field.Header
-                          label="Relationships"
-                          variant="stacking"
-                          tooltip="Select the resource relationships to include in the license file."
-                        >
-                          <FormControl>
-                            <MultiSelect
-                              value={field.value ?? []}
-                              onChange={field.onChange}
-                              options={IncludeOptions}
-                              placeholder="Select relationships..."
-                              disabled={!includeEnabled}
-                              disabledTooltip="Enable relationship data to configure this field."
-                            />
-                          </FormControl>
-                        </Forms.Field.Header>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </Forms.Section.Card>
-              </Forms.Section.Step>
-
-              <Forms.Section.Step
-                crumb="Time to live"
-                fields={["ttlEnabled", "ttl"]}
-              >
-                <Forms.Section.Card title="Time to live">
-                  <FormField
-                    control={form.control}
-                    name="ttlEnabled"
-                    render={({ field }) => (
-                      <FormItem>
-                        <Forms.Field.Header
-                          label="Add a custom TTL"
-                          variant="inline"
-                          tooltip="A time-to-live (TTL) defines how long before the license file expires.
-                                  If no TTL is set, the license file will default to a TTL of 30 days."
-                        >
-                          <FormControl>
-                            <Checkbox
-                              checked={!!field.value}
-                              onCheckedChange={(value) => {
-                                field.onChange(!!value)
-                                if (!value) {
-                                  form.resetField("ttl")
-                                }
-                              }}
-                            />
-                          </FormControl>
-                        </Forms.Field.Header>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="ttl"
-                    render={({ field }) => (
-                      <FormItem>
-                        <Forms.Field.Header
-                          label="Duration"
-                          variant="stacking"
-                          tooltip="Set a custom TTL duration for the license file."
-                        >
-                          <FormControl>
-                            <DurationInput
-                              value={field.value}
-                              onChange={field.onChange}
-                              units={["days", "weeks", "months", "years"]}
-                              disabled={!ttlEnabled}
-                              disabledTooltip="Enable a custom TTL to configure this field."
-                            />
-                          </FormControl>
-                        </Forms.Field.Header>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </Forms.Section.Card>
-              </Forms.Section.Step>
-
-              <Forms.Section.Step
-                crumb="Additional configuration"
-                fields={["encrypt", "algorithm"]}
-              >
-                <Forms.Section.Card title="Additional options">
-                  <FormField
-                    control={form.control}
-                    name="encryptEnabled"
-                    render={({ field }) => (
-                      <FormItem>
-                        <Forms.Field.Header
-                          label="Encrypt the license file"
-                          variant="inline"
-                          tooltip="Encryption adds another layer of security to your offline licensing system."
-                        >
-                          <FormControl>
-                            <Checkbox
-                              checked={!!field.value}
-                              onCheckedChange={(value) =>
-                                field.onChange(!!value)
+                      >
+                        <FormControl>
+                          <Checkbox
+                            checked={!!field.value}
+                            onCheckedChange={(value) => {
+                              field.onChange(!!value)
+                              if (!value) {
+                                form.resetField("include")
                               }
-                            />
-                          </FormControl>
-                        </Forms.Field.Header>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="algorithm"
-                    render={({ field }) => (
-                      <FormItem>
-                        <Forms.Field.Header
-                          label="Signing algorithm"
-                          variant="stacking"
-                          tooltip="The cryptographic algorithm used to sign the license file."
-                        >
-                          <FormControl>
-                            <Select
-                              value={field.value}
-                              onValueChange={field.onChange}
-                            >
-                              <SelectTrigger className="w-full">
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {Object.values(SigningAlgorithm).map((alg) => (
-                                  <SelectItem key={alg} value={alg}>
-                                    {SigningAlgorithmLabels[alg]}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                          </FormControl>
-                        </Forms.Field.Header>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </Forms.Section.Card>
+                            }}
+                          />
+                        </FormControl>
+                      </Forms.Field.Header>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="include"
+                  render={({ field }) => (
+                    <FormItem>
+                      <Forms.Field.Header
+                        label="Relationships"
+                        variant="stacking"
+                        tooltip="Select the resource relationships to include in the license file."
+                      >
+                        <FormControl>
+                          <MultiSelect
+                            value={field.value ?? []}
+                            onChange={field.onChange}
+                            options={IncludeOptions}
+                            placeholder="Select relationships..."
+                            disabled={!includeEnabled}
+                            disabledTooltip="Enable relationship data to configure this field."
+                          />
+                        </FormControl>
+                      </Forms.Field.Header>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </Forms.Section.Card>
+            </Forms.Section.Step>
 
-                <div className="space-y-2 px-8 text-sm text-content-subdued">
-                  <p>
-                    Checking out a license will generate a License File, which
-                    can be decoded and used in offline/air-gap environments.
-                  </p>
-                  <ul className="list-inside list-disc space-y-2">
+            <Forms.Section.Step
+              crumb="Time to live"
+              fields={["ttlEnabled", "ttl"]}
+            >
+              <Forms.Section.Card title="Time to live">
+                <FormField
+                  control={form.control}
+                  name="ttlEnabled"
+                  render={({ field }) => (
+                    <FormItem>
+                      <Forms.Field.Header
+                        label="Add a custom TTL"
+                        variant="inline"
+                        tooltip="A time-to-live (TTL) defines how long before the license file expires.
+                                  If no TTL is set, the license file will default to a TTL of 30 days."
+                      >
+                        <FormControl>
+                          <Checkbox
+                            checked={!!field.value}
+                            onCheckedChange={(value) => {
+                              field.onChange(!!value)
+                              if (!value) {
+                                form.resetField("ttl")
+                              }
+                            }}
+                          />
+                        </FormControl>
+                      </Forms.Field.Header>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="ttl"
+                  render={({ field }) => (
+                    <FormItem>
+                      <Forms.Field.Header
+                        label="Duration"
+                        variant="stacking"
+                        tooltip="Set a custom TTL duration for the license file."
+                      >
+                        <FormControl>
+                          <DurationInput
+                            value={field.value}
+                            onChange={field.onChange}
+                            units={["days", "weeks", "months", "years"]}
+                            disabled={!ttlEnabled}
+                            disabledTooltip="Enable a custom TTL to configure this field."
+                          />
+                        </FormControl>
+                      </Forms.Field.Header>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </Forms.Section.Card>
+            </Forms.Section.Step>
+
+            <Forms.Section.Step
+              crumb="Additional configuration"
+              fields={["encrypt", "algorithm"]}
+            >
+              <Forms.Section.Card title="Additional options">
+                <FormField
+                  control={form.control}
+                  name="encryptEnabled"
+                  render={({ field }) => (
+                    <FormItem>
+                      <Forms.Field.Header
+                        label="Encrypt the license file"
+                        variant="inline"
+                        tooltip="Encryption adds another layer of security to your offline licensing system."
+                      >
+                        <FormControl>
+                          <Checkbox
+                            checked={!!field.value}
+                            onCheckedChange={(value) => field.onChange(!!value)}
+                          />
+                        </FormControl>
+                      </Forms.Field.Header>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="algorithm"
+                  render={({ field }) => (
+                    <FormItem>
+                      <Forms.Field.Header
+                        label="Signing algorithm"
+                        variant="stacking"
+                        tooltip="The cryptographic algorithm used to sign the license file."
+                      >
+                        <FormControl>
+                          <Select
+                            value={field.value}
+                            onValueChange={field.onChange}
+                          >
+                            <SelectTrigger className="w-full">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {Object.values(SigningAlgorithm).map((alg) => (
+                                <SelectItem key={alg} value={alg}>
+                                  {SigningAlgorithmLabels[alg]}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </FormControl>
+                      </Forms.Field.Header>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </Forms.Section.Card>
+
+              <div className="space-y-2 px-8 text-sm text-content-subdued">
+                <p>
+                  Checking out a license will generate a License File, which can
+                  be decoded and used in offline/air-gap environments.
+                </p>
+                <ul className="list-inside list-disc space-y-2">
+                  <li>
+                    You're currently checking out an{" "}
+                    {encryptEnabled ? "encrypted" : "unencrypted"} license file,
+                    signed with{" "}
+                    {SigningAlgorithmLabels[algorithm as SigningAlgorithm] ??
+                      algorithm}
+                    {encryptEnabled && " and encrypted with AES-256-GCM"}.
+                  </li>
+                  {includeEnabled && include.length > 0 && (
                     <li>
-                      You're currently checking out an{" "}
-                      {encryptEnabled ? "encrypted" : "unencrypted"} license
-                      file, signed with{" "}
-                      {SigningAlgorithmLabels[algorithm as SigningAlgorithm] ??
-                        algorithm}
-                      {encryptEnabled && " and encrypted with AES-256-GCM"}.
+                      The following relationships will be included in the
+                      license file: {include.join(", ")}.
                     </li>
-                    {includeEnabled && include.length > 0 && (
-                      <li>
-                        The following relationships will be included in the
-                        license file: {include.join(", ")}.
-                      </li>
-                    )}
-                    <li>
-                      {ttlEnabled
-                        ? `The license file has a TTL of ${formatTtlLabel(ttl)}.`
-                        : "It has the default TTL of 30 days."}
-                    </li>
-                  </ul>
-                </div>
-              </Forms.Section.Step>
-            </Forms.Layout.Wizard>
-          </Form>
+                  )}
+                  <li>
+                    {ttlEnabled
+                      ? `The license file has a TTL of ${formatTtlLabel(ttl)}.`
+                      : "It has the default TTL of 30 days."}
+                  </li>
+                </ul>
+              </div>
+            </Forms.Section.Step>
+          </Forms.Layout.Wizard>
         </Forms.Container.Dialog>
       )}
 
@@ -363,6 +361,6 @@ export default function CheckOutLicenseForm({
           }}
         />
       )}
-    </>
+    </Forms.Provider>
   )
 }

--- a/src/components/licenses/form/create.tsx
+++ b/src/components/licenses/form/create.tsx
@@ -2,8 +2,6 @@ import { useCallback, useMemo } from "react"
 import { useForm, useWatch } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 
-import { Form } from "@/components/ui/form"
-
 import * as Schemas from "@/schemas"
 import {
   useCreateLicense,
@@ -104,8 +102,8 @@ export default function CreateLicenseForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
           onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
@@ -257,7 +255,7 @@ export default function CreateLicenseForm({
             <DocumentationLink page="licenses" />
           </Forms.Section.Step>
         </Forms.Layout.Wizard>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/licenses/form/edit.tsx
+++ b/src/components/licenses/form/edit.tsx
@@ -3,7 +3,6 @@ import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useParams } from "@tanstack/react-router"
 
-import { Form } from "@/components/ui/form"
 import { Separator } from "@/components/ui/separator"
 
 import * as Schemas from "@/schemas"
@@ -147,8 +146,12 @@ export default function EditLicenseForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange} fullscreen>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog
+        open={open}
+        onOpenChange={onOpenChange}
+        fullscreen
+      >
         <Forms.Layout.Sheet
           title="Editing an existing license"
           onCancel={() => onOpenChange(false)}
@@ -211,7 +214,7 @@ export default function EditLicenseForm({
             </Forms.Section.Column>
           </Forms.Section.Columns>
         </Forms.Layout.Sheet>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/machines/form/check-out.tsx
+++ b/src/components/machines/form/check-out.tsx
@@ -12,7 +12,6 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import {
-  Form,
   FormField,
   FormItem,
   FormControl,
@@ -117,7 +116,7 @@ export default function CheckOutMachineForm({
   )
 
   return (
-    <>
+    <Forms.Provider form={form}>
       <Forms.Container.Overlay open={open} onOpenChange={handleOpenChange} />
 
       {!showResult && (
@@ -126,226 +125,225 @@ export default function CheckOutMachineForm({
           onOpenChange={handleOpenChange}
           disableOverlay
         >
-          <Form {...form}>
-            <Forms.Layout.Wizard
-              onBack={() => handleOpenChange(false)}
-              onSubmit={() => form.handleSubmit(handleCheckOut)()}
-              isPending={checkOutMachine.isPending}
-              submitLabel="Checkout machine"
-              description="Checking out a machine"
+          <Forms.Layout.Wizard
+            // NB(ezekg) using raw open handler so we don't clear form on "back"
+            //           i.e. it's less explicit than "close" and we don't want
+            //           the user to lose form state on accidental close
+            onBack={() => onOpenChange(false)}
+            onSubmit={() => form.handleSubmit(handleCheckOut)()}
+            isPending={checkOutMachine.isPending}
+            submitLabel="Checkout machine"
+            description="Checking out a machine"
+          >
+            <Forms.Section.Step
+              crumb="Include relationships"
+              fields={["includeEnabled", "include"]}
             >
-              <Forms.Section.Step
-                crumb="Include relationships"
-                fields={["includeEnabled", "include"]}
-              >
-                <Forms.Section.Card title="Relationships">
-                  <FormField
-                    control={form.control}
-                    name="includeEnabled"
-                    render={({ field }) => (
-                      <FormItem>
-                        <Forms.Field.Header
-                          label="Include relationship data"
-                          variant="inline"
-                          tooltip="You can include additional relationship data in the machine file,
+              <Forms.Section.Card title="Relationships">
+                <FormField
+                  control={form.control}
+                  name="includeEnabled"
+                  render={({ field }) => (
+                    <FormItem>
+                      <Forms.Field.Header
+                        label="Include relationship data"
+                        variant="inline"
+                        tooltip="You can include additional relationship data in the machine file,
                                   such as a machine's license, or its components.
                                   This data will be embedded into the machine file and can be decoded for offline use."
-                        >
-                          <FormControl>
-                            <Checkbox
-                              checked={!!field.value}
-                              onCheckedChange={(value) => {
-                                field.onChange(!!value)
-                                if (!value) {
-                                  form.resetField("include")
-                                }
-                              }}
-                            />
-                          </FormControl>
-                        </Forms.Field.Header>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="include"
-                    render={({ field }) => (
-                      <FormItem>
-                        <Forms.Field.Header
-                          label="Relationships"
-                          variant="stacking"
-                          tooltip="Select the resource relationships to include in the machine file."
-                        >
-                          <FormControl>
-                            <MultiSelect
-                              value={field.value ?? []}
-                              onChange={field.onChange}
-                              options={IncludeOptions}
-                              placeholder="Select relationships..."
-                              disabled={!includeEnabled}
-                              disabledTooltip="Enable relationship data to configure this field."
-                            />
-                          </FormControl>
-                        </Forms.Field.Header>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </Forms.Section.Card>
-              </Forms.Section.Step>
-
-              <Forms.Section.Step
-                crumb="Time to live"
-                fields={["ttlEnabled", "ttl"]}
-              >
-                <Forms.Section.Card title="Time to live">
-                  <FormField
-                    control={form.control}
-                    name="ttlEnabled"
-                    render={({ field }) => (
-                      <FormItem>
-                        <Forms.Field.Header
-                          label="Add a custom TTL"
-                          variant="inline"
-                          tooltip="A time-to-live (TTL) defines how long before the machine file expires.
-                                  If no TTL is set, the machine file will default to a TTL of 30 days."
-                        >
-                          <FormControl>
-                            <Checkbox
-                              checked={!!field.value}
-                              onCheckedChange={(value) => {
-                                field.onChange(!!value)
-                                if (!value) {
-                                  form.resetField("ttl")
-                                }
-                              }}
-                            />
-                          </FormControl>
-                        </Forms.Field.Header>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="ttl"
-                    render={({ field }) => (
-                      <FormItem>
-                        <Forms.Field.Header
-                          label="Duration"
-                          variant="stacking"
-                          tooltip="Set a custom TTL duration for the machine file."
-                        >
-                          <FormControl>
-                            <DurationInput
-                              value={field.value}
-                              onChange={field.onChange}
-                              units={["days", "weeks", "months", "years"]}
-                              disabled={!ttlEnabled}
-                              disabledTooltip="Enable a custom TTL to configure this field."
-                            />
-                          </FormControl>
-                        </Forms.Field.Header>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </Forms.Section.Card>
-              </Forms.Section.Step>
-
-              <Forms.Section.Step
-                crumb="Additional configuration"
-                fields={["encrypt", "algorithm"]}
-              >
-                <Forms.Section.Card title="Additional options">
-                  <FormField
-                    control={form.control}
-                    name="encryptEnabled"
-                    render={({ field }) => (
-                      <FormItem>
-                        <Forms.Field.Header
-                          label="Encrypt the machine file"
-                          variant="inline"
-                          tooltip="Encryption adds another layer of security to your offline licensing system."
-                        >
-                          <FormControl>
-                            <Checkbox
-                              checked={!!field.value}
-                              onCheckedChange={(value) =>
-                                field.onChange(!!value)
+                      >
+                        <FormControl>
+                          <Checkbox
+                            checked={!!field.value}
+                            onCheckedChange={(value) => {
+                              field.onChange(!!value)
+                              if (!value) {
+                                form.resetField("include")
                               }
-                            />
-                          </FormControl>
-                        </Forms.Field.Header>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="algorithm"
-                    render={({ field }) => (
-                      <FormItem>
-                        <Forms.Field.Header
-                          label="Signing algorithm"
-                          variant="stacking"
-                          tooltip="The cryptographic algorithm used to sign the machine file."
-                        >
-                          <FormControl>
-                            <Select
-                              value={field.value}
-                              onValueChange={field.onChange}
-                            >
-                              <SelectTrigger className="w-full">
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {Object.values(SigningAlgorithm).map((alg) => (
-                                  <SelectItem key={alg} value={alg}>
-                                    {SigningAlgorithmLabels[alg]}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                          </FormControl>
-                        </Forms.Field.Header>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </Forms.Section.Card>
+                            }}
+                          />
+                        </FormControl>
+                      </Forms.Field.Header>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="include"
+                  render={({ field }) => (
+                    <FormItem>
+                      <Forms.Field.Header
+                        label="Relationships"
+                        variant="stacking"
+                        tooltip="Select the resource relationships to include in the machine file."
+                      >
+                        <FormControl>
+                          <MultiSelect
+                            value={field.value ?? []}
+                            onChange={field.onChange}
+                            options={IncludeOptions}
+                            placeholder="Select relationships..."
+                            disabled={!includeEnabled}
+                            disabledTooltip="Enable relationship data to configure this field."
+                          />
+                        </FormControl>
+                      </Forms.Field.Header>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </Forms.Section.Card>
+            </Forms.Section.Step>
 
-                <div className="space-y-2 px-8 text-sm text-content-subdued">
-                  <p>
-                    Checking out a machine will generate a Machine File, which
-                    can be decoded and used in offline/air-gap environments.
-                  </p>
-                  <ul className="list-inside list-disc space-y-2">
+            <Forms.Section.Step
+              crumb="Time to live"
+              fields={["ttlEnabled", "ttl"]}
+            >
+              <Forms.Section.Card title="Time to live">
+                <FormField
+                  control={form.control}
+                  name="ttlEnabled"
+                  render={({ field }) => (
+                    <FormItem>
+                      <Forms.Field.Header
+                        label="Add a custom TTL"
+                        variant="inline"
+                        tooltip="A time-to-live (TTL) defines how long before the machine file expires.
+                                  If no TTL is set, the machine file will default to a TTL of 30 days."
+                      >
+                        <FormControl>
+                          <Checkbox
+                            checked={!!field.value}
+                            onCheckedChange={(value) => {
+                              field.onChange(!!value)
+                              if (!value) {
+                                form.resetField("ttl")
+                              }
+                            }}
+                          />
+                        </FormControl>
+                      </Forms.Field.Header>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="ttl"
+                  render={({ field }) => (
+                    <FormItem>
+                      <Forms.Field.Header
+                        label="Duration"
+                        variant="stacking"
+                        tooltip="Set a custom TTL duration for the machine file."
+                      >
+                        <FormControl>
+                          <DurationInput
+                            value={field.value}
+                            onChange={field.onChange}
+                            units={["days", "weeks", "months", "years"]}
+                            disabled={!ttlEnabled}
+                            disabledTooltip="Enable a custom TTL to configure this field."
+                          />
+                        </FormControl>
+                      </Forms.Field.Header>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </Forms.Section.Card>
+            </Forms.Section.Step>
+
+            <Forms.Section.Step
+              crumb="Additional configuration"
+              fields={["encrypt", "algorithm"]}
+            >
+              <Forms.Section.Card title="Additional options">
+                <FormField
+                  control={form.control}
+                  name="encryptEnabled"
+                  render={({ field }) => (
+                    <FormItem>
+                      <Forms.Field.Header
+                        label="Encrypt the machine file"
+                        variant="inline"
+                        tooltip="Encryption adds another layer of security to your offline licensing system."
+                      >
+                        <FormControl>
+                          <Checkbox
+                            checked={!!field.value}
+                            onCheckedChange={(value) => field.onChange(!!value)}
+                          />
+                        </FormControl>
+                      </Forms.Field.Header>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="algorithm"
+                  render={({ field }) => (
+                    <FormItem>
+                      <Forms.Field.Header
+                        label="Signing algorithm"
+                        variant="stacking"
+                        tooltip="The cryptographic algorithm used to sign the machine file."
+                      >
+                        <FormControl>
+                          <Select
+                            value={field.value}
+                            onValueChange={field.onChange}
+                          >
+                            <SelectTrigger className="w-full">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {Object.values(SigningAlgorithm).map((alg) => (
+                                <SelectItem key={alg} value={alg}>
+                                  {SigningAlgorithmLabels[alg]}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </FormControl>
+                      </Forms.Field.Header>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </Forms.Section.Card>
+
+              <div className="space-y-2 px-8 text-sm text-content-subdued">
+                <p>
+                  Checking out a machine will generate a Machine File, which can
+                  be decoded and used in offline/air-gap environments.
+                </p>
+                <ul className="list-inside list-disc space-y-2">
+                  <li>
+                    You're currently checking out an{" "}
+                    {encryptEnabled ? "encrypted" : "unencrypted"} machine file,
+                    signed with{" "}
+                    {SigningAlgorithmLabels[algorithm as SigningAlgorithm] ??
+                      algorithm}
+                    {encryptEnabled && " and encrypted with AES-256-GCM"}.
+                  </li>
+                  {includeEnabled && include.length > 0 && (
                     <li>
-                      You're currently checking out an{" "}
-                      {encryptEnabled ? "encrypted" : "unencrypted"} machine
-                      file, signed with{" "}
-                      {SigningAlgorithmLabels[algorithm as SigningAlgorithm] ??
-                        algorithm}
-                      {encryptEnabled && " and encrypted with AES-256-GCM"}.
+                      The following relationships will be included in the
+                      machine file: {include.join(", ")}.
                     </li>
-                    {includeEnabled && include.length > 0 && (
-                      <li>
-                        The following relationships will be included in the
-                        machine file: {include.join(", ")}.
-                      </li>
-                    )}
-                    <li>
-                      {ttlEnabled
-                        ? `The machine file has a TTL of ${formatTtlLabel(ttl)}.`
-                        : "It has the default TTL of 30 days."}
-                    </li>
-                  </ul>
-                </div>
-              </Forms.Section.Step>
-            </Forms.Layout.Wizard>
-          </Form>
+                  )}
+                  <li>
+                    {ttlEnabled
+                      ? `The machine file has a TTL of ${formatTtlLabel(ttl)}.`
+                      : "It has the default TTL of 30 days."}
+                  </li>
+                </ul>
+              </div>
+            </Forms.Section.Step>
+          </Forms.Layout.Wizard>
         </Forms.Container.Dialog>
       )}
 
@@ -365,6 +363,6 @@ export default function CheckOutMachineForm({
           }}
         />
       )}
-    </>
+    </Forms.Provider>
   )
 }

--- a/src/components/machines/form/create.tsx
+++ b/src/components/machines/form/create.tsx
@@ -2,8 +2,6 @@ import { useCallback } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 
-import { Form } from "@/components/ui/form"
-
 import * as Schemas from "@/schemas"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 import {
@@ -76,8 +74,8 @@ export default function CreateMachineForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
           onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
@@ -183,7 +181,7 @@ export default function CreateMachineForm({
             <DocumentationLink page="machines" />
           </Forms.Section.Step>
         </Forms.Layout.Wizard>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/machines/form/edit.tsx
+++ b/src/components/machines/form/edit.tsx
@@ -3,7 +3,6 @@ import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useParams } from "@tanstack/react-router"
 
-import { Form } from "@/components/ui/form"
 import { Separator } from "@/components/ui/separator"
 
 import * as Schemas from "@/schemas"
@@ -84,8 +83,8 @@ export default function EditMachineForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing machine"
           onCancel={() => onOpenChange(false)}
@@ -143,7 +142,7 @@ export default function EditMachineForm({
             </Forms.Section.Column>
           </Forms.Section.Columns>
         </Forms.Layout.Sheet>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/policies/form/create.tsx
+++ b/src/components/policies/form/create.tsx
@@ -17,7 +17,6 @@ import {
   PopoverContent,
 } from "@/components/ui/popover"
 import {
-  Form,
   FormField,
   FormItem,
   FormControl,
@@ -332,21 +331,21 @@ function TemplatesSelectionForm({
   ]
 
   return (
-    <Forms.Container.Dialog
-      open={open}
-      onOpenChange={onOpenChange}
-      disableOverlay
-    >
-      <Forms.Section.Header>
-        <Forms.Section.Title className="text-base">
-          New policy
-        </Forms.Section.Title>
-        <Forms.Section.Description className="text-sm">
-          Select all parameters that apply to the policy
-        </Forms.Section.Description>
-      </Forms.Section.Header>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog
+        open={open}
+        onOpenChange={onOpenChange}
+        disableOverlay
+      >
+        <Forms.Section.Header>
+          <Forms.Section.Title className="text-base">
+            New policy
+          </Forms.Section.Title>
+          <Forms.Section.Description className="text-sm">
+            Select all parameters that apply to the policy
+          </Forms.Section.Description>
+        </Forms.Section.Header>
 
-      <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <ScrollArea className="h-[calc(100vh-15rem)] md:w-3xl">
             <div className="space-y-8">
@@ -501,8 +500,8 @@ function TemplatesSelectionForm({
             </div>
           </div>
         </form>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }
 
@@ -528,12 +527,12 @@ function TemplatesForm({
   errorMessage,
 }: TemplatesFormProps) {
   return (
-    <Forms.Container.Dialog
-      open={open}
-      onOpenChange={onOpenChange}
-      disableOverlay
-    >
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog
+        open={open}
+        onOpenChange={onOpenChange}
+        disableOverlay
+      >
         <Forms.Layout.Wizard
           onSubmit={onSubmit}
           onBack={onBack}
@@ -864,8 +863,8 @@ function TemplatesForm({
             </Forms.Section.Step>
           )}
         </Forms.Layout.Wizard>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }
 
@@ -889,13 +888,13 @@ function ScratchForm({
   errorMessage,
 }: ScratchFormProps) {
   return (
-    <Forms.Container.Dialog
-      open={open}
-      onOpenChange={onOpenChange}
-      fullscreen
-      disableOverlay
-    >
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog
+        open={open}
+        onOpenChange={onOpenChange}
+        fullscreen
+        disableOverlay
+      >
         <Forms.Layout.Wizard
           variant="sidebar"
           title="Creating a new policy"
@@ -1085,7 +1084,7 @@ function ScratchForm({
             <DocumentationLink page="policies" />
           </Forms.Section.Step>
         </Forms.Layout.Wizard>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/policies/form/duplicate.tsx
+++ b/src/components/policies/form/duplicate.tsx
@@ -3,7 +3,6 @@ import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useParams } from "@tanstack/react-router"
 
-import { Form } from "@/components/ui/form"
 import { toast } from "@/lib/toast"
 
 import {
@@ -119,17 +118,21 @@ export default function DuplicatePolicyForm({
   }
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange} fullscreen>
-      {policyLoading ? (
-        <div className="flex w-full justify-center py-8">
-          <Loading.Dots />
-        </div>
-      ) : policyError || !policy ? (
-        <p className="text-center text-sm text-red-500">
-          Failed to load policy.
-        </p>
-      ) : (
-        <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog
+        open={open}
+        onOpenChange={onOpenChange}
+        fullscreen
+      >
+        {policyLoading ? (
+          <div className="flex w-full justify-center py-8">
+            <Loading.Dots />
+          </div>
+        ) : policyError || !policy ? (
+          <p className="text-center text-sm text-red-500">
+            Failed to load policy.
+          </p>
+        ) : (
           <Forms.Layout.Sheet
             title="Duplicating an existing policy"
             onSubmit={handleSubmit}
@@ -214,8 +217,8 @@ export default function DuplicatePolicyForm({
               </Forms.Section.Column>
             </Forms.Section.Columns>
           </Forms.Layout.Sheet>
-        </Form>
-      )}
-    </Forms.Container.Dialog>
+        )}
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/policies/form/edit.tsx
+++ b/src/components/policies/form/edit.tsx
@@ -3,8 +3,6 @@ import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useParams } from "@tanstack/react-router"
 
-import { Form } from "@/components/ui/form"
-
 import { toast } from "@/lib/toast"
 
 import {
@@ -106,8 +104,12 @@ export default function EditPolicyForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange} fullscreen>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog
+        open={open}
+        onOpenChange={onOpenChange}
+        fullscreen
+      >
         <Forms.Layout.Sheet
           title="Editing an existing policy"
           onSubmit={handleSubmit}
@@ -199,7 +201,7 @@ export default function EditPolicyForm({
             </Forms.Section.Column>
           </Forms.Section.Columns>
         </Forms.Layout.Sheet>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/processes/form/create.tsx
+++ b/src/components/processes/form/create.tsx
@@ -2,8 +2,6 @@ import { useCallback } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 
-import { Form } from "@/components/ui/form"
-
 import * as Schemas from "@/schemas"
 import { useCreateProcess } from "@/queries/processes"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
@@ -46,8 +44,8 @@ export default function CreateProcessForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
           onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
@@ -91,7 +89,7 @@ export default function CreateProcessForm({
             <DocumentationLink page="processes" />
           </Forms.Section.Step>
         </Forms.Layout.Wizard>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/processes/form/edit.tsx
+++ b/src/components/processes/form/edit.tsx
@@ -3,8 +3,6 @@ import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useParams } from "@tanstack/react-router"
 
-import { Form } from "@/components/ui/form"
-
 import * as Schemas from "@/schemas"
 import { useGetProcess, useUpdateProcess } from "@/queries/processes"
 
@@ -45,8 +43,8 @@ export default function EditProcessForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing process"
           onCancel={() => onOpenChange(false)}
@@ -61,7 +59,7 @@ export default function EditProcessForm({
             fieldVariant="stacking"
           />
         </Forms.Layout.Sheet>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/products/form/create.tsx
+++ b/src/components/products/form/create.tsx
@@ -2,8 +2,6 @@ import { useCallback } from "react"
 import { useForm, useWatch } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 
-import { Form } from "@/components/ui/form"
-
 import { Award, Lock, Unlock } from "lucide-react"
 
 import * as Schemas from "@/schemas"
@@ -61,8 +59,8 @@ export default function CreateProductForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
           onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
@@ -154,7 +152,7 @@ export default function CreateProductForm({
             <DocumentationLink page="products" />
           </Forms.Section.Step>
         </Forms.Layout.Wizard>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/products/form/edit.tsx
+++ b/src/components/products/form/edit.tsx
@@ -3,7 +3,6 @@ import { useForm } from "react-hook-form"
 import { useParams } from "@tanstack/react-router"
 import { zodResolver } from "@hookform/resolvers/zod"
 
-import { Form } from "@/components/ui/form"
 import { Separator } from "@/components/ui/separator"
 
 import * as Schemas from "@/schemas"
@@ -56,8 +55,8 @@ export default function EditProductForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing product"
           onCancel={() => onOpenChange(false)}
@@ -100,7 +99,7 @@ export default function EditProductForm({
             fieldVariant="stacking"
           />
         </Forms.Layout.Sheet>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/users/form/create.tsx
+++ b/src/components/users/form/create.tsx
@@ -2,8 +2,6 @@ import { useCallback } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 
-import { Form } from "@/components/ui/form"
-
 import * as Schemas from "@/schemas"
 import { UserRole } from "@/types/users"
 
@@ -63,8 +61,8 @@ export default function CreateUserForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
           onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
@@ -159,7 +157,7 @@ export default function CreateUserForm({
             <DocumentationLink page="users" />
           </Forms.Section.Step>
         </Forms.Layout.Wizard>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }

--- a/src/components/users/form/edit.tsx
+++ b/src/components/users/form/edit.tsx
@@ -3,7 +3,6 @@ import { useForm } from "react-hook-form"
 import { useParams } from "@tanstack/react-router"
 import { zodResolver } from "@hookform/resolvers/zod"
 
-import { Form } from "@/components/ui/form"
 import { Separator } from "@/components/ui/separator"
 
 import * as Schemas from "@/schemas"
@@ -64,8 +63,8 @@ export default function EditUserForm({
   )
 
   return (
-    <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
-      <Form {...form}>
+    <Forms.Provider form={form}>
+      <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing user"
           onCancel={() => onOpenChange(false)}
@@ -112,7 +111,7 @@ export default function EditUserForm({
             </Forms.Section.Column>
           </Forms.Section.Columns>
         </Forms.Layout.Sheet>
-      </Form>
-    </Forms.Container.Dialog>
+      </Forms.Container.Dialog>
+    </Forms.Provider>
   )
 }


### PR DESCRIPTION
Closes #34. Introduces a form provider component to replace direct usage of `Form` from `react-hook-form`. Also tries to separate "close" from "back" to prevent a user from accidentally exiting a form and losing progress.