### PR TITLE
Add filter bar to users

### DIFF
--- a/src/components/filter-bar/array-filter.tsx
+++ b/src/components/filter-bar/array-filter.tsx
@@ -1,0 +1,84 @@
+import { type LucideIcon } from "lucide-react"
+
+import { useFilterState } from "@/hooks/use-filter-state"
+import {
+  FilterSegmentGroup,
+  FilterSegment,
+  FilterPopoverSegment,
+} from "./filter-segment"
+
+import { cn } from "@/lib/utils"
+
+export interface ArrayFilterProps {
+  label: string
+  icon?: LucideIcon
+  options: ReadonlyArray<{ value: string; label: string }>
+  value?: string[]
+  onChange: (value: string[] | undefined) => void
+}
+
+export default function ArrayFilter({
+  label,
+  icon,
+  options,
+  value,
+  onChange,
+}: ArrayFilterProps) {
+  const filter = useFilterState(value, [] as string[], onChange)
+
+  const selected = options.filter((o) => filter.value.includes(o.value))
+  const displayValue =
+    selected.length > 0 ? selected.map((o) => o.label).join(", ") : "select..."
+
+  return (
+    <FilterSegmentGroup
+      state={filter.state}
+      icon={icon}
+      label={label}
+      onDraft={filter.handleDraft}
+      onActivate={filter.handleActivate}
+      onDeactivate={filter.handleDeactivate}
+      confirmDisabled={filter.value.length === 0}
+    >
+      <FilterSegment>{label}</FilterSegment>
+      <FilterSegment>in</FilterSegment>
+      <FilterPopoverSegment
+        className="w-44"
+        popover={(close) => (
+          <div className="flex flex-col gap-0.5">
+            {options.map((opt) => {
+              const isSelected = filter.value.includes(opt.value)
+
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className={cn(
+                    "w-full cursor-pointer rounded-sm px-2 py-1 text-left text-xs transition-colors hover:bg-accent",
+                    isSelected && "bg-accent",
+                  )}
+                  onClick={(e) => {
+                    if (e.ctrlKey || e.metaKey) {
+                      const next = isSelected
+                        ? filter.value.filter((v) => v !== opt.value)
+                        : [...filter.value, opt.value]
+
+                      filter.handleDraftChange(next)
+                    } else {
+                      filter.handleChange([opt.value])
+                      close()
+                    }
+                  }}
+                >
+                  {opt.label}
+                </button>
+              )
+            })}
+          </div>
+        )}
+      >
+        {displayValue}
+      </FilterPopoverSegment>
+    </FilterSegmentGroup>
+  )
+}

--- a/src/components/filter-bar/index.ts
+++ b/src/components/filter-bar/index.ts
@@ -1,4 +1,5 @@
 export { default as FilterBar } from "./filter-bar"
+export { default as ArrayFilter } from "./array-filter"
 export { default as BooleanFilter } from "./boolean-filter"
 export { default as DateFilter } from "./date-filter"
 export { default as DurationFilter } from "./duration-filter"

