### PR TITLE
Fix authentication failing when mode was set to multiplayer

### DIFF
--- a/src/keygen/authenticate.ts
+++ b/src/keygen/authenticate.ts
@@ -21,7 +21,7 @@ export async function authenticate({
 
   const body = otp != null ? JSON.stringify({ meta: { otp } }) : undefined
 
-  const result = (await client.request("/tokens", {
+  const result = (await client.request(`/accounts/${config.id}/tokens`, {
     method: "POST",
     headers: { Authorization: `Basic ${credentials}` },
     body,


### PR DESCRIPTION
Updates auth endpoint that only allowed authentication in `singleplayer` mode to now work in both `singleplayer` and `multiplayer` modes.