### PR TITLE
Fix list query invalidation for create queries

### DIFF
--- a/src/queries/artifacts.ts
+++ b/src/queries/artifacts.ts
@@ -73,18 +73,14 @@ export function useCreateArtifact() {
       return response.data
     },
 
-    onSuccess: (newArtifact) => {
-      queryClient.setQueryData(
-        ["artifacts", { environment: code }],
-        (old: Artifact[] | undefined) => {
-          if (Array.isArray(old)) return [newArtifact, ...old]
-          return undefined
-        },
-      )
+    onSuccess: async (newArtifact) => {
       queryClient.setQueryData(
         ["artifacts", newArtifact.id, { environment: code }],
         newArtifact,
       )
+      await queryClient.invalidateQueries({
+        queryKey: ["artifacts", { environment: code }],
+      })
     },
   })
 }

--- a/src/queries/components.ts
+++ b/src/queries/components.ts
@@ -68,18 +68,14 @@ export function useCreateComponent() {
       return response.data
     },
 
-    onSuccess: (newComponent) => {
-      queryClient.setQueryData(
-        ["components", { environment: code }],
-        (old: Component[] | undefined) => {
-          if (Array.isArray(old)) return [newComponent, ...old]
-          return undefined
-        },
-      )
+    onSuccess: async (newComponent) => {
       queryClient.setQueryData(
         ["components", newComponent.id, { environment: code }],
         newComponent,
       )
+      await queryClient.invalidateQueries({
+        queryKey: ["components", { environment: code }],
+      })
     },
   })
 }

--- a/src/queries/entitlements.ts
+++ b/src/queries/entitlements.ts
@@ -71,20 +71,16 @@ export function useCreateEntitlement() {
       return response.data
     },
 
-    onSuccess: (newEntitlement) => {
+    onSuccess: async (newEntitlement) => {
       if (!newEntitlement || !newEntitlement.id) return
 
-      queryClient.setQueryData(
-        ["entitlements", { environment: code }],
-        (old: Entitlement[] | undefined) => {
-          if (Array.isArray(old)) return [newEntitlement, ...old]
-          return undefined
-        },
-      )
       queryClient.setQueryData(
         ["entitlements", newEntitlement.id, { environment: code }],
         newEntitlement,
       )
+      await queryClient.invalidateQueries({
+        queryKey: ["entitlements", { environment: code }],
+      })
     },
   })
 }

--- a/src/queries/environments.ts
+++ b/src/queries/environments.ts
@@ -58,18 +58,14 @@ export function useCreateEnvironment() {
       return response.data
     },
 
-    onSuccess: (newEnvironment) => {
-      queryClient.setQueryData(
-        ["environments"],
-        (old: Environment[] | undefined) => {
-          if (Array.isArray(old)) return [newEnvironment, ...old]
-          return undefined
-        },
-      )
+    onSuccess: async (newEnvironment) => {
       queryClient.setQueryData(
         ["environment", newEnvironment.id],
         newEnvironment,
       )
+      await queryClient.invalidateQueries({
+        queryKey: ["environments"],
+      })
     },
   })
 }

--- a/src/queries/groups.ts
+++ b/src/queries/groups.ts
@@ -74,18 +74,14 @@ export function useCreateGroup() {
       return response.data
     },
 
-    onSuccess: (newGroup) => {
-      queryClient.setQueryData(
-        ["groups", { environment: code }],
-        (old: Group[] | undefined) => {
-          if (Array.isArray(old)) return [newGroup, ...old]
-          return undefined
-        },
-      )
+    onSuccess: async (newGroup) => {
       queryClient.setQueryData(
         ["groups", newGroup.id, { environment: code }],
         newGroup,
       )
+      await queryClient.invalidateQueries({
+        queryKey: ["groups", { environment: code }],
+      })
     },
   })
 }

