### PR TITLE
Fix default filters on user detail

### DIFF
--- a/src/hooks/use-filter-search.ts
+++ b/src/hooks/use-filter-search.ts
@@ -1,12 +1,13 @@
 import { useCallback } from "react"
 import { useSearch, useNavigate } from "@tanstack/react-router"
 
-export function useFilterSearch<T extends Record<string, unknown>>(): [
-  T,
-  (next: T) => void,
-] {
-  const filters = useSearch({ strict: false }) as T
+export function useFilterSearch<T extends Record<string, unknown>>(
+  defaults?: Partial<T>,
+): [T, (next: T) => void] {
+  const search = useSearch({ strict: false }) as T
   const navigate = useNavigate()
+
+  const filters = { ...defaults, ...search } as T
 
   const setFilters = useCallback(
     (next: T) => {

--- a/src/pages/app/user/list.tsx
+++ b/src/pages/app/user/list.tsx
@@ -6,7 +6,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { useUserTableColumns } from "@/hooks/use-user-table-columns"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { useDataTable } from "@/hooks/use-data-table"
-import { User, type UserFilters } from "@/types/users"
+import { User, UserRole, type UserFilters } from "@/types/users"
 
 import { useListUsers } from "@/queries/users"
 
@@ -22,7 +22,11 @@ export default function UsersList() {
   const table = useDataTable()
   const columns = useUserTableColumns()
 
-  const [filters, setFilters] = useFilterSearch<UserFilters>()
+  const [rawFilters, setFilters] = useFilterSearch<UserFilters>()
+  const filters: UserFilters = {
+    ...rawFilters,
+    roles: rawFilters.roles ?? [UserRole.User],
+  }
 
   const handleFiltersChange = useCallback(
     (next: UserFilters) => {

--- a/src/pages/app/user/list.tsx
+++ b/src/pages/app/user/list.tsx
@@ -22,11 +22,9 @@ export default function UsersList() {
   const table = useDataTable()
   const columns = useUserTableColumns()
 
-  const [rawFilters, setFilters] = useFilterSearch<UserFilters>()
-  const filters: UserFilters = {
-    ...rawFilters,
-    roles: rawFilters.roles ?? [UserRole.User],
-  }
+  const [filters, setFilters] = useFilterSearch<UserFilters>({
+    roles: [UserRole.User],
+  })
 
   const handleFiltersChange = useCallback(
     (next: UserFilters) => {

--- a/src/routes/$accountId/app.users.tsx
+++ b/src/routes/$accountId/app.users.tsx
@@ -14,7 +14,6 @@ function validateSearch(search: Record<string, unknown>): UserFilters {
   if (typeof search.product === "string") filters.product = search.product
   if (typeof search.group === "string") filters.group = search.group
   if (Array.isArray(search.roles)) filters.roles = search.roles as string[]
-  else filters.roles = ["user"]
   if (isRecord(search.metadata))
     filters.metadata = search.metadata as Record<string, string>
 


### PR DESCRIPTION
Refactors where default filters are applied, since the defaults on `/users` would also be applied to child routes like `/users/$id`. This resulted in user detail pages having `?roles=["user"]` appended onto the URL, which triggers my OCD severely.