### PR TITLE
Add wildcard and none multiselect options

### DIFF
--- a/src/components/account/form/fields.tsx
+++ b/src/components/account/form/fields.tsx
@@ -273,7 +273,7 @@ function LicensePermissionsField({ autoFocus }: { autoFocus?: boolean }) {
               ]}
               includeNone
               includeWildcard
-              placeholder="Leave blank to use defaults"
+              placeholder="Select permissions..."
               autoFocus={autoFocus}
             />
           </Forms.Field.Header>
@@ -310,7 +310,7 @@ function UserPermissionsField({ autoFocus }: { autoFocus?: boolean }) {
               ]}
               includeNone
               includeWildcard
-              placeholder="Leave blank to use defaults"
+              placeholder="Select permissions..."
               autoFocus={autoFocus}
             />
           </Forms.Field.Header>

--- a/src/components/account/form/fields.tsx
+++ b/src/components/account/form/fields.tsx
@@ -264,13 +264,10 @@ function LicensePermissionsField({ autoFocus }: { autoFocus?: boolean }) {
             <MultiSelect
               value={field.value}
               onChange={field.onChange}
-              options={[
-                { label: "*", value: "*" },
-                ...LicensePermissions.map((p) => ({
-                  label: p,
-                  value: p,
-                })),
-              ]}
+              options={LicensePermissions.map((p) => ({
+                label: p,
+                value: p,
+              }))}
               includeNone
               includeWildcard
               placeholder="Select permissions..."
@@ -301,13 +298,10 @@ function UserPermissionsField({ autoFocus }: { autoFocus?: boolean }) {
             <MultiSelect
               value={field.value}
               onChange={field.onChange}
-              options={[
-                { label: "*", value: "*" },
-                ...UserPermissions.map((p) => ({
-                  label: p,
-                  value: p,
-                })),
-              ]}
+              options={UserPermissions.map((p) => ({
+                label: p,
+                value: p,
+              }))}
               includeNone
               includeWildcard
               placeholder="Select permissions..."

--- a/src/components/account/form/fields.tsx
+++ b/src/components/account/form/fields.tsx
@@ -271,8 +271,8 @@ function LicensePermissionsField({ autoFocus }: { autoFocus?: boolean }) {
                   value: p,
                 })),
               ]}
-              noneOption
-              exclusiveOptions={["*"]}
+              includeNone
+              includeWildcard
               placeholder="Leave blank to use defaults"
               autoFocus={autoFocus}
             />
@@ -308,8 +308,8 @@ function UserPermissionsField({ autoFocus }: { autoFocus?: boolean }) {
                   value: p,
                 })),
               ]}
-              noneOption
-              exclusiveOptions={["*"]}
+              includeNone
+              includeWildcard
               placeholder="Leave blank to use defaults"
               autoFocus={autoFocus}
             />