--- a/src/queries/licenses.ts
+++ b/src/queries/licenses.ts
@@ -87,11 +87,8 @@ export function useCreateLicense() {
 
     onSuccess: async (newLicense) => {
       queryClient.setQueryData(
-        ["licenses", { environment: code }],
-        (old: License[] | undefined) => {
-          if (Array.isArray(old)) return [newLicense, ...old]
-          return undefined
-        },
+        ["licenses", newLicense.id, { environment: code }],
+        newLicense,
       )
       await queryClient.invalidateQueries({
         queryKey: ["licenses", { environment: code }],

--- a/src/queries/machines.ts
+++ b/src/queries/machines.ts
@@ -81,18 +81,14 @@ export function useCreateMachine() {
       return response.data
     },
 
-    onSuccess: (newMachine) => {
-      queryClient.setQueryData(
-        ["machines", { environment: code }],
-        (old: Machine[] | undefined) => {
-          if (Array.isArray(old)) return [newMachine, ...old]
-          return undefined
-        },
-      )
+    onSuccess: async (newMachine) => {
       queryClient.setQueryData(
         ["machines", newMachine.id, { environment: code }],
         newMachine,
       )
+      await queryClient.invalidateQueries({
+        queryKey: ["machines", { environment: code }],
+      })
     },
   })
 }

--- a/src/queries/packages.ts
+++ b/src/queries/packages.ts
@@ -66,18 +66,14 @@ export function useCreatePackage() {
         return response.data
       }),
 
-    onSuccess: (newPackage) => {
-      queryClient.setQueryData(
-        ["packages", { environment: code }],
-        (old: Package[] | undefined) => {
-          if (Array.isArray(old)) return [newPackage, ...old]
-          return undefined
-        },
-      )
+    onSuccess: async (newPackage) => {
       queryClient.setQueryData(
         ["packages", newPackage.id, { environment: code }],
         newPackage,
       )
+      await queryClient.invalidateQueries({
+        queryKey: ["packages", { environment: code }],
+      })
     },
   })
 }

--- a/src/queries/policies.ts
+++ b/src/queries/policies.ts
@@ -80,15 +80,11 @@ export function useCreatePolicy() {
       return response.data
     },
 
-    onSuccess: (newPolicy) => {
-      queryClient.setQueryData(
-        ["policies", { environment: code }],
-        (old: Policy[] | undefined) => {
-          if (Array.isArray(old)) return [newPolicy, ...old]
-          return undefined
-        },
-      )
+    onSuccess: async (newPolicy) => {
       queryClient.setQueryData(["policy", newPolicy.id], newPolicy)
+      await queryClient.invalidateQueries({
+        queryKey: ["policies", { environment: code }],
+      })
     },
   })
 }

--- a/src/queries/processes.ts
+++ b/src/queries/processes.ts
@@ -68,18 +68,14 @@ export function useCreateProcess() {
       return response.data
     },
 
-    onSuccess: (newProcess) => {
-      queryClient.setQueryData(
-        ["processes", { environment: code }],
-        (old: Process[] | undefined) => {
-          if (Array.isArray(old)) return [newProcess, ...old]
-          return undefined
-        },
-      )
+    onSuccess: async (newProcess) => {
       queryClient.setQueryData(
         ["processes", newProcess.id, { environment: code }],
         newProcess,
       )
+      await queryClient.invalidateQueries({
+        queryKey: ["processes", { environment: code }],
+      })
     },
   })
 }

--- a/src/queries/products.ts
+++ b/src/queries/products.ts
@@ -70,18 +70,14 @@ export function useCreateProduct() {
         return response.data
       }),
 
-    onSuccess: (newProduct) => {
-      queryClient.setQueryData(
-        ["products", { environment: code }],
-        (old: Product[] | undefined) => {
-          if (Array.isArray(old)) return [newProduct, ...old]
-          return undefined
-        },
-      )
+    onSuccess: async (newProduct) => {
       queryClient.setQueryData(
         ["products", newProduct.id, { environment: code }],
         newProduct,
       )
+      await queryClient.invalidateQueries({
+        queryKey: ["products", { environment: code }],
+      })
     },
   })
 }

--- a/src/queries/releases.ts
+++ b/src/queries/releases.ts
@@ -66,18 +66,14 @@ export function useCreateRelease() {
         return response.data
       }),
 
-    onSuccess: (newRelease) => {
-      queryClient.setQueryData(
-        ["releases", { environment: code }],
-        (old: Release[] | undefined) => {
-          if (Array.isArray(old)) return [newRelease, ...old]
-          return undefined
-        },
-      )
+    onSuccess: async (newRelease) => {
       queryClient.setQueryData(
         ["releases", newRelease.id, { environment: code }],
         newRelease,
       )
+      await queryClient.invalidateQueries({
+        queryKey: ["releases", { environment: code }],
+      })
     },
   })
 }

--- a/src/queries/users.ts
+++ b/src/queries/users.ts
@@ -80,18 +80,14 @@ export function useCreateUser() {
       return response.data
     },
 
-    onSuccess: (newUser) => {
-      queryClient.setQueryData(
-        ["users", { environment: code }],
-        (old: User[] | undefined) => {
-          if (Array.isArray(old)) return [newUser, ...old]
-          return undefined
-        },
-      )
+    onSuccess: async (newUser) => {
       queryClient.setQueryData(
         ["users", newUser.id, { environment: code }],
         newUser,
       )
+      await queryClient.invalidateQueries({
+        queryKey: ["users", { environment: code }],
+      })
     },
   })
 }


### PR DESCRIPTION
Some resources didn't invalidate the list query so the new resource didn't show up unless you reloaded the app. Also gets rid of the manual list push for new records, instead relying on the API as the source of truth.