### PR TITLE
Add routing and dialog guards to dirty forms

### DIFF
--- a/src/components/components/form/create.tsx
+++ b/src/components/components/form/create.tsx
@@ -38,10 +38,9 @@ export default function CreateComponentForm({
     async (values: Schemas.Components.CreateValues) => {
       const component = await createComponent.mutateAsync(values)
       toast({ message: "Component created", variant: "success" })
-      onOpenChange(false)
       await navigateToResource(component)
     },
-    [createComponent, navigateToResource, onOpenChange],
+    [createComponent, navigateToResource],
   )
 
   return (

--- a/src/components/components/form/create.tsx
+++ b/src/components/components/form/create.tsx
@@ -48,7 +48,6 @@ export default function CreateComponentForm({
     <Forms.Provider form={form}>
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
-          onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           isPending={createComponent.isPending}
           description="Creating a new component"

--- a/src/components/components/form/edit.tsx
+++ b/src/components/components/form/edit.tsx
@@ -50,7 +50,6 @@ export default function EditComponentForm({
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing component"
-          onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           errorMessage="Failed to update component"
           isPending={updateComponent.isPending}

--- a/src/components/components/form/edit.tsx
+++ b/src/components/components/form/edit.tsx
@@ -40,9 +40,8 @@ export default function EditComponentForm({
     async (values: Schemas.Components.UpdateValues) => {
       await updateComponent.mutateAsync(values)
       toast({ message: "Component updated", variant: "success" })
-      onOpenChange(false)
     },
-    [updateComponent, onOpenChange],
+    [updateComponent],
   )
 
   return (

--- a/src/components/entitlements/form/create.tsx
+++ b/src/components/entitlements/form/create.tsx
@@ -37,10 +37,9 @@ export default function CreateEntitlementForm({
     async (values: Schemas.Entitlements.CreateValues) => {
       const entitlement = await createEntitlement.mutateAsync(values)
       toast({ message: "Entitlement created", variant: "success" })
-      onOpenChange(false)
       await navigateToResource(entitlement)
     },
-    [createEntitlement, navigateToResource, onOpenChange],
+    [createEntitlement, navigateToResource],
   )
 
   return (

--- a/src/components/entitlements/form/create.tsx
+++ b/src/components/entitlements/form/create.tsx
@@ -47,7 +47,6 @@ export default function CreateEntitlementForm({
     <Forms.Provider form={form}>
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
-          onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           isPending={createEntitlement.isPending}
           description="Creating a new entitlement"

--- a/src/components/entitlements/form/edit.tsx
+++ b/src/components/entitlements/form/edit.tsx
@@ -41,9 +41,8 @@ export default function EditEntitlementForm({
     async (values: Schemas.Entitlements.UpdateValues) => {
       await updateEntitlement.mutateAsync(values)
       toast({ message: "Entitlement updated", variant: "success" })
-      onOpenChange(false)
     },
-    [updateEntitlement, onOpenChange],
+    [updateEntitlement],
   )
 
   return (

--- a/src/components/entitlements/form/edit.tsx
+++ b/src/components/entitlements/form/edit.tsx
@@ -51,7 +51,6 @@ export default function EditEntitlementForm({
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing entitlement"
-          onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           errorMessage="Failed to update entitlement"
           isPending={updateEntitlement.isPending}

--- a/src/components/environments/form/create.tsx
+++ b/src/components/environments/form/create.tsx
@@ -45,9 +45,8 @@ export default function CreateEnvironmentForm({
     async (values: Schemas.Environments.CreateValues) => {
       await createEnvironment.mutateAsync(values)
       toast({ message: "Environment created", variant: "success" })
-      onOpenChange(false)
     },
-    [createEnvironment, onOpenChange],
+    [createEnvironment],
   )
 
   return (

--- a/src/components/environments/form/create.tsx
+++ b/src/components/environments/form/create.tsx
@@ -58,7 +58,6 @@ export default function CreateEnvironmentForm({
         disableOverlay
       >
         <Forms.Layout.Wizard
-          onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           isPending={createEnvironment.isPending}
           errorMessage="Failed to create environment"

--- a/src/components/environments/form/edit.tsx
+++ b/src/components/environments/form/edit.tsx
@@ -53,7 +53,6 @@ export default function EditEnvironmentForm({
       >
         <Forms.Layout.Sheet
           title="Editing an existing environment"
-          onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           errorMessage="Failed to update environment"
           isPending={updateEnvironment.isPending}

--- a/src/components/environments/form/edit.tsx
+++ b/src/components/environments/form/edit.tsx
@@ -39,9 +39,8 @@ export default function EditEnvironmentForm({
     async (values: Schemas.Environments.UpdateValues) => {
       await updateEnvironment.mutateAsync(values)
       toast({ message: "Environment updated", variant: "success" })
-      onOpenChange(false)
     },
-    [updateEnvironment, onOpenChange],
+    [updateEnvironment],
   )
 
   return (

--- a/src/components/forms/container/dialog.tsx
+++ b/src/components/forms/container/dialog.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react"
 import {
   Dialog,
   DialogContent,
@@ -33,7 +34,7 @@ export default function FormsContainerDialog({
   className,
 }: FormsContainerDialogProps) {
   return (
-    <FormDialogGuard onOpenChange={onOpenChange}>
+    <FormDialogGuard onClose={() => onOpenChange(false)}>
       <FormsContainerDialogInner
         open={open}
         fullscreen={fullscreen}
@@ -62,10 +63,19 @@ function FormsContainerDialogInner({
   className,
 }: FormsContainerDialogInnerProps) {
   const isMobile = useMobile()
-  const { guardedOpenChange } = useFormDialogGuardContext()
+  const { abandonForm } = useFormDialogGuardContext()
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        abandonForm()
+      }
+    },
+    [abandonForm],
+  )
 
   return (
-    <Dialog open={open} onOpenChange={guardedOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         disableOverlay={disableOverlay}
         className={cn(

--- a/src/components/forms/container/dialog.tsx
+++ b/src/components/forms/container/dialog.tsx
@@ -63,15 +63,15 @@ function FormsContainerDialogInner({
   className,
 }: FormsContainerDialogInnerProps) {
   const isMobile = useMobile()
-  const { abandonForm } = useFormDialogGuardContext()
+  const { abandon } = useFormDialogGuardContext()
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
       if (!open) {
-        abandonForm()
+        abandon()
       }
     },
-    [abandonForm],
+    [abandon],
   )
 
   return (

--- a/src/components/forms/container/dialog.tsx
+++ b/src/components/forms/container/dialog.tsx
@@ -1,6 +1,3 @@
-import { useCallback } from "react"
-import { useFormContext } from "react-hook-form"
-
 import {
   Dialog,
   DialogContent,
@@ -12,6 +9,9 @@ import {
 } from "@/components/ui/dialog"
 
 import { useMobile } from "@/hooks/use-mobile"
+
+import { FormDialogGuard } from "@/components/forms/guard"
+import { useFormDialogGuardContext } from "@/contexts/form-dialog-guard-context"
 
 import { cn } from "@/lib/utils"
 
@@ -32,21 +32,40 @@ export default function FormsContainerDialog({
   children,
   className,
 }: FormsContainerDialogProps) {
-  const isMobile = useMobile()
-  const form = useFormContext()
-
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      onOpenChange(open)
-      if (!open) {
-        form.reset() // reset form when closed
-      }
-    },
-    [onOpenChange, form],
+  return (
+    <FormDialogGuard onOpenChange={onOpenChange}>
+      <FormsContainerDialogInner
+        open={open}
+        fullscreen={fullscreen}
+        disableOverlay={disableOverlay}
+        className={className}
+      >
+        {children}
+      </FormsContainerDialogInner>
+    </FormDialogGuard>
   )
+}
+
+interface FormsContainerDialogInnerProps {
+  open: boolean
+  fullscreen?: boolean
+  disableOverlay?: boolean
+  children: React.ReactNode
+  className?: string
+}
+
+function FormsContainerDialogInner({
+  open,
+  fullscreen = false,
+  disableOverlay = false,
+  children,
+  className,
+}: FormsContainerDialogInnerProps) {
+  const isMobile = useMobile()
+  const { guardedOpenChange } = useFormDialogGuardContext()
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={guardedOpenChange}>
       <DialogContent
         disableOverlay={disableOverlay}
         className={cn(
@@ -76,7 +95,9 @@ export function FormsContainerOverlay({
   open,
   onOpenChange,
 }: FormsContainerOverlayProps) {
-  if (!open) return null
+  if (!open) {
+    return null
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/forms/guard.tsx
+++ b/src/components/forms/guard.tsx
@@ -9,10 +9,10 @@ import { FormDialogGuardContext } from "@/contexts/form-dialog-guard-context"
 // FormRouteGuard blocks and confirms routing navigation when the form is dirty
 export function FormRouteGuard({ children }: { children: React.ReactNode }) {
   const form = useFormContext()
-  const { isDirty } = form.formState
+  const { isDirty, isSubmitting } = form.formState
 
   const { status, proceed, reset } = useBlocker({
-    shouldBlockFn: () => isDirty,
+    shouldBlockFn: () => isDirty && !isSubmitting,
     withResolver: true,
     enableBeforeUnload: false,
   })

--- a/src/components/forms/guard.tsx
+++ b/src/components/forms/guard.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useState } from "react"
+import { useFormContext } from "react-hook-form"
+import { useBlocker } from "@tanstack/react-router"
+
+import UnsavedChangesModal from "@/components/unsaved-changes-modal"
+
+import { FormDialogGuardContext } from "@/contexts/form-dialog-guard-context"
+
+// FormRouteGuard blocks and confirms routing navigation when the form is dirty
+export function FormRouteGuard({ children }: { children: React.ReactNode }) {
+  const form = useFormContext()
+  const { isDirty } = form.formState
+
+  const { status, proceed, reset } = useBlocker({
+    shouldBlockFn: () => isDirty,
+    withResolver: true,
+    enableBeforeUnload: false,
+  })
+
+  const handleConfirm = useCallback(() => {
+    proceed?.()
+  }, [proceed])
+
+  const handleCancel = useCallback(() => {
+    reset?.()
+  }, [reset])
+
+  return (
+    <>
+      {children}
+      <UnsavedChangesModal
+        open={status === "blocked"}
+        onClose={handleCancel}
+        onConfirm={handleConfirm}
+      />
+    </>
+  )
+}
+
+interface FormDialogGuardProps {
+  onOpenChange: (open: boolean) => void
+  children: React.ReactNode
+}
+
+// FormDialogGuard intercepts and confirms dialog close when the form is dirty
+export function FormDialogGuard({
+  onOpenChange,
+  children,
+}: FormDialogGuardProps) {
+  const form = useFormContext()
+  const { isDirty } = form.formState
+  const [closeBlocked, setCloseBlocked] = useState(false)
+
+  const guardedOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen && isDirty) {
+        setCloseBlocked(true)
+        return
+      }
+
+      if (!nextOpen) {
+        form.reset()
+      }
+
+      onOpenChange(nextOpen)
+    },
+    [isDirty, onOpenChange, form],
+  )
+
+  const handleConfirm = useCallback(() => {
+    setCloseBlocked(false)
+    form.reset()
+    onOpenChange(false)
+  }, [form, onOpenChange])
+
+  const handleCancel = useCallback(() => {
+    setCloseBlocked(false)
+  }, [])
+
+  return (
+    <FormDialogGuardContext.Provider value={{ guardedOpenChange }}>
+      {children}
+      <UnsavedChangesModal
+        open={closeBlocked}
+        onClose={handleCancel}
+        onConfirm={handleConfirm}
+      />
+    </FormDialogGuardContext.Provider>
+  )
+}

--- a/src/components/forms/guard.tsx
+++ b/src/components/forms/guard.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useState } from "react"
-import { useFormContext } from "react-hook-form"
+import { useCallback, useMemo, useState } from "react"
+import { useFormContext, useFormState } from "react-hook-form"
 import { useBlocker } from "@tanstack/react-router"
 
 import UnsavedChangesModal from "@/components/unsaved-changes-modal"
@@ -8,8 +8,19 @@ import { FormDialogGuardContext } from "@/contexts/form-dialog-guard-context"
 
 // FormRouteGuard blocks and confirms routing navigation when the form is dirty
 export function FormRouteGuard({ children }: { children: React.ReactNode }) {
-  const form = useFormContext()
-  const { isDirty, isSubmitting } = form.formState
+  return (
+    <>
+      {children}
+      <FormRouteGuardModal />
+    </>
+  )
+}
+
+// NB(ezekg) FormRouteGuardModal isolates isDirty/isSubmitting subscriptions outside
+//           of the main guard to avoid unnecessary re-renders of its children
+function FormRouteGuardModal() {
+  const { control } = useFormContext()
+  const { isDirty, isSubmitting } = useFormState({ control })
 
   const { status, proceed, reset } = useBlocker({
     shouldBlockFn: () => isDirty && !isSubmitting,
@@ -26,14 +37,11 @@ export function FormRouteGuard({ children }: { children: React.ReactNode }) {
   }, [reset])
 
   return (
-    <>
-      {children}
-      <UnsavedChangesModal
-        open={status === "blocked"}
-        onClose={handleCancel}
-        onConfirm={handleConfirm}
-      />
-    </>
+    <UnsavedChangesModal
+      open={status === "blocked"}
+      onClose={handleCancel}
+      onConfirm={handleConfirm}
+    />
   )
 }
 
@@ -45,7 +53,12 @@ interface FormDialogGuardProps {
 // FormDialogGuard intercepts and confirms dialog close when the form is dirty
 export function FormDialogGuard({ onClose, children }: FormDialogGuardProps) {
   const form = useFormContext()
-  const { isDirty } = form.formState
+
+  // NB(ezekg) isolate isDirty subscription to avoid unnecessary re-renders
+  const { isDirty } = useFormState({
+    control: form.control,
+  })
+
   const [pendingAction, setPendingAction] = useState<(() => void) | null>(null)
 
   const close = useCallback(() => {
@@ -65,7 +78,7 @@ export function FormDialogGuard({ onClose, children }: FormDialogGuardProps) {
       form.reset()
       action()
     },
-    [isDirty, form, onClose],
+    [form, onClose, isDirty],
   )
 
   const handleConfirm = useCallback(() => {
@@ -79,8 +92,10 @@ export function FormDialogGuard({ onClose, children }: FormDialogGuardProps) {
     setPendingAction(null)
   }, [])
 
+  const contextValue = useMemo(() => ({ abandon, close }), [abandon, close])
+
   return (
-    <FormDialogGuardContext.Provider value={{ abandon, close }}>
+    <FormDialogGuardContext.Provider value={contextValue}>
       {children}
       <UnsavedChangesModal
         open={pendingAction !== null}

--- a/src/components/forms/guard.tsx
+++ b/src/components/forms/guard.tsx
@@ -49,10 +49,11 @@ export function FormDialogGuard({ onClose, children }: FormDialogGuardProps) {
   const [pendingAction, setPendingAction] = useState<(() => void) | null>(null)
 
   const close = useCallback(() => {
+    form.reset()
     onClose()
-  }, [onClose])
+  }, [form, onClose])
 
-  const abandonForm = useCallback(
+  const abandon = useCallback(
     (action?: () => void) => {
       const resolve = action ?? onClose
 
@@ -79,7 +80,7 @@ export function FormDialogGuard({ onClose, children }: FormDialogGuardProps) {
   }, [])
 
   return (
-    <FormDialogGuardContext.Provider value={{ abandonForm, close }}>
+    <FormDialogGuardContext.Provider value={{ abandon, close }}>
       {children}
       <UnsavedChangesModal
         open={pendingAction !== null}

--- a/src/components/forms/guard.tsx
+++ b/src/components/forms/guard.tsx
@@ -48,22 +48,22 @@ export function FormDialogGuard({ onClose, children }: FormDialogGuardProps) {
   const { isDirty } = form.formState
   const [pendingAction, setPendingAction] = useState<(() => void) | null>(null)
 
-  const close = useCallback(() => {
+  const complete = useCallback(() => {
     form.reset()
     onClose()
   }, [form, onClose])
 
   const abandon = useCallback(
-    (action?: () => void) => {
-      const resolve = action ?? onClose
+    (callback?: () => void) => {
+      const action = callback ?? onClose
 
       if (isDirty) {
-        setPendingAction(() => resolve)
+        setPendingAction(() => action)
         return
       }
 
       form.reset()
-      resolve()
+      action()
     },
     [isDirty, form, onClose],
   )
@@ -80,7 +80,7 @@ export function FormDialogGuard({ onClose, children }: FormDialogGuardProps) {
   }, [])
 
   return (
-    <FormDialogGuardContext.Provider value={{ abandon, close }}>
+    <FormDialogGuardContext.Provider value={{ abandon, complete }}>
       {children}
       <UnsavedChangesModal
         open={pendingAction !== null}

--- a/src/components/forms/guard.tsx
+++ b/src/components/forms/guard.tsx
@@ -38,50 +38,47 @@ export function FormRouteGuard({ children }: { children: React.ReactNode }) {
 }
 
 interface FormDialogGuardProps {
-  onOpenChange: (open: boolean) => void
+  onClose: () => void
   children: React.ReactNode
 }
 
 // FormDialogGuard intercepts and confirms dialog close when the form is dirty
-export function FormDialogGuard({
-  onOpenChange,
-  children,
-}: FormDialogGuardProps) {
+export function FormDialogGuard({ onClose, children }: FormDialogGuardProps) {
   const form = useFormContext()
   const { isDirty } = form.formState
-  const [closeBlocked, setCloseBlocked] = useState(false)
+  const [pendingAction, setPendingAction] = useState<(() => void) | null>(null)
 
-  const guardedOpenChange = useCallback(
-    (nextOpen: boolean) => {
-      if (!nextOpen && isDirty) {
-        setCloseBlocked(true)
+  const abandonForm = useCallback(
+    (action?: () => void) => {
+      const resolve = action ?? onClose
+
+      if (isDirty) {
+        setPendingAction(() => resolve)
         return
       }
 
-      if (!nextOpen) {
-        form.reset()
-      }
-
-      onOpenChange(nextOpen)
+      form.reset()
+      resolve()
     },
-    [isDirty, onOpenChange, form],
+    [isDirty, form, onClose],
   )
 
   const handleConfirm = useCallback(() => {
-    setCloseBlocked(false)
+    const action = pendingAction
+    setPendingAction(null)
     form.reset()
-    onOpenChange(false)
-  }, [form, onOpenChange])
+    action?.()
+  }, [form, pendingAction])
 
   const handleCancel = useCallback(() => {
-    setCloseBlocked(false)
+    setPendingAction(null)
   }, [])
 
   return (
-    <FormDialogGuardContext.Provider value={{ guardedOpenChange }}>
+    <FormDialogGuardContext.Provider value={{ abandonForm }}>
       {children}
       <UnsavedChangesModal
-        open={closeBlocked}
+        open={pendingAction !== null}
         onClose={handleCancel}
         onConfirm={handleConfirm}
       />

--- a/src/components/forms/guard.tsx
+++ b/src/components/forms/guard.tsx
@@ -48,6 +48,10 @@ export function FormDialogGuard({ onClose, children }: FormDialogGuardProps) {
   const { isDirty } = form.formState
   const [pendingAction, setPendingAction] = useState<(() => void) | null>(null)
 
+  const close = useCallback(() => {
+    onClose()
+  }, [onClose])
+
   const abandonForm = useCallback(
     (action?: () => void) => {
       const resolve = action ?? onClose
@@ -75,7 +79,7 @@ export function FormDialogGuard({ onClose, children }: FormDialogGuardProps) {
   }, [])
 
   return (
-    <FormDialogGuardContext.Provider value={{ abandonForm }}>
+    <FormDialogGuardContext.Provider value={{ abandonForm, close }}>
       {children}
       <UnsavedChangesModal
         open={pendingAction !== null}

--- a/src/components/forms/guard.tsx
+++ b/src/components/forms/guard.tsx
@@ -48,7 +48,7 @@ export function FormDialogGuard({ onClose, children }: FormDialogGuardProps) {
   const { isDirty } = form.formState
   const [pendingAction, setPendingAction] = useState<(() => void) | null>(null)
 
-  const complete = useCallback(() => {
+  const close = useCallback(() => {
     form.reset()
     onClose()
   }, [form, onClose])
@@ -80,7 +80,7 @@ export function FormDialogGuard({ onClose, children }: FormDialogGuardProps) {
   }, [])
 
   return (
-    <FormDialogGuardContext.Provider value={{ abandon, complete }}>
+    <FormDialogGuardContext.Provider value={{ abandon, close }}>
       {children}
       <UnsavedChangesModal
         open={pendingAction !== null}

--- a/src/components/forms/layout/sheet.tsx
+++ b/src/components/forms/layout/sheet.tsx
@@ -46,7 +46,7 @@ export default function FormsContentSheet<T extends FieldValues = FieldValues>({
       async (data) => {
         try {
           await onSubmit(data as T)
-          guard.complete()
+          guard.close()
         } catch (error) {
           if (errorMessage && error instanceof APIError) {
             await handleFormError({

--- a/src/components/forms/layout/sheet.tsx
+++ b/src/components/forms/layout/sheet.tsx
@@ -18,7 +18,6 @@ import * as Loading from "@/components/loading"
 interface FormsContentSheetProps<T extends FieldValues = FieldValues> {
   title: string
   onSubmit: (data: T) => void | Promise<void>
-  onCancel?: () => void
   errorMessage?: string
   submitLabel?: string
   cancelLabel?: string
@@ -31,7 +30,6 @@ interface FormsContentSheetProps<T extends FieldValues = FieldValues> {
 export default function FormsContentSheet<T extends FieldValues = FieldValues>({
   title,
   onSubmit,
-  onCancel,
   errorMessage,
   submitLabel = "Submit",
   cancelLabel = "Cancel",
@@ -47,7 +45,9 @@ export default function FormsContentSheet<T extends FieldValues = FieldValues>({
     await form.handleSubmit(
       async (data) => {
         try {
+          form.reset(data)
           await onSubmit(data as T)
+          guard.abandonForm()
         } catch (error) {
           if (errorMessage && error instanceof APIError) {
             await handleFormError({
@@ -101,7 +101,7 @@ export default function FormsContentSheet<T extends FieldValues = FieldValues>({
         <Button
           variant="outline"
           type="button"
-          onClick={onCancel ?? (() => guard.guardedOpenChange(false))}
+          onClick={() => guard.abandonForm()}
           disabled={isPending}
           className="max-w-48 flex-1 basis-1/2"
         >

--- a/src/components/forms/layout/sheet.tsx
+++ b/src/components/forms/layout/sheet.tsx
@@ -45,7 +45,6 @@ export default function FormsContentSheet<T extends FieldValues = FieldValues>({
     await form.handleSubmit(
       async (data) => {
         try {
-          form.reset(data)
           await onSubmit(data as T)
           guard.close()
         } catch (error) {
@@ -101,7 +100,7 @@ export default function FormsContentSheet<T extends FieldValues = FieldValues>({
         <Button
           variant="outline"
           type="button"
-          onClick={() => guard.abandonForm()}
+          onClick={() => guard.abandon()}
           disabled={isPending}
           className="max-w-48 flex-1 basis-1/2"
         >

--- a/src/components/forms/layout/sheet.tsx
+++ b/src/components/forms/layout/sheet.tsx
@@ -46,7 +46,7 @@ export default function FormsContentSheet<T extends FieldValues = FieldValues>({
       async (data) => {
         try {
           await onSubmit(data as T)
-          guard.close()
+          guard.complete()
         } catch (error) {
           if (errorMessage && error instanceof APIError) {
             await handleFormError({

--- a/src/components/forms/layout/sheet.tsx
+++ b/src/components/forms/layout/sheet.tsx
@@ -47,7 +47,7 @@ export default function FormsContentSheet<T extends FieldValues = FieldValues>({
         try {
           form.reset(data)
           await onSubmit(data as T)
-          guard.abandonForm()
+          guard.close()
         } catch (error) {
           if (errorMessage && error instanceof APIError) {
             await handleFormError({

--- a/src/components/forms/layout/sheet.tsx
+++ b/src/components/forms/layout/sheet.tsx
@@ -11,12 +11,14 @@ import { handleFormError } from "@/lib/form-errors"
 
 import { useSubmitOnce } from "@/hooks/use-submit-once"
 
+import { useFormDialogGuardContext } from "@/contexts/form-dialog-guard-context"
+
 import * as Loading from "@/components/loading"
 
 interface FormsContentSheetProps<T extends FieldValues = FieldValues> {
   title: string
   onSubmit: (data: T) => void | Promise<void>
-  onCancel: () => void
+  onCancel?: () => void
   errorMessage?: string
   submitLabel?: string
   cancelLabel?: string
@@ -39,6 +41,7 @@ export default function FormsContentSheet<T extends FieldValues = FieldValues>({
   className,
 }: FormsContentSheetProps<T>) {
   const form = useFormContext()
+  const guard = useFormDialogGuardContext()
 
   const [submitOnce, resetSubmitOnce] = useSubmitOnce(async () => {
     await form.handleSubmit(
@@ -98,7 +101,7 @@ export default function FormsContentSheet<T extends FieldValues = FieldValues>({
         <Button
           variant="outline"
           type="button"
-          onClick={onCancel}
+          onClick={onCancel ?? (() => guard.guardedOpenChange(false))}
           disabled={isPending}
           className="max-w-48 flex-1 basis-1/2"
         >

--- a/src/components/forms/layout/wizard.tsx
+++ b/src/components/forms/layout/wizard.tsx
@@ -119,7 +119,7 @@ export default function FormsContentWizard<
         try {
           await onSubmit(data as T)
           if (autoClose) {
-            guard.complete()
+            guard.close()
           } else {
             form.reset()
           }

--- a/src/components/forms/layout/wizard.tsx
+++ b/src/components/forms/layout/wizard.tsx
@@ -119,7 +119,6 @@ export default function FormsContentWizard<
         try {
           await onSubmit(data as T)
           if (autoClose) {
-            form.reset(data)
             guard.close()
           }
         } catch (error) {
@@ -191,9 +190,9 @@ export default function FormsContentWizard<
   const back = useCallback(() => {
     if (isFirst) {
       if (onBack) {
-        guard.abandonForm(onBack)
+        guard.abandon(onBack)
       } else {
-        guard.abandonForm()
+        guard.abandon()
       }
     } else {
       goTo(currentIndex - 1)
@@ -212,7 +211,7 @@ export default function FormsContentWizard<
       isLast={isLast}
       next={next}
       back={back}
-      onCancel={() => guard.abandonForm()}
+      onCancel={() => guard.abandon()}
       submitLabel={submitLabel}
       backLabel={backLabel}
       cancelLabel={cancelLabel}

--- a/src/components/forms/layout/wizard.tsx
+++ b/src/components/forms/layout/wizard.tsx
@@ -120,7 +120,7 @@ export default function FormsContentWizard<
           await onSubmit(data as T)
           if (autoClose) {
             form.reset(data)
-            guard.abandonForm()
+            guard.close()
           }
         } catch (error) {
           if (errorMessage && error instanceof APIError) {

--- a/src/components/forms/layout/wizard.tsx
+++ b/src/components/forms/layout/wizard.tsx
@@ -13,6 +13,8 @@ import { useMobile } from "@/hooks/use-mobile"
 import { useSlide } from "@/hooks/use-slide"
 import { useSubmitOnce } from "@/hooks/use-submit-once"
 
+import { useFormDialogGuardContext } from "@/contexts/form-dialog-guard-context"
+
 import * as Motion from "@/components/motion"
 import * as Loading from "@/components/loading"
 import StepProgress from "@/components/step-progress"
@@ -36,7 +38,7 @@ interface FormsContentWizardProps<T extends FieldValues = FieldValues> {
   title?: string
   description?: React.ReactNode
   onSubmit: (data: T) => void | Promise<void>
-  onBack: () => void
+  onBack?: () => void
   onCancel?: () => void
   errorMessage?: string
   submitLabel?: string
@@ -91,6 +93,7 @@ export default function FormsContentWizard<
   className,
 }: FormsContentWizardProps<T>) {
   const form = useFormContext()
+  const guard = useFormDialogGuardContext()
   const steps = useMemo(() => getStepsFromChildren(children), [children])
 
   const stepIndices = useMemo(() => steps.map((_, i) => i), [steps])
@@ -183,11 +186,15 @@ export default function FormsContentWizard<
 
   const back = useCallback(() => {
     if (isFirst) {
-      onBack()
+      if (onBack) {
+        onBack()
+      } else {
+        guard.guardedOpenChange(false)
+      }
     } else {
       goTo(currentIndex - 1)
     }
-  }, [currentIndex, isFirst, goTo, onBack])
+  }, [currentIndex, isFirst, goTo, onBack, guard])
 
   return variant === "sidebar" ? (
     <SidebarContent
@@ -201,7 +208,7 @@ export default function FormsContentWizard<
       isLast={isLast}
       next={next}
       back={back}
-      onCancel={onCancel ?? onBack}
+      onCancel={onCancel ?? (() => guard.guardedOpenChange(false))}
       submitLabel={submitLabel}
       backLabel={backLabel}
       cancelLabel={cancelLabel}

--- a/src/components/forms/layout/wizard.tsx
+++ b/src/components/forms/layout/wizard.tsx
@@ -39,7 +39,6 @@ interface FormsContentWizardProps<T extends FieldValues = FieldValues> {
   description?: React.ReactNode
   onSubmit: (data: T) => void | Promise<void>
   onBack?: () => void
-  onCancel?: () => void
   errorMessage?: string
   submitLabel?: string
   backLabel?: string
@@ -83,7 +82,6 @@ export default function FormsContentWizard<
   description,
   onSubmit,
   onBack,
-  onCancel,
   errorMessage,
   submitLabel = "Submit",
   backLabel = "Back",
@@ -117,7 +115,9 @@ export default function FormsContentWizard<
     await form.handleSubmit(
       async (data) => {
         try {
+          form.reset(data)
           await onSubmit(data as T)
+          guard.abandonForm()
         } catch (error) {
           if (errorMessage && error instanceof APIError) {
             await handleFormError({
@@ -187,9 +187,9 @@ export default function FormsContentWizard<
   const back = useCallback(() => {
     if (isFirst) {
       if (onBack) {
-        onBack()
+        guard.abandonForm(onBack)
       } else {
-        guard.guardedOpenChange(false)
+        guard.abandonForm()
       }
     } else {
       goTo(currentIndex - 1)
@@ -208,7 +208,7 @@ export default function FormsContentWizard<
       isLast={isLast}
       next={next}
       back={back}
-      onCancel={onCancel ?? (() => guard.guardedOpenChange(false))}
+      onCancel={() => guard.abandonForm()}
       submitLabel={submitLabel}
       backLabel={backLabel}
       cancelLabel={cancelLabel}

--- a/src/components/forms/layout/wizard.tsx
+++ b/src/components/forms/layout/wizard.tsx
@@ -119,7 +119,7 @@ export default function FormsContentWizard<
         try {
           await onSubmit(data as T)
           if (autoClose) {
-            guard.close()
+            guard.complete()
           }
         } catch (error) {
           if (errorMessage && error instanceof APIError) {

--- a/src/components/forms/layout/wizard.tsx
+++ b/src/components/forms/layout/wizard.tsx
@@ -120,6 +120,8 @@ export default function FormsContentWizard<
           await onSubmit(data as T)
           if (autoClose) {
             guard.complete()
+          } else {
+            form.reset()
           }
         } catch (error) {
           if (errorMessage && error instanceof APIError) {

--- a/src/components/forms/layout/wizard.tsx
+++ b/src/components/forms/layout/wizard.tsx
@@ -39,6 +39,7 @@ interface FormsContentWizardProps<T extends FieldValues = FieldValues> {
   description?: React.ReactNode
   onSubmit: (data: T) => void | Promise<void>
   onBack?: () => void
+  autoClose?: boolean
   errorMessage?: string
   submitLabel?: string
   backLabel?: string
@@ -82,6 +83,7 @@ export default function FormsContentWizard<
   description,
   onSubmit,
   onBack,
+  autoClose = true,
   errorMessage,
   submitLabel = "Submit",
   backLabel = "Back",
@@ -115,9 +117,11 @@ export default function FormsContentWizard<
     await form.handleSubmit(
       async (data) => {
         try {
-          form.reset(data)
           await onSubmit(data as T)
-          guard.abandonForm()
+          if (autoClose) {
+            form.reset(data)
+            guard.abandonForm()
+          }
         } catch (error) {
           if (errorMessage && error instanceof APIError) {
             await handleFormError({

--- a/src/components/forms/provider.tsx
+++ b/src/components/forms/provider.tsx
@@ -4,6 +4,8 @@ import {
   FormProvider,
 } from "react-hook-form"
 
+import { FormRouteGuard } from "@/components/forms/guard"
+
 interface FormsProviderProps<T extends FieldValues = FieldValues> {
   form: UseFormReturn<T>
   children: React.ReactNode
@@ -13,5 +15,9 @@ export default function FormsProvider<T extends FieldValues = FieldValues>({
   form,
   children,
 }: FormsProviderProps<T>) {
-  return <FormProvider {...form}>{children}</FormProvider>
+  return (
+    <FormProvider {...form}>
+      <FormRouteGuard>{children}</FormRouteGuard>
+    </FormProvider>
+  )
 }

--- a/src/components/groups/form/create.tsx
+++ b/src/components/groups/form/create.tsx
@@ -39,10 +39,9 @@ export default function CreateGroupForm({
     async (values: Schemas.Groups.CreateValues) => {
       const group = await createGroup.mutateAsync(values)
       toast({ message: "Group created", variant: "success" })
-      onOpenChange(false)
       await navigateToResource(group)
     },
-    [createGroup, navigateToResource, onOpenChange],
+    [createGroup, navigateToResource],
   )
 
   return (

--- a/src/components/groups/form/create.tsx
+++ b/src/components/groups/form/create.tsx
@@ -50,7 +50,6 @@ export default function CreateGroupForm({
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
           description="Creating a new group"
-          onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           isPending={createGroup.isPending}
           errorMessage="Failed to create group"

--- a/src/components/groups/form/edit.tsx
+++ b/src/components/groups/form/edit.tsx
@@ -44,9 +44,8 @@ export default function EditGroupForm({
     async (values: Schemas.Groups.UpdateValues) => {
       await updateGroup.mutateAsync(values)
       toast({ message: "Group updated", variant: "success" })
-      onOpenChange(false)
     },
-    [updateGroup, onOpenChange],
+    [updateGroup],
   )
 
   return (

--- a/src/components/groups/form/edit.tsx
+++ b/src/components/groups/form/edit.tsx
@@ -54,7 +54,6 @@ export default function EditGroupForm({
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing group"
-          onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           errorMessage="Failed to update group"
           isPending={updateGroup.isPending}

--- a/src/components/licenses/form/check-out.tsx
+++ b/src/components/licenses/form/check-out.tsx
@@ -124,10 +124,6 @@ export default function CheckOutLicenseForm({
           disableOverlay
         >
           <Forms.Layout.Wizard
-            // NB(ezekg) using raw open handler so we don't clear form on "back"
-            //           i.e. it's less explicit than "close" and we don't want
-            //           the user to lose form state on accidental close
-            onBack={() => onOpenChange(false)}
             onSubmit={() => form.handleSubmit(handleCheckOut)()}
             isPending={checkOutLicense.isPending}
             submitLabel="Checkout license"

--- a/src/components/licenses/form/check-out.tsx
+++ b/src/components/licenses/form/check-out.tsx
@@ -107,10 +107,9 @@ export default function CheckOutLicenseForm({
       if (!value) {
         setShowResult(false)
         setCertificate("")
-        form.reset()
       }
     },
-    [onOpenChange, form],
+    [onOpenChange],
   )
 
   return (

--- a/src/components/licenses/form/check-out.tsx
+++ b/src/components/licenses/form/check-out.tsx
@@ -124,7 +124,8 @@ export default function CheckOutLicenseForm({
           disableOverlay
         >
           <Forms.Layout.Wizard
-            onSubmit={() => form.handleSubmit(handleCheckOut)()}
+            onSubmit={handleCheckOut}
+            autoClose={false}
             isPending={checkOutLicense.isPending}
             submitLabel="Checkout license"
             description="Checking out a license"

--- a/src/components/licenses/form/create.tsx
+++ b/src/components/licenses/form/create.tsx
@@ -87,7 +87,6 @@ export default function CreateLicenseForm({
         await attachUsers.mutateAsync({ licenseId: license.id, userIds })
 
       toast({ message: "License created", variant: "success" })
-      onOpenChange(false)
       await navigateToResource(license)
     },
     [
@@ -97,7 +96,6 @@ export default function CreateLicenseForm({
       attachEntitlements,
       attachUsers,
       navigateToResource,
-      onOpenChange,
     ],
   )
 

--- a/src/components/licenses/form/create.tsx
+++ b/src/components/licenses/form/create.tsx
@@ -105,7 +105,6 @@ export default function CreateLicenseForm({
     <Forms.Provider form={form}>
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
-          onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           isPending={
             createLicense.isPending ||

--- a/src/components/licenses/form/edit.tsx
+++ b/src/components/licenses/form/edit.tsx
@@ -128,12 +128,10 @@ export default function EditLicenseForm({
 
       await updateLicense.mutateAsync(values)
       toast({ message: "License updated", variant: "success" })
-      onOpenChange(false)
     },
     [
       form,
       license,
-      onOpenChange,
       updateLicense,
       licenseEntitlements,
       attachEntitlements,

--- a/src/components/licenses/form/edit.tsx
+++ b/src/components/licenses/form/edit.tsx
@@ -154,7 +154,6 @@ export default function EditLicenseForm({
       >
         <Forms.Layout.Sheet
           title="Editing an existing license"
-          onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           errorMessage="Failed to update license"
           isPending={

--- a/src/components/machines/form/check-out.tsx
+++ b/src/components/machines/form/check-out.tsx
@@ -109,10 +109,9 @@ export default function CheckOutMachineForm({
       if (!value) {
         setShowResult(false)
         setCertificate("")
-        form.reset()
       }
     },
-    [onOpenChange, form],
+    [onOpenChange],
   )
 
   return (

--- a/src/components/machines/form/check-out.tsx
+++ b/src/components/machines/form/check-out.tsx
@@ -126,10 +126,6 @@ export default function CheckOutMachineForm({
           disableOverlay
         >
           <Forms.Layout.Wizard
-            // NB(ezekg) using raw open handler so we don't clear form on "back"
-            //           i.e. it's less explicit than "close" and we don't want
-            //           the user to lose form state on accidental close
-            onBack={() => onOpenChange(false)}
             onSubmit={() => form.handleSubmit(handleCheckOut)()}
             isPending={checkOutMachine.isPending}
             submitLabel="Checkout machine"

--- a/src/components/machines/form/check-out.tsx
+++ b/src/components/machines/form/check-out.tsx
@@ -126,7 +126,8 @@ export default function CheckOutMachineForm({
           disableOverlay
         >
           <Forms.Layout.Wizard
-            onSubmit={() => form.handleSubmit(handleCheckOut)()}
+            onSubmit={handleCheckOut}
+            autoClose={false}
             isPending={checkOutMachine.isPending}
             submitLabel="Checkout machine"
             description="Checking out a machine"

--- a/src/components/machines/form/create.tsx
+++ b/src/components/machines/form/create.tsx
@@ -77,7 +77,6 @@ export default function CreateMachineForm({
     <Forms.Provider form={form}>
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
-          onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           isPending={
             createMachine.isPending ||

--- a/src/components/machines/form/create.tsx
+++ b/src/components/machines/form/create.tsx
@@ -67,10 +67,9 @@ export default function CreateMachineForm({
       }
 
       toast({ message: "Machine activated", variant: "success" })
-      onOpenChange(false)
       await navigateToResource(machine)
     },
-    [createMachine, changeGroup, changeOwner, navigateToResource, onOpenChange],
+    [createMachine, changeGroup, changeOwner, navigateToResource],
   )
 
   return (

--- a/src/components/machines/form/edit.tsx
+++ b/src/components/machines/form/edit.tsx
@@ -77,9 +77,8 @@ export default function EditMachineForm({
 
       await updateMachine.mutateAsync(values)
       toast({ message: "Machine updated", variant: "success" })
-      onOpenChange(false)
     },
-    [machine, updateMachine, changeGroup, changeOwner, onOpenChange],
+    [machine, updateMachine, changeGroup, changeOwner],
   )
 
   return (

--- a/src/components/machines/form/edit.tsx
+++ b/src/components/machines/form/edit.tsx
@@ -87,7 +87,6 @@ export default function EditMachineForm({
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing machine"
-          onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           errorMessage="Failed to update machine"
           isPending={

--- a/src/components/packages/form/create.tsx
+++ b/src/components/packages/form/create.tsx
@@ -42,10 +42,9 @@ export default function CreatePackageForm({
       const pkg = await createPackage.mutateAsync(values)
 
       toast({ message: "Package created", variant: "success" })
-      onOpenChange(false)
       await navigateToResource(pkg)
     },
-    [createPackage, navigateToResource, onOpenChange],
+    [createPackage, navigateToResource],
   )
 
   return (

--- a/src/components/packages/form/edit.tsx
+++ b/src/components/packages/form/edit.tsx
@@ -45,9 +45,8 @@ export default function EditPackageForm({
 
       await updatePackage.mutateAsync(values)
       toast({ message: "Package updated", variant: "success" })
-      onOpenChange(false)
     },
-    [pkg, onOpenChange, updatePackage],
+    [pkg, updatePackage],
   )
 
   return (
@@ -55,7 +54,6 @@ export default function EditPackageForm({
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing package"
-          onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           errorMessage="Failed to update package"
           isPending={updatePackage.isPending}

--- a/src/components/policies/form/create.tsx
+++ b/src/components/policies/form/create.tsx
@@ -149,7 +149,6 @@ export default function CreatePolicyForm({
 
       toast({ message: "Policy created", variant: "success" })
       await navigateToResource(policy)
-      onOpenChange(false)
     },
     [
       form,
@@ -157,7 +156,6 @@ export default function CreatePolicyForm({
       createEntitlement,
       attachEntitlements,
       navigateToResource,
-      onOpenChange,
     ],
   )
 
@@ -899,7 +897,6 @@ function ScratchForm({
           variant="sidebar"
           title="Creating a new policy"
           onSubmit={onSubmit}
-          onCancel={onBack}
           onBack={onBack}
           isPending={isPending}
           errorMessage={errorMessage}

--- a/src/components/policies/form/create.tsx
+++ b/src/components/policies/form/create.tsx
@@ -180,7 +180,7 @@ export default function CreatePolicyForm({
   )
 
   return (
-    <>
+    <Forms.Provider form={form}>
       <Forms.Container.Overlay open={open} onOpenChange={handleOpenChange} />
 
       {mode === "templates" && !selection && (
@@ -237,7 +237,7 @@ export default function CreatePolicyForm({
           errorMessage="Failed to create policy"
         />
       )}
-    </>
+    </Forms.Provider>
   )
 }
 

--- a/src/components/policies/form/duplicate.tsx
+++ b/src/components/policies/form/duplicate.tsx
@@ -91,7 +91,6 @@ export default function DuplicatePolicyForm({
         })
 
       toast({ message: "Policy created", variant: "success" })
-      onOpenChange(false)
       await navigateToResource(created)
     },
     [
@@ -101,7 +100,6 @@ export default function DuplicatePolicyForm({
       createEntitlement,
       attachEntitlements,
       navigateToResource,
-      onOpenChange,
     ],
   )
 

--- a/src/components/policies/form/duplicate.tsx
+++ b/src/components/policies/form/duplicate.tsx
@@ -138,7 +138,6 @@ export default function DuplicatePolicyForm({
           <Forms.Layout.Sheet
             title="Duplicating an existing policy"
             onSubmit={handleSubmit}
-            onCancel={() => onOpenChange(false)}
             errorMessage="Failed to create policy"
             isPending={
               createPolicy.isPending ||

--- a/src/components/policies/form/edit.tsx
+++ b/src/components/policies/form/edit.tsx
@@ -89,12 +89,10 @@ export default function EditPolicyForm({
 
       await updatePolicy.mutateAsync(values)
       toast({ message: "Policy updated", variant: "success" })
-      onOpenChange(false)
     },
     [
       form,
       policy,
-      onOpenChange,
       updatePolicy,
       policyEntitlements,
       attachEntitlements,

--- a/src/components/policies/form/edit.tsx
+++ b/src/components/policies/form/edit.tsx
@@ -113,7 +113,6 @@ export default function EditPolicyForm({
         <Forms.Layout.Sheet
           title="Editing an existing policy"
           onSubmit={handleSubmit}
-          onCancel={() => onOpenChange(false)}
           errorMessage="Failed to update policy"
           isPending={
             updatePolicy.isPending ||

--- a/src/components/processes/form/create.tsx
+++ b/src/components/processes/form/create.tsx
@@ -47,7 +47,6 @@ export default function CreateProcessForm({
     <Forms.Provider form={form}>
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
-          onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           isPending={createProcess.isPending}
           submitLabel="Spawn"

--- a/src/components/processes/form/create.tsx
+++ b/src/components/processes/form/create.tsx
@@ -37,10 +37,9 @@ export default function CreateProcessForm({
     async (values: Schemas.Processes.CreateValues) => {
       const process = await createProcess.mutateAsync(values)
       toast({ message: "Process spawned", variant: "success" })
-      onOpenChange(false)
       await navigateToResource(process)
     },
-    [createProcess, navigateToResource, onOpenChange],
+    [createProcess, navigateToResource],
   )
 
   return (

--- a/src/components/processes/form/edit.tsx
+++ b/src/components/processes/form/edit.tsx
@@ -37,9 +37,8 @@ export default function EditProcessForm({
     async (values: Schemas.Processes.UpdateValues) => {
       await updateProcess.mutateAsync(values)
       toast({ message: "Process updated", variant: "success" })
-      onOpenChange(false)
     },
-    [updateProcess, onOpenChange],
+    [updateProcess],
   )
 
   return (

--- a/src/components/processes/form/edit.tsx
+++ b/src/components/processes/form/edit.tsx
@@ -47,7 +47,6 @@ export default function EditProcessForm({
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing process"
-          onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           errorMessage="Failed to update process"
           isPending={updateProcess.isPending}

--- a/src/components/products/form/create.tsx
+++ b/src/components/products/form/create.tsx
@@ -62,7 +62,6 @@ export default function CreateProductForm({
     <Forms.Provider form={form}>
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
-          onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           isPending={createProduct.isPending}
           description={

--- a/src/components/products/form/create.tsx
+++ b/src/components/products/form/create.tsx
@@ -52,10 +52,9 @@ export default function CreateProductForm({
     async (values: Schemas.Products.CreateValues) => {
       const product = await createProduct.mutateAsync(values)
       toast({ message: "Product created", variant: "success" })
-      onOpenChange(false)
       await navigateToResource(product)
     },
-    [createProduct, navigateToResource, onOpenChange],
+    [createProduct, navigateToResource],
   )
 
   return (

--- a/src/components/products/form/edit.tsx
+++ b/src/components/products/form/edit.tsx
@@ -59,7 +59,6 @@ export default function EditProductForm({
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing product"
-          onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           errorMessage="Failed to update product"
           isPending={updateProduct.isPending}

--- a/src/components/products/form/edit.tsx
+++ b/src/components/products/form/edit.tsx
@@ -49,9 +49,8 @@ export default function EditProductForm({
     async (values: Schemas.Products.UpdateValues) => {
       await updateProduct.mutateAsync(values)
       toast({ message: "Product updated", variant: "success" })
-      onOpenChange(false)
     },
-    [updateProduct, onOpenChange],
+    [updateProduct],
   )
 
   return (

--- a/src/components/releases/form/create.tsx
+++ b/src/components/releases/form/create.tsx
@@ -73,10 +73,9 @@ export default function CreateReleaseForm({
         })
 
       toast({ message: "Release created", variant: "success" })
-      onOpenChange(false)
       await navigateToResource(release)
     },
-    [createRelease, attachConstraints, navigateToResource, onOpenChange],
+    [createRelease, attachConstraints, navigateToResource],
   )
 
   return (

--- a/src/components/releases/form/edit.tsx
+++ b/src/components/releases/form/edit.tsx
@@ -94,11 +94,9 @@ export default function EditReleaseForm({
 
       await updateRelease.mutateAsync(values)
       toast({ message: "Release updated", variant: "success" })
-      onOpenChange(false)
     },
     [
       release,
-      onOpenChange,
       updateRelease,
       releaseConstraints,
       attachConstraints,
@@ -111,7 +109,6 @@ export default function EditReleaseForm({
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing release"
-          onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           errorMessage="Failed to update release"
           isPending={

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -4,8 +4,6 @@ import { Slot } from "@radix-ui/react-slot"
 import {
   Controller,
   FormProvider,
-  useFormContext,
-  useFormState,
   type ControllerProps,
   type FieldPath,
   type FieldValues,
@@ -16,18 +14,13 @@ import { Label } from "@/components/ui/label"
 
 import { CircleAlert } from "lucide-react"
 
+import {
+  FormFieldContext,
+  FormItemContext,
+  useFormField,
+} from "@/contexts/form-field-context"
+
 const Form = FormProvider
-
-type FormFieldContextValue<
-  TFieldValues extends FieldValues = FieldValues,
-  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
-> = {
-  name: TName
-}
-
-const FormFieldContext = React.createContext<FormFieldContextValue>(
-  {} as FormFieldContextValue,
-)
 
 const FormField = <
   TFieldValues extends FieldValues = FieldValues,
@@ -41,37 +34,6 @@ const FormField = <
     </FormFieldContext.Provider>
   )
 }
-
-const useFormField = () => {
-  const fieldContext = React.useContext(FormFieldContext)
-  const itemContext = React.useContext(FormItemContext)
-  const { getFieldState } = useFormContext()
-  const formState = useFormState({ name: fieldContext.name })
-  const fieldState = getFieldState(fieldContext.name, formState)
-
-  if (!fieldContext) {
-    throw new Error("useFormField should be used within <FormField>")
-  }
-
-  const { id } = itemContext
-
-  return {
-    id,
-    name: fieldContext.name,
-    formItemId: `${id}-form-item`,
-    formDescriptionId: `${id}-form-item-description`,
-    formMessageId: `${id}-form-item-message`,
-    ...fieldState,
-  }
-}
-
-type FormItemContextValue = {
-  id: string
-}
-
-const FormItemContext = React.createContext<FormItemContextValue>(
-  {} as FormItemContextValue,
-)
 
 function FormItem({ className, ...props }: React.ComponentProps<"div">) {
   const id = React.useId()

--- a/src/components/unsaved-changes-modal.tsx
+++ b/src/components/unsaved-changes-modal.tsx
@@ -1,0 +1,25 @@
+import ConfirmationModal from "@/components/confirmation-modal"
+
+interface UnsavedChangesModalProps {
+  open: boolean
+  onClose: () => void
+  onConfirm: () => void
+}
+
+export default function UnsavedChangesModal({
+  open,
+  onClose,
+  onConfirm,
+}: UnsavedChangesModalProps) {
+  return (
+    <ConfirmationModal
+      title="Unsaved changes"
+      description="You have unsaved changes that will be lost. Are you sure you want to continue?"
+      label="Discard"
+      variant="destructive"
+      open={open}
+      onClose={onClose}
+      onConfirm={onConfirm}
+    />
+  )
+}

--- a/src/components/users/form/create.tsx
+++ b/src/components/users/form/create.tsx
@@ -64,7 +64,6 @@ export default function CreateUserForm({
     <Forms.Provider form={form}>
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Wizard
-          onBack={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           isPending={createUser.isPending}
           description="Creating a new user"

--- a/src/components/users/form/create.tsx
+++ b/src/components/users/form/create.tsx
@@ -54,10 +54,9 @@ export default function CreateUserForm({
       }
 
       toast({ message: "User created", variant: "success" })
-      onOpenChange(false)
       await navigateToResource(user)
     },
-    [createUser, changeGroup, navigateToResource, onOpenChange],
+    [createUser, changeGroup, navigateToResource],
   )
 
   return (

--- a/src/components/users/form/edit.tsx
+++ b/src/components/users/form/edit.tsx
@@ -57,9 +57,8 @@ export default function EditUserForm({
 
       await updateUser.mutateAsync(values)
       toast({ message: "User updated", variant: "success" })
-      onOpenChange(false)
     },
-    [updateUser, changeGroup, user, onOpenChange],
+    [updateUser, changeGroup, user],
   )
 
   return (

--- a/src/components/users/form/edit.tsx
+++ b/src/components/users/form/edit.tsx
@@ -67,7 +67,6 @@ export default function EditUserForm({
       <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
         <Forms.Layout.Sheet
           title="Editing an existing user"
-          onCancel={() => onOpenChange(false)}
           onSubmit={handleSubmit}
           errorMessage="Failed to update user"
           isPending={userLoading}

--- a/src/contexts/form-dialog-guard-context.tsx
+++ b/src/contexts/form-dialog-guard-context.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react"
+
+export interface FormDialogGuardContextValue {
+  guardedOpenChange: (open: boolean) => void
+}
+
+export const FormDialogGuardContext =
+  createContext<FormDialogGuardContextValue | null>(null)
+
+export function useFormDialogGuardContext() {
+  const context = useContext(FormDialogGuardContext)
+  if (!context) {
+    throw new Error(
+      "useFormDialogGuardContext must be used within a FormDialogGuard",
+    )
+  }
+
+  return context
+}

--- a/src/contexts/form-dialog-guard-context.tsx
+++ b/src/contexts/form-dialog-guard-context.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from "react"
 
 export interface FormDialogGuardContextValue {
-  guardedOpenChange: (open: boolean) => void
+  abandonForm: (action?: () => void) => void
 }
 
 export const FormDialogGuardContext =

--- a/src/contexts/form-dialog-guard-context.tsx
+++ b/src/contexts/form-dialog-guard-context.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from "react"
 
 export interface FormDialogGuardContextValue {
-  abandonForm: (action?: () => void) => void
+  abandon: (action?: () => void) => void
   close: () => void
 }
 

--- a/src/contexts/form-dialog-guard-context.tsx
+++ b/src/contexts/form-dialog-guard-context.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext } from "react"
 
 export interface FormDialogGuardContextValue {
   abandonForm: (action?: () => void) => void
+  close: () => void
 }
 
 export const FormDialogGuardContext =

--- a/src/contexts/form-dialog-guard-context.tsx
+++ b/src/contexts/form-dialog-guard-context.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext } from "react"
 
 export interface FormDialogGuardContextValue {
   abandon: (action?: () => void) => void
-  complete: () => void
+  close: () => void
 }
 
 export const FormDialogGuardContext =

--- a/src/contexts/form-dialog-guard-context.tsx
+++ b/src/contexts/form-dialog-guard-context.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext } from "react"
 
 export interface FormDialogGuardContextValue {
   abandon: (action?: () => void) => void
-  close: () => void
+  complete: () => void
 }
 
 export const FormDialogGuardContext =

--- a/src/contexts/form-field-context.tsx
+++ b/src/contexts/form-field-context.tsx
@@ -1,0 +1,49 @@
+import { createContext, useContext } from "react"
+import {
+  useFormContext,
+  useFormState,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form"
+
+export type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName
+}
+
+export const FormFieldContext = createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue,
+)
+
+export type FormItemContextValue = {
+  id: string
+}
+
+export const FormItemContext = createContext<FormItemContextValue>(
+  {} as FormItemContextValue,
+)
+
+export const useFormField = () => {
+  const fieldContext = useContext(FormFieldContext)
+  const itemContext = useContext(FormItemContext)
+  const { getFieldState } = useFormContext()
+  const formState = useFormState({ name: fieldContext.name })
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}


### PR DESCRIPTION
Closes #95. Requires #105. ~~Will rebase once that's approved and merged.~~ Adds a confirmation modal when a user tries to "abandon" a dirty form, either via direct route navigation or closing the form dialog. Forms dialogs, by default, are now `autoClose` on submit, but that can be disabled via `autoClose={false}`, as is the case for e.g. the checkout forms. In addition, I removed the `onCancel` handler from the form primitives, as it's now an internally managed concern, and exposing a close handler introduced the possibility of bypassing the guard's built by the form dialog.