--- a/src/components/users/filter-bar.tsx
+++ b/src/components/users/filter-bar.tsx
@@ -1,0 +1,126 @@
+import {
+  CircleDot,
+  UserCheck,
+  Box,
+  SquareStack,
+  Shield,
+  Braces,
+} from "lucide-react"
+
+import { useState, useCallback } from "react"
+
+import * as Filters from "@/components/filter-bar"
+
+import { useListProducts } from "@/queries/products"
+import { useListGroups } from "@/queries/groups"
+import {
+  UserStatus,
+  UserStatusLabels,
+  UserRole,
+  UserRoleLabels,
+  AllRoles,
+} from "@/types/users"
+import { type UserFilters } from "@/queries/users"
+
+const STATUS_OPTIONS = Object.values(UserStatus).map((status) => ({
+  label: UserStatusLabels[status],
+  value: status,
+}))
+
+const ROLE_OPTIONS = Object.values(UserRole).map((role) => ({
+  label: UserRoleLabels[role],
+  value: role,
+}))
+
+interface UserFilterBarProps {
+  filters: UserFilters
+  onChange: (filters: UserFilters) => void
+}
+
+export default function UserFilterBar({
+  filters,
+  onChange,
+}: UserFilterBarProps) {
+  const filterCount = Object.entries(filters).filter(([k, v]) => {
+    if (v == null) {
+      return false
+    }
+
+    // NB(ezekg) the "unset" value of roles is to include all roles since the default is ["user"]
+    if (k === "roles") {
+      return Array.isArray(v) && v.length !== AllRoles.length
+    }
+
+    return true
+  }).length
+
+  const [enabled, setEnabled] = useState<Record<string, boolean>>({})
+  const enable = useCallback((key: string) => {
+    setEnabled((prev) => (prev[key] ? prev : { ...prev, [key]: true }))
+  }, [])
+
+  const { data: products = [] } = useListProducts(
+    { page: 1, pageSize: 10 },
+    { enabled: !!enabled.products },
+  )
+  const { data: groups = [] } = useListGroups(
+    { page: 1, pageSize: 10 },
+    { enabled: !!enabled.groups },
+  )
+
+  return (
+    <Filters.FilterBar
+      filterCount={filterCount}
+      onClearAll={() => onChange({ roles: AllRoles })}
+      pinned={
+        <Filters.EnumFilter
+          label="Status"
+          icon={CircleDot}
+          options={STATUS_OPTIONS}
+          value={filters.status}
+          onChange={(status) => onChange({ ...filters, status })}
+        />
+      }
+    >
+      <Filters.BooleanFilter
+        label="Assigned"
+        icon={UserCheck}
+        value={filters.assigned}
+        onChange={(assigned) => onChange({ ...filters, assigned })}
+      />
+      <Filters.ResourceFilter
+        label="Product"
+        icon={Box}
+        resource="products"
+        options={products}
+        value={filters.product}
+        onDraft={() => enable("products")}
+        onChange={(product) => onChange({ ...filters, product })}
+      />
+      <Filters.ResourceFilter
+        label="Group"
+        icon={SquareStack}
+        resource="groups"
+        options={groups}
+        value={filters.group}
+        onDraft={() => enable("groups")}
+        onChange={(group) => onChange({ ...filters, group })}
+      />
+      <Filters.ArrayFilter
+        label="Roles"
+        icon={Shield}
+        options={ROLE_OPTIONS}
+        value={
+          filters.roles?.length === AllRoles.length ? undefined : filters.roles
+        }
+        onChange={(roles) => onChange({ ...filters, roles: roles ?? AllRoles })}
+      />
+      <Filters.MetadataFilter
+        label="Metadata"
+        icon={Braces}
+        value={filters.metadata}
+        onChange={(metadata) => onChange({ ...filters, metadata })}
+      />
+    </Filters.FilterBar>
+  )
+}

--- a/src/components/users/index.ts
+++ b/src/components/users/index.ts
@@ -4,3 +4,4 @@ export { Form }
 export { default as AttributeGroup } from "./attribute-group"
 export { default as AllAttributes } from "./all-attributes"
 export { default as AdvancedDialog } from "./advanced-dialog"
+export { default as FilterBar } from "./filter-bar"

--- a/src/keygen/users/list.ts
+++ b/src/keygen/users/list.ts
@@ -1,6 +1,6 @@
 import config from "@/keygen/config"
 import client from "@/keygen/client"
-import { UserListResponse, AllRoles } from "@/types/users"
+import { UserListResponse, AllRoles, type UserFilters } from "@/types/users"
 
 config.validate()
 
@@ -8,12 +8,14 @@ interface ListProps {
   limit?: number
   pageNumber?: number
   pageSize?: number
+  filters?: UserFilters
 }
 
 export default async function list({
   limit,
   pageNumber,
   pageSize,
+  filters,
 }: ListProps): Promise<UserListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
