### PR TITLE
Remove form guard check on touched fields

### DIFF
--- a/src/components/forms/guard.tsx
+++ b/src/components/forms/guard.tsx
@@ -29,11 +29,10 @@ export function FormRouteGuard({ children }: { children: React.ReactNode }) {
 //           of the main guard to avoid unnecessary re-renders of its children
 function FormRouteGuardModal() {
   const { control } = useFormContext()
-  const { isDirty, isSubmitting, touchedFields } = useFormState({ control })
+  const { isDirty, isSubmitting } = useFormState({ control })
 
   const { status, proceed, reset } = useBlocker({
-    shouldBlockFn: () =>
-      isDirty && !isSubmitting && Object.keys(touchedFields).length > 0,
+    shouldBlockFn: () => isDirty && !isSubmitting,
     withResolver: true,
     enableBeforeUnload: false,
   })


### PR DESCRIPTION
There was an additional check on touched fields added in #139 that seems like it introduced this bug where the permissions form is unguarded when navigating away from the dirtied page form:

https://github.com/user-attachments/assets/0f492694-66dc-49f8-bcde-7c6454e5f2f1

Not sure what the original intent was, but I'm not sure it's needed. lmk if I'm missing something, though?