### PR TITLE
Fix inconsistent page header height

### DIFF
--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -19,7 +19,7 @@ export default function PageHeader({
   return (
     <header
       className={cn(
-        "flex items-center gap-2 border-b border-accent p-2 md:p-4",
+        "flex min-h-[60px] items-center gap-2 border-b border-accent p-2 md:min-h-[70px] md:p-4",
         className,
       )}
     >


### PR DESCRIPTION
When navigating between some pages, namely Settings, the page header would slightly change height. This adds a min height so this happens less often. Ideally, we could add a text overflow w/ ellipsis so that height is always consistent.

https://github.com/user-attachments/assets/8d27b147-108d-4367-8c43-cf8133dbfe2a