@@ -25,8 +27,27 @@ export default async function list({
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
   }
+  if (filters?.status) {
+    params.set("status", filters.status)
+  }
+  if (filters?.assigned != null) {
+    params.set("assigned", filters.assigned.toString())
+  }
+  if (filters?.product) {
+    params.set("product", filters.product)
+  }
+  if (filters?.group) {
+    params.set("group", filters.group)
+  }
 
-  AllRoles.forEach((role) => params.append("roles[]", role))
+  const roles = filters?.roles ?? AllRoles
+  roles.forEach((role) => params.append("roles[]", role))
+
+  if (filters?.metadata) {
+    for (const [key, value] of Object.entries(filters.metadata)) {
+      params.set(`metadata[${key}]`, value)
+    }
+  }
 
   const result = (await client.request(
     `/accounts/${config.id}/users?${params.toString()}`,

--- a/src/pages/app/user/list.tsx
+++ b/src/pages/app/user/list.tsx
@@ -1,11 +1,12 @@
-import { useState } from "react"
+import { useState, useCallback } from "react"
 
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { useUserTableColumns } from "@/hooks/use-user-table-columns"
+import { useFilterSearch } from "@/hooks/use-filter-search"
 import { useDataTable } from "@/hooks/use-data-table"
-import { User } from "@/types/users"
+import { User, type UserFilters } from "@/types/users"
 
 import { useListUsers } from "@/queries/users"
 
@@ -21,6 +22,16 @@ export default function UsersList() {
   const table = useDataTable()
   const columns = useUserTableColumns()
 
+  const [filters, setFilters] = useFilterSearch<UserFilters>()
+
+  const handleFiltersChange = useCallback(
+    (next: UserFilters) => {
+      setFilters(next)
+      table.setPage(1)
+    },
+    [table, setFilters],
+  )
+
   const {
     data: users,
     links,
@@ -28,6 +39,7 @@ export default function UsersList() {
   } = useListUsers({
     page: table.page,
     pageSize: table.pageSize,
+    filters,
   })
 
   const totalPages = links?.meta?.pages ?? 1
@@ -43,6 +55,10 @@ export default function UsersList() {
           New User
         </Button>
       </PageHeader>
+
+      <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
+        <Users.FilterBar filters={filters} onChange={handleFiltersChange} />
+      </div>
 
       <Users.Form.Create open={open} onOpenChange={setOpen} />
 

--- a/src/queries/users.ts
+++ b/src/queries/users.ts
@@ -5,7 +5,7 @@ import { useEnvironment } from "@/hooks/use-environment"
 import * as Schemas from "@/schemas"
 
 import { APIError } from "@/types/api"
-import { User } from "@/types/users"
+import { User, type UserFilters } from "@/types/users"
 
 import * as keygen from "@/keygen"
 import { diff } from "@/lib/utils"
@@ -28,8 +28,10 @@ export function useGetUser(userId: string) {
   })
 }
 
+export type { UserFilters }
+
 export function useListUsers(
-  params?: { page: number; pageSize: number },
+  params?: { page: number; pageSize: number; filters?: UserFilters },
   options?: { enabled?: boolean },
 ) {
   const { code } = useEnvironment()
@@ -38,7 +40,13 @@ export function useListUsers(
     queryKey: ["users", { environment: code, ...params }],
     queryFn: async () => {
       const response = await keygen.users.list(
-        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+        params
+          ? {
+              pageNumber: params.page,
+              pageSize: params.pageSize,
+              filters: params.filters,
+            }
+          : {},
       )
 
       if (response.errors) {

--- a/src/routes/$accountId/app.users.tsx
+++ b/src/routes/$accountId/app.users.tsx
@@ -1,6 +1,27 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { type UserFilters } from "@/queries/users"
 import * as Page from "@/pages/index"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function validateSearch(search: Record<string, unknown>): UserFilters {
+  const filters: UserFilters = {}
+
+  if (typeof search.status === "string") filters.status = search.status
+  if (typeof search.assigned === "boolean") filters.assigned = search.assigned
+  if (typeof search.product === "string") filters.product = search.product
+  if (typeof search.group === "string") filters.group = search.group
+  if (Array.isArray(search.roles)) filters.roles = search.roles as string[]
+  else filters.roles = ["user"]
+  if (isRecord(search.metadata))
+    filters.metadata = search.metadata as Record<string, string>
+
+  return filters
+}
 
 export const Route = createFileRoute("/$accountId/app/users")({
   component: () => <Page.App.Users />,
+  validateSearch,
 })

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -160,6 +160,15 @@ export const InternalRoles: UserRole[] = [
 
 export const AllRoles: UserRole[] = [...ExternalRoles, ...InternalRoles]
 
+export type UserFilters = {
+  status?: string
+  assigned?: boolean
+  product?: string
+  group?: string
+  roles?: string[]
+  metadata?: Record<string, string>
+}
+
 export const UserPermissions = [
   "account.read",
   "arch.read",


### PR DESCRIPTION
Adds filtering support for users, and adjusts the default user list to exclude admins (which aligns with the API's default), which will be handled via a separate teammates section in account settings.

<img width="2164" height="1066" alt="image" src="https://github.com/user-attachments/assets/3cb9ffc5-4f37-4aaf-835e-a69c35630fec" />