--- a/src/components/account/form/fields.tsx
+++ b/src/components/account/form/fields.tsx
@@ -262,12 +262,17 @@ function LicensePermissionsField({ autoFocus }: { autoFocus?: boolean }) {
             tooltip={AccountFormFieldDescriptions.defaultLicensePermissions}
           >
             <MultiSelect
-              value={field.value ?? []}
+              value={field.value}
               onChange={field.onChange}
-              options={LicensePermissions.map((p) => ({
-                label: p,
-                value: p,
-              }))}
+              options={[
+                { label: "*", value: "*" },
+                ...LicensePermissions.map((p) => ({
+                  label: p,
+                  value: p,
+                })),
+              ]}
+              noneOption
+              exclusiveOptions={["*"]}
               placeholder="Leave blank to use defaults"
               autoFocus={autoFocus}
             />
@@ -294,12 +299,17 @@ function UserPermissionsField({ autoFocus }: { autoFocus?: boolean }) {
             tooltip={AccountFormFieldDescriptions.defaultUserPermissions}
           >
             <MultiSelect
-              value={field.value ?? []}
+              value={field.value}
               onChange={field.onChange}
-              options={UserPermissions.map((p) => ({
-                label: p,
-                value: p,
-              }))}
+              options={[
+                { label: "*", value: "*" },
+                ...UserPermissions.map((p) => ({
+                  label: p,
+                  value: p,
+                })),
+              ]}
+              noneOption
+              exclusiveOptions={["*"]}
               placeholder="Leave blank to use defaults"
               autoFocus={autoFocus}
             />

--- a/src/components/account/form/permissions.tsx
+++ b/src/components/account/form/permissions.tsx
@@ -36,8 +36,8 @@ export default function EditLicensePermissionsForm({
     mode: "onChange",
     values: {
       defaultLicensePermissions:
-        defaultLicensePermissions?.attributes.value ?? [],
-      defaultUserPermissions: defaultUserPermissions?.attributes.value ?? [],
+        defaultLicensePermissions?.attributes.value ?? null,
+      defaultUserPermissions: defaultUserPermissions?.attributes.value ?? null,
     },
   })
 

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -33,11 +33,12 @@ interface RequiredOption extends Option {
 }
 
 interface MultiSelectProps {
-  value: string[]
-  onChange: (value: string[]) => void
+  value: string[] | null | undefined
+  onChange: (value: string[] | null) => void
   options: Option[]
+  noneOption?: boolean
   requiredOptions?: RequiredOption[]
-  wildcard?: string
+  exclusiveOptions?: string[]
   placeholder?: string
   disabled?: boolean
   autoFocus?: boolean
@@ -49,15 +50,18 @@ export default function MultiSelect({
   value,
   onChange,
   options,
+  noneOption,
   requiredOptions = [],
-  wildcard,
+  exclusiveOptions = [],
   placeholder = "Choose...",
   disabled,
   autoFocus,
   disabledTooltip,
   className,
 }: MultiSelectProps) {
-  const selected = value ?? []
+  const items = value ?? []
+  const hasNoneOption = !!noneOption && requiredOptions.length === 0
+  const isNoneActive = hasNoneOption && value != null && value.length === 0
   const [query, setQuery] = useState("")
   const [open, setOpen] = useState(false)
 
@@ -83,24 +87,38 @@ export default function MultiSelect({
       ),
     [query, options],
   )
+  const showNoneOption = useMemo(
+    () => hasNoneOption && "none".includes(query.toLowerCase()),
+    [hasNoneOption, query],
+  )
 
-  const setSelected = (next: string[], focus = true) => {
+  const emit = (next: string[] | null, focus = true) => {
     onChange(next)
     setQuery("")
     if (focus) inputRef.current?.focus()
   }
 
+  const exclusiveSet = useMemo(
+    () => new Set(exclusiveOptions),
+    [exclusiveOptions],
+  )
+
+  const toggleNone = (focus = true) => {
+    emit(isNoneActive ? null : [], focus)
+  }
+
   const toggle = (value: string, focus = true) => {
     if (requiredSet.has(value)) return
 
-    const isActive = selected.includes(value)
-    const next =
-      wildcard && value === wildcard
-        ? []
-        : isActive
-          ? selected.filter((v) => v !== value)
-          : [...selected, value]
-    setSelected(next, focus)
+    if (exclusiveSet.has(value)) {
+      emit(items.includes(value) ? null : [value], focus)
+      return
+    }
+
+    const base = items.filter((v) => !exclusiveSet.has(v))
+    const isActive = base.includes(value)
+    const next = isActive ? base.filter((v) => v !== value) : [...base, value]
+    emit(next.length === 0 ? null : next, focus)
   }
 
   const remove = (value: string) => {
@@ -152,7 +170,18 @@ export default function MultiSelect({
                 </TooltipContent>
               </Tooltip>
             ))}
-            {selected
+            {isNoneActive && (
+              <Badge
+                className="h-5 cursor-pointer text-content-muted"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  toggleNone(open)
+                }}
+              >
+                None <span className="ml-1">&times;</span>
+              </Badge>
+            )}
+            {items
               .filter((v) => !requiredSet.has(v))
               .map((value) => (
                 <Badge
@@ -174,7 +203,9 @@ export default function MultiSelect({
               disabled={disabled}
               autoFocus={autoFocus}
               placeholder={
-                selected.length || requiredOptions.length ? "" : placeholder
+                items.length || isNoneActive || requiredOptions.length
+                  ? ""
+                  : placeholder
               }
               fieldSize="sm"
               className="h-5 flex-1 border-none"
@@ -188,8 +219,12 @@ export default function MultiSelect({
                   return
                 }
 
-                if (e.key === "Backspace" && !query && selected.length) {
-                  remove(selected[selected.length - 1])
+                if (e.key === "Backspace" && !query) {
+                  if (isNoneActive) {
+                    toggleNone(open)
+                  } else if (items.length) {
+                    remove(items[items.length - 1])
+                  }
                 } else if (e.key === "Escape") {
                   setOpen(false)
                   setQuery("")
@@ -209,7 +244,24 @@ export default function MultiSelect({
       >
         <Command shouldFilter={false}>
           <CommandList>
-            <ScrollArea className={cn(visibleOptions.length > 5 && "h-48")}>
+            <ScrollArea
+              className={cn(
+                visibleOptions.length + (showNoneOption ? 1 : 0) > 5 && "h-48",
+              )}
+            >
+              {showNoneOption && (
+                <CommandItem
+                  tabIndex={-1}
+                  onSelect={() => toggleNone()}
+                  className="cursor-pointer"
+                >
+                  <Checkbox
+                    checked={isNoneActive}
+                    className="pointer-events-none mr-2"
+                  />
+                  None
+                </CommandItem>
+              )}
               {visibleOptions.map(({ label, value }) => {
                 const isRequired = requiredSet.has(value)
 
@@ -223,12 +275,7 @@ export default function MultiSelect({
                     )}
                   >
                     <Checkbox
-                      checked={
-                        isRequired ||
-                        (wildcard && value === wildcard
-                          ? selected.length === 0
-                          : selected.includes(value))
-                      }
+                      checked={isRequired || items.includes(value)}
                       disabled={isRequired}
                       className="pointer-events-none mr-2"
                     />

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -38,9 +38,9 @@ interface MultiSelectProps {
   value: string[] | null | undefined
   onChange: (value: string[] | null) => void
   options: Option[]
-  noneOption?: boolean
+  includeNone?: boolean
+  includeWildcard?: boolean
   requiredOptions?: RequiredOption[]
-  exclusiveOptions?: string[]
   placeholder?: string
   disabled?: boolean
   autoFocus?: boolean
@@ -52,9 +52,9 @@ export default function MultiSelect({
   value,
   onChange,
   options,
-  noneOption,
+  includeNone,
+  includeWildcard,
   requiredOptions = [],
-  exclusiveOptions = [],
   placeholder = "Choose...",
   disabled,
   autoFocus,
@@ -62,7 +62,7 @@ export default function MultiSelect({
   className,
 }: MultiSelectProps) {
   const items = value ?? []
-  const hasNoneOption = !!noneOption && requiredOptions.length === 0
+  const hasNoneOption = !!includeNone && requiredOptions.length === 0
   const isNoneSelected = hasNoneOption && value != null && value.length === 0
   const [query, setQuery] = useState("")
   const [open, setOpen] = useState(false)
@@ -96,11 +96,6 @@ export default function MultiSelect({
     if (focus) inputRef.current?.focus()
   }
 
-  const exclusiveSet = useMemo(
-    () => new Set(exclusiveOptions),
-    [exclusiveOptions],
-  )
-
   const toggle = (value: string, focus = true) => {
     if (value === NONE) {
       emit(isNoneSelected ? null : [], focus)
@@ -109,12 +104,12 @@ export default function MultiSelect({
 
     if (requiredSet.has(value)) return
 
-    if (exclusiveSet.has(value)) {
+    if (includeWildcard && value === "*") {
       emit(items.includes(value) ? null : [value], focus)
       return
     }
 
-    const base = items.filter((v) => !exclusiveSet.has(v))
+    const base = items.filter((v) => !(includeWildcard && v === "*"))
     const isActive = base.includes(value)
     const next = isActive ? base.filter((v) => v !== value) : [...base, value]
     emit(next.length === 0 ? null : next, focus)

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -85,7 +85,7 @@ export default function MultiSelect({
   const normalizedOptions = useMemo(() => {
     const base = options.slice()
     if (includeWildcard && !base.some((o) => o.value === "*")) {
-      base.unshift({ label: "*", value: "*" })
+      base.unshift({ label: "All", value: "*" })
     }
     return base
   }, [options, includeWildcard])

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -23,6 +23,8 @@ import {
 } from "@/components/ui/command"
 import { useMobile } from "@/hooks/use-mobile"
 
+const NONE = "__NONE__"
+
 interface Option {
   label: string
   value: string
@@ -61,7 +63,7 @@ export default function MultiSelect({
 }: MultiSelectProps) {
   const items = value ?? []
   const hasNoneOption = !!noneOption && requiredOptions.length === 0
-  const isNoneActive = hasNoneOption && value != null && value.length === 0
+  const isNoneSelected = hasNoneOption && value != null && value.length === 0
   const [query, setQuery] = useState("")
   const [open, setOpen] = useState(false)
 
@@ -87,10 +89,6 @@ export default function MultiSelect({
       ),
     [query, options],
   )
-  const showNoneOption = useMemo(
-    () => hasNoneOption && "none".includes(query.toLowerCase()),
-    [hasNoneOption, query],
-  )
 
   const emit = (next: string[] | null, focus = true) => {
     onChange(next)
@@ -103,11 +101,12 @@ export default function MultiSelect({
     [exclusiveOptions],
   )
 
-  const toggleNone = (focus = true) => {
-    emit(isNoneActive ? null : [], focus)
-  }
-
   const toggle = (value: string, focus = true) => {
+    if (value === NONE) {
+      emit(isNoneSelected ? null : [], focus)
+      return
+    }
+
     if (requiredSet.has(value)) return
 
     if (exclusiveSet.has(value)) {
@@ -170,12 +169,12 @@ export default function MultiSelect({
                 </TooltipContent>
               </Tooltip>
             ))}
-            {isNoneActive && (
+            {isNoneSelected && (
               <Badge
                 className="h-5 cursor-pointer text-content-muted"
                 onClick={(e) => {
                   e.stopPropagation()
-                  toggleNone(open)
+                  toggle(NONE, open)
                 }}
               >
                 None <span className="ml-1">&times;</span>
@@ -203,7 +202,7 @@ export default function MultiSelect({
               disabled={disabled}
               autoFocus={autoFocus}
               placeholder={
-                items.length || isNoneActive || requiredOptions.length
+                items.length || isNoneSelected || requiredOptions.length
                   ? ""
                   : placeholder
               }
@@ -220,8 +219,8 @@ export default function MultiSelect({
                 }
 
                 if (e.key === "Backspace" && !query) {
-                  if (isNoneActive) {
-                    toggleNone(open)
+                  if (isNoneSelected) {
+                    toggle(NONE, open)
                   } else if (items.length) {
                     remove(items[items.length - 1])
                   }
@@ -246,17 +245,17 @@ export default function MultiSelect({
           <CommandList>
             <ScrollArea
               className={cn(
-                visibleOptions.length + (showNoneOption ? 1 : 0) > 5 && "h-48",
+                visibleOptions.length + (hasNoneOption ? 1 : 0) > 5 && "h-48",
               )}
             >
-              {showNoneOption && (
+              {hasNoneOption && (
                 <CommandItem
                   tabIndex={-1}
-                  onSelect={() => toggleNone()}
+                  onSelect={() => toggle(NONE)}
                   className="cursor-pointer"
                 >
                   <Checkbox
-                    checked={isNoneActive}
+                    checked={isNoneSelected}
                     className="pointer-events-none mr-2"
                   />
                   None

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -82,12 +82,20 @@ export default function MultiSelect({
     () => new Map(options.map((o) => [o.value, o.label])),
     [options],
   )
+  const normalizedOptions = useMemo(() => {
+    const base = options.slice()
+    if (includeWildcard && !base.some((o) => o.value === "*")) {
+      base.unshift({ label: "*", value: "*" })
+    }
+    return base
+  }, [options, includeWildcard])
+
   const visibleOptions = useMemo(
     () =>
-      options.filter((option) =>
+      normalizedOptions.filter((option) =>
         option.label.toLowerCase().includes(query.toLowerCase()),
       ),
-    [query, options],
+    [query, normalizedOptions],
   )
 
   const emit = (next: string[] | null, focus = true) => {

--- a/src/components/products/form/create.tsx
+++ b/src/components/products/form/create.tsx
@@ -34,7 +34,7 @@ export default function CreateProductForm({
       code: "",
       url: "",
       platforms: [],
-      permissions: [],
+      permissions: null,
       metadata: {},
       distributionStrategy: DistributionStrategy.Licensed,
     },

--- a/src/components/products/form/edit.tsx
+++ b/src/components/products/form/edit.tsx
@@ -40,7 +40,7 @@ export default function EditProductForm({
         product?.attributes.distributionStrategy ??
         DistributionStrategy.Licensed,
       platforms: product?.attributes.platforms ?? [],
-      permissions: product?.attributes.permissions ?? [],
+      permissions: product?.attributes.permissions ?? null,
       metadata: product?.attributes.metadata ?? {},
     },
   })

--- a/src/components/products/form/fields.tsx
+++ b/src/components/products/form/fields.tsx
@@ -339,8 +339,8 @@ function PermissionsField({
                   value: p,
                 })),
               ]}
-              noneOption
-              exclusiveOptions={["*"]}
+              includeNone
+              includeWildcard
               placeholder="Leave blank to use defaults"
               autoFocus={autoFocus}
             />

--- a/src/components/products/form/fields.tsx
+++ b/src/components/products/form/fields.tsx
@@ -330,13 +330,17 @@ function PermissionsField({
             optional
           >
             <MultiSelect
-              value={field.value ?? []}
+              value={field.value}
               onChange={field.onChange}
-              options={ProductPermissions.map((p) => ({
-                label: p === "*" ? "*" : p,
-                value: p,
-              }))}
-              wildcard="*"
+              options={[
+                { label: "*", value: "*" },
+                ...ProductPermissions.map((p) => ({
+                  label: p,
+                  value: p,
+                })),
+              ]}
+              noneOption
+              exclusiveOptions={["*"]}
               placeholder="Leave blank to use defaults"
               autoFocus={autoFocus}
             />

--- a/src/components/products/form/fields.tsx
+++ b/src/components/products/form/fields.tsx
@@ -27,6 +27,7 @@ import TagInput from "@/components/tag-input"
 import MultiSelect from "@/components/multi-select"
 import KeyValueInput from "@/components/key-value-input"
 import { CardSelector, CardOption } from "@/components/card-selector"
+
 type Descriptions = typeof ProductFormFieldDescriptions
 
 interface ProductsFormFieldsProps {
@@ -35,7 +36,7 @@ interface ProductsFormFieldsProps {
   autoFocus?: Schemas.Products.FieldNames
   titleVariant?: boolean
   fieldVariant?: FieldVariant
-  schema?: "create" | "edit"
+  schema?: Schemas.Products.SchemaNames
 }
 
 const IncludeDefaultFields: Schemas.Products.FieldNames[] = [
@@ -105,6 +106,7 @@ export default function ProductsFormFields({
             return (
               <PermissionsField
                 key="permissions"
+                schema={schema}
                 autoFocus={autoFocus === "permissions"}
                 fieldVariant={fieldVariant}
                 descriptions={descriptions}
@@ -307,10 +309,12 @@ function DistributionStrategyField() {
 }
 
 function PermissionsField({
+  schema,
   autoFocus,
   fieldVariant = "row",
   descriptions,
 }: {
+  schema?: Schemas.Products.SchemaNames
   autoFocus?: boolean
   fieldVariant?: FieldVariant
   descriptions: Descriptions
@@ -341,7 +345,11 @@ function PermissionsField({
               ]}
               includeNone
               includeWildcard
-              placeholder="Leave blank to use defaults"
+              placeholder={
+                schema === "create"
+                  ? "Leave blank to use defaults"
+                  : "Select permissions..."
+              }
               autoFocus={autoFocus}
             />
           </Forms.Field.Header>

--- a/src/components/products/form/fields.tsx
+++ b/src/components/products/form/fields.tsx
@@ -336,13 +336,10 @@ function PermissionsField({
             <MultiSelect
               value={field.value}
               onChange={field.onChange}
-              options={[
-                { label: "*", value: "*" },
-                ...ProductPermissions.map((p) => ({
-                  label: p,
-                  value: p,
-                })),
-              ]}
+              options={ProductPermissions.map((p) => ({
+                label: p,
+                value: p,
+              }))}
               includeNone
               includeWildcard
               placeholder={

--- a/src/components/users/form/create.tsx
+++ b/src/components/users/form/create.tsx
@@ -32,7 +32,7 @@ export default function CreateUserForm({
       lastName: null,
       password: null,
       role: UserRole.User,
-      permissions: [],
+      permissions: null,
       groupId: null,
       metadata: {},
     },

--- a/src/components/users/form/edit.tsx
+++ b/src/components/users/form/edit.tsx
@@ -25,7 +25,7 @@ export default function EditUserForm({
   onOpenChange,
 }: EditUserFormProps) {
   const { id } = useParams({ from: "/$accountId/app/users/$id" })
-  const { data: user, isLoading: userLoading } = useGetUser(id)
+  const { data: user } = useGetUser(id)
   const updateUser = useUpdateUser(user?.id ?? "")
   const changeGroup = useChangeUserGroup()
 
@@ -68,7 +68,7 @@ export default function EditUserForm({
           title="Editing an existing user"
           onSubmit={handleSubmit}
           errorMessage="Failed to update user"
-          isPending={userLoading}
+          isPending={updateUser.isPending}
           submitLabel="Update"
           className="md:h-[66vh]!"
         >

--- a/src/components/users/form/edit.tsx
+++ b/src/components/users/form/edit.tsx
@@ -37,7 +37,7 @@ export default function EditUserForm({
       firstName: user?.attributes.firstName ?? null,
       lastName: user?.attributes.lastName ?? null,
       role: user?.attributes.role ?? UserRole.User,
-      permissions: user?.attributes.permissions ?? [],
+      permissions: user?.attributes.permissions ?? null,
       groupId: user?.relationships.group?.data?.id ?? null,
       metadata: user?.attributes.metadata ?? {},
     },

--- a/src/components/users/form/fields.tsx
+++ b/src/components/users/form/fields.tsx
@@ -545,13 +545,10 @@ function PermissionsField({
             <MultiSelect
               value={field.value}
               onChange={field.onChange}
-              options={[
-                { label: "*", value: "*" },
-                ...ProductPermissions.map((p) => ({
-                  label: p,
-                  value: p,
-                })),
-              ]}
+              options={ProductPermissions.map((p) => ({
+                label: p,
+                value: p,
+              }))}
               includeNone
               includeWildcard
               placeholder={
@@ -600,13 +597,10 @@ function InternalPermissionsField({
             <MultiSelect
               value={field.value}
               onChange={field.onChange}
-              options={[
-                { label: "*", value: "*" },
-                ...AdminPermissions.map((p) => ({
-                  label: p,
-                  value: p,
-                })),
-              ]}
+              options={AdminPermissions.map((p) => ({
+                label: p,
+                value: p,
+              }))}
               includeNone
               includeWildcard
               requiredOptions={PORTAL_REQUIRED_OPTIONS}

--- a/src/components/users/form/fields.tsx
+++ b/src/components/users/form/fields.tsx
@@ -540,12 +540,17 @@ function PermissionsField({
             tooltip={descriptions.permissions}
           >
             <MultiSelect
-              value={field.value ?? []}
+              value={field.value}
               onChange={field.onChange}
-              options={ProductPermissions.map((p) => ({
-                label: p,
-                value: p,
-              }))}
+              options={[
+                { label: "*", value: "*" },
+                ...ProductPermissions.map((p) => ({
+                  label: p,
+                  value: p,
+                })),
+              ]}
+              noneOption
+              exclusiveOptions={["*"]}
               placeholder="Leave blank to use defaults"
               autoFocus={autoFocus}
             />
@@ -586,12 +591,17 @@ function InternalPermissionsField({
             tooltip={descriptions.permissions}
           >
             <MultiSelect
-              value={field.value ?? []}
+              value={field.value}
               onChange={field.onChange}
-              options={AdminPermissions.map((p) => ({
-                label: p,
-                value: p,
-              }))}
+              options={[
+                { label: "*", value: "*" },
+                ...AdminPermissions.map((p) => ({
+                  label: p,
+                  value: p,
+                })),
+              ]}
+              noneOption
+              exclusiveOptions={["*"]}
               requiredOptions={PORTAL_REQUIRED_OPTIONS}
               autoFocus={autoFocus}
             />

--- a/src/components/users/form/fields.tsx
+++ b/src/components/users/form/fields.tsx
@@ -50,7 +50,7 @@ interface UsersFormFieldsProps {
   autoFocus?: Schemas.Users.FieldNames
   titleVariant?: boolean
   fieldVariant?: FieldVariant
-  schema?: "create" | "edit"
+  schema?: Schemas.Users.SchemaNames
 }
 
 const IncludeDefaultFields: Schemas.Users.FieldNames[] = [
@@ -173,6 +173,7 @@ export default function UsersFormFields({
             return (
               <PermissionsField
                 key="permissions"
+                schema={schema}
                 autoFocus={autoFocus === "permissions"}
                 fieldVariant={fieldVariant}
                 descriptions={descriptions}
@@ -517,10 +518,12 @@ function InternalRoleField({
 }
 
 function PermissionsField({
+  schema,
   autoFocus,
   fieldVariant = "row",
   descriptions,
 }: {
+  schema?: Schemas.Users.SchemaNames
   autoFocus?: boolean
   fieldVariant?: FieldVariant
   descriptions: Descriptions
@@ -551,7 +554,11 @@ function PermissionsField({
               ]}
               includeNone
               includeWildcard
-              placeholder="Leave blank to use defaults"
+              placeholder={
+                schema === "create" || schema === "invite"
+                  ? "Leave blank to use defaults"
+                  : "Select permissions..."
+              }
               autoFocus={autoFocus}
             />
           </Forms.Field.Header>

--- a/src/components/users/form/fields.tsx
+++ b/src/components/users/form/fields.tsx
@@ -549,8 +549,8 @@ function PermissionsField({
                   value: p,
                 })),
               ]}
-              noneOption
-              exclusiveOptions={["*"]}
+              includeNone
+              includeWildcard
               placeholder="Leave blank to use defaults"
               autoFocus={autoFocus}
             />
@@ -600,8 +600,8 @@ function InternalPermissionsField({
                   value: p,
                 })),
               ]}
-              noneOption
-              exclusiveOptions={["*"]}
+              includeNone
+              includeWildcard
               requiredOptions={PORTAL_REQUIRED_OPTIONS}
               autoFocus={autoFocus}
             />

--- a/src/components/users/form/invite.tsx
+++ b/src/components/users/form/invite.tsx
@@ -76,6 +76,7 @@ export default function InviteUserForm({
           <Separator dashed className="my-8" />
 
           <Users.Form.Fields
+            schema="invite"
             include={["internalPermissions"]}
             fieldVariant="stacking"
           />

--- a/src/schemas/account.ts
+++ b/src/schemas/account.ts
@@ -11,8 +11,8 @@ export type DeveloperValues = Writable<
   Pick<AccountAttributes, "apiVersion" | "protected">
 >
 export type PermissionsValues = {
-  defaultUserPermissions?: string[]
-  defaultLicensePermissions?: string[]
+  defaultUserPermissions?: string[] | null
+  defaultLicensePermissions?: string[] | null
 }
 export type AllValues = CombineFormValues<BaseValues, UpdateValues> &
   DeveloperValues &
@@ -58,8 +58,8 @@ export const DeveloperSchema: z.ZodType<DeveloperValues> =
   DeveloperRules(DeveloperShape)
 
 const PermissionsShape = z.object({
-  defaultUserPermissions: z.array(z.string()).optional(),
-  defaultLicensePermissions: z.array(z.string()).optional(),
+  defaultUserPermissions: z.array(z.string()).nullable().optional(),
+  defaultLicensePermissions: z.array(z.string()).nullable().optional(),
 })
 
 const PermissionsRules = (

--- a/src/schemas/products.ts
+++ b/src/schemas/products.ts
@@ -34,7 +34,7 @@ const BaseShape = z.object({
     .refine((v) => !v || z.string().url().safeParse(v).success, {
       message: "Must be a valid URL",
     }),
-  permissions: z.array(z.string()).default([]),
+  permissions: z.array(z.string()).nullable().default(null),
   platforms: z.array(z.string()).default([]),
   metadata: z.record(z.string()).default({}),
 })

--- a/src/schemas/products.ts
+++ b/src/schemas/products.ts
@@ -66,3 +66,11 @@ const AttributesRules = (
 }
 export const AttributesSchema = AttributesRules(AttributesShape)
 export type AttributesValues = z.infer<typeof AttributesSchema>
+
+export const SchemaMap = {
+  base: BaseSchema,
+  create: CreateSchema,
+  edit: UpdateSchema,
+} as const
+
+export type SchemaNames = keyof typeof SchemaMap

--- a/src/schemas/users.ts
+++ b/src/schemas/users.ts
@@ -45,7 +45,7 @@ const BaseShape = z.object({
   firstName: z.string().trim().nullable().optional(),
   lastName: z.string().trim().nullable().optional(),
   role: z.nativeEnum(UserRole).optional(),
-  permissions: z.array(z.string()).optional(),
+  permissions: z.array(z.string()).nullable().optional(),
   metadata: z.record(z.unknown()).default({}),
   groupId: z.string().nullable().optional(),
 })
@@ -88,7 +88,7 @@ const InviteShape = z.object({
   firstName: z.string().trim().nullable().optional(),
   lastName: z.string().trim().nullable().optional(),
   role: z.nativeEnum(UserRole),
-  permissions: z.array(z.string()).optional(),
+  permissions: z.array(z.string()).nullable().optional(),
 })
 
 const InviteRules = (

--- a/src/schemas/users.ts
+++ b/src/schemas/users.ts
@@ -100,3 +100,14 @@ const InviteRules = (
 export const InviteSchema: z.ZodType<InviteValues> = InviteRules(
   InviteShape as z.ZodType<InviteValues>,
 )
+
+export const SchemaMap = {
+  base: BaseSchema,
+  create: CreateSchema,
+  edit: UpdateSchema,
+  profile: UpdateSchema,
+  password: PasswordSchema,
+  invite: InviteSchema,
+} as const
+
+export type SchemaNames = keyof typeof SchemaMap

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -28,7 +28,7 @@ export type ProductAttributes = {
   distributionStrategy: DistributionStrategy
   url: string
   platforms: string[]
-  permissions: string[]
+  permissions: string[] | null
   metadata: Record<string, unknown>
   created: string
   updated: string

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -34,7 +34,7 @@ export type UserAttributes = {
   fullName: string | null
   status: UserStatus
   role: UserRole
-  permissions: string[]
+  permissions: string[] | null
   metadata: Record<string, unknown>
   created: string
   updated: string
@@ -45,7 +45,7 @@ export interface UserInput {
   firstName?: string | null
   lastName?: string | null
   role?: UserRole
-  permissions?: string[]
+  permissions?: string[] | null
   metadata?: Record<string, unknown>
 }
 


### PR DESCRIPTION
Closes #157. Adds a couple of props to the `multi-select` component that allows us to add `None` and `*` as options, and implements said props in permission form fields across the app.

* Adds a `includeNone` prop that will set the field to an empty array, which can be useful in our case where sending `[]` to the API for permission-related attributes will allow the API to correctly initialize the attribute with an empty array rather than use default permissions from setting the field to `null`. Also, it's an optional prop so we can omit it in certain cases, such as the permissions field in the invite user form where we require some permissions for Portal access.
* Renames `wildcard` to `includeWildcard` prop for consistency with the above addition and better represent that it's a bool.

<img width="800" src="https://github.com/user-attachments/assets/a900572b-3397-4760-b7b7-55e847a76f5a" />

<img width="800" src="https://github.com/user-attachments/assets/58672b32-759c-4d9a-ba5b-8e76eee19c0e" />
