### PR TITLE
Add filter bar to policies

### DIFF
--- a/src/components/filter-bar/filter-bar.tsx
+++ b/src/components/filter-bar/filter-bar.tsx
@@ -145,26 +145,28 @@ export default function FilterBar({
         {pinned}
 
         {/* scroll arrows */}
-        <div className="flex shrink-0 items-center gap-0.5 text-content-subdued">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-5"
-            disabled={!canScrollLeft}
-            onClick={scrollLeft}
-          >
-            <ChevronLeft className="size-3" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-5"
-            disabled={!canScrollRight}
-            onClick={scrollRight}
-          >
-            <ChevronRight className="size-3" />
-          </Button>
-        </div>
+        {!allVisible && (
+          <div className="flex shrink-0 items-center gap-0.5 text-content-subdued">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-5"
+              disabled={!canScrollLeft}
+              onClick={scrollLeft}
+            >
+              <ChevronLeft className="size-3" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-5"
+              disabled={!canScrollRight}
+              onClick={scrollRight}
+            >
+              <ChevronRight className="size-3" />
+            </Button>
+          </div>
+        )}
 
         {/* scroll region */}
         <div className="relative h-full min-w-0 flex-1 overflow-hidden pr-1">

--- a/src/components/policies/filter-bar.tsx
+++ b/src/components/policies/filter-bar.tsx
@@ -1,0 +1,47 @@
+import { Box } from "lucide-react"
+
+import { useState, useCallback } from "react"
+
+import * as Filters from "@/components/filter-bar"
+
+import { useListProducts } from "@/queries/products"
+import { type PolicyFilters } from "@/queries/policies"
+
+interface PolicyFilterBarProps {
+  filters: PolicyFilters
+  onChange: (filters: PolicyFilters) => void
+}
+
+export default function PolicyFilterBar({
+  filters,
+  onChange,
+}: PolicyFilterBarProps) {
+  const filterCount = Object.values(filters).filter((v) => v != null).length
+
+  const [enabled, setEnabled] = useState<Record<string, boolean>>({})
+  const enable = useCallback((key: string) => {
+    setEnabled((prev) => (prev[key] ? prev : { ...prev, [key]: true }))
+  }, [])
+
+  const { data: products = [] } = useListProducts(
+    { page: 1, pageSize: 10 },
+    { enabled: !!enabled.products },
+  )
+
+  return (
+    <Filters.FilterBar
+      filterCount={filterCount}
+      onClearAll={() => onChange({})}
+    >
+      <Filters.ResourceFilter
+        label="Product"
+        icon={Box}
+        resource="products"
+        options={products}
+        value={filters.product}
+        onDraft={() => enable("products")}
+        onChange={(product) => onChange({ ...filters, product })}
+      />
+    </Filters.FilterBar>
+  )
+}

--- a/src/components/policies/index.ts
+++ b/src/components/policies/index.ts
@@ -1,6 +1,7 @@
 export { default as AdvancedDialog } from "./advanced-dialog"
 export { default as AttributeGroup } from "./attribute-group"
 export { default as AllAttributes } from "./all-attributes"
+export { default as FilterBar } from "./filter-bar"
 
 import * as Form from "./form"
 export { Form }

--- a/src/keygen/policies/list.ts
+++ b/src/keygen/policies/list.ts
@@ -1,6 +1,6 @@
 import config from "@/keygen/config"
 import client from "@/keygen/client"
-import { PoliciesListResponse } from "@/types/policies"
+import { PoliciesListResponse, type PolicyFilters } from "@/types/policies"
 
 config.validate()
 
@@ -8,12 +8,14 @@ interface ListProps {
   limit?: number
   pageNumber?: number
   pageSize?: number
+  filters?: PolicyFilters
 }
 
 export default async function list({
   limit,
   pageNumber,
   pageSize,
+  filters,
 }: ListProps): Promise<PoliciesListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
@@ -24,6 +26,9 @@ export default async function list({
   }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+  }
+  if (filters?.product) {
+    params.set("product", filters.product)
   }
 
   const result = (await client.request(

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -1,13 +1,14 @@
-import { useState } from "react"
+import { useState, useCallback } from "react"
 
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { usePolicyTableColumns } from "@/hooks/use-policy-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
+import { useFilterSearch } from "@/hooks/use-filter-search"
 import { Policy } from "@/types/policies"
 
-import { useListPolicies } from "@/queries/policies"
+import { useListPolicies, type PolicyFilters } from "@/queries/policies"
 
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
@@ -21,6 +22,16 @@ export default function PoliciesList() {
   const table = useDataTable()
   const columns = usePolicyTableColumns()
 
+  const [filters, setFilters] = useFilterSearch<PolicyFilters>()
+
+  const handleFiltersChange = useCallback(
+    (next: PolicyFilters) => {
+      setFilters(next)
+      table.setPage(1)
+    },
+    [table, setFilters],
+  )
+
   const {
     data: policies,
     links,
@@ -28,6 +39,7 @@ export default function PoliciesList() {
   } = useListPolicies({
     page: table.page,
     pageSize: table.pageSize,
+    filters,
   })
 
   const totalPages = links?.meta?.pages ?? 1
@@ -49,6 +61,10 @@ export default function PoliciesList() {
 
         <Policies.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
+
+      <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
+        <Policies.FilterBar filters={filters} onChange={handleFiltersChange} />
+      </div>
 
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Policy>

--- a/src/queries/policies.ts
+++ b/src/queries/policies.ts
@@ -5,10 +5,12 @@ import { useEnvironment } from "@/hooks/use-environment"
 import * as Schemas from "@/schemas"
 
 import { APIError } from "@/types/api"
-import { Policy } from "@/types/policies"
+import { Policy, type PolicyFilters } from "@/types/policies"
 
 import * as keygen from "@/keygen"
 import { diff } from "@/lib/utils"
+
+export type { PolicyFilters }
 
 export function useGetPolicy(policyId: string) {
   const { code } = useEnvironment()
@@ -29,7 +31,7 @@ export function useGetPolicy(policyId: string) {
 }
 
 export function useListPolicies(
-  params?: { page: number; pageSize: number },
+  params?: { page: number; pageSize: number; filters?: PolicyFilters },
   options?: { enabled?: boolean },
 ) {
   const { code } = useEnvironment()
@@ -38,7 +40,13 @@ export function useListPolicies(
     queryKey: ["policies", { environment: code, ...params }],
     queryFn: async () => {
       const response = await keygen.policies.list(
-        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+        params
+          ? {
+              pageNumber: params.page,
+              pageSize: params.pageSize,
+              filters: params.filters,
+            }
+          : {},
       )
 
       if (response.errors) {

--- a/src/routes/$accountId/app.policies.tsx
+++ b/src/routes/$accountId/app.policies.tsx
@@ -1,6 +1,16 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { type PolicyFilters } from "@/queries/policies"
 import * as Page from "@/pages/index"
+
+function validateSearch(search: Record<string, unknown>): PolicyFilters {
+  const filters: PolicyFilters = {}
+
+  if (typeof search.product === "string") filters.product = search.product
+
+  return filters
+}
 
 export const Route = createFileRoute("/$accountId/app/policies")({
   component: () => <Page.App.Policies />,
+  validateSearch,
 })

--- a/src/types/policies.ts
+++ b/src/types/policies.ts
@@ -227,6 +227,10 @@ export type Policy = Resource<"policies", PolicyAttributes, PolicyRelationships>
 export type PolicyResponse = APIResponse<Policy>
 export type PoliciesListResponse = APIResponse<Policy[]>
 
+export type PolicyFilters = {
+  product?: string
+}
+
 export const PolicyAttributeDescriptions: Readonly<
   Record<keyof Writable<PolicyAttributes>, string>
 > = {


### PR DESCRIPTION
Adds filtering support for policies, and also adjusts the filter bar to hide scroll indicators when all filters are visible.

<img width="2107" height="907" alt="image" src="https://github.com/user-attachments/assets/7e2c8e1d-59da-4d05-964b-11b2caa3511e" />