### PR TITLE
Add Portal version detection with refresh prompt

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -10,3 +10,5 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv
 }
+
+declare const __APP_VERSION__: string

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@tanstack/router-cli": "^1.139.13",
+    "@types/node": "^25.6.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@types/semver": "^7.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,7 +63,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tailwindcss/vite':
         specifier: ^4.0.12
-        version: 4.1.11(vite@6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))
+        version: 4.1.11(vite@6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))
       '@tanstack/react-query':
         specifier: ^5.83.0
         version: 5.83.0(react@19.1.0)
@@ -72,13 +72,13 @@ importers:
         version: 1.139.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tanstack/react-router-devtools':
         specifier: ^1.139.13
-        version: 1.139.13(@tanstack/react-router@1.139.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@tanstack/router-core@1.139.13)(csstype@3.1.3)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.7)(tsx@4.21.0)
+        version: 1.139.13(@tanstack/react-router@1.139.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@tanstack/router-core@1.139.13)(@types/node@25.6.0)(csstype@3.1.3)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.7)(tsx@4.21.0)
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@tanstack/router-plugin':
         specifier: ^1.139.13
-        version: 1.139.13(@tanstack/react-router@1.139.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))
+        version: 1.139.13(@tanstack/react-router@1.139.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -132,7 +132,7 @@ importers:
         version: 1.0.7(tailwindcss@4.1.11)
       vite-plugin-svgr:
         specifier: ^4.3.0
-        version: 4.3.0(rollup@4.53.3)(typescript@5.7.3)(vite@6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))
+        version: 4.3.0(rollup@4.53.3)(typescript@5.7.3)(vite@6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))
       zod:
         specifier: ^3.24.2
         version: 3.25.76
@@ -143,6 +143,9 @@ importers:
       '@tanstack/router-cli':
         specifier: ^1.139.13
         version: 1.139.13
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
       '@types/react':
         specifier: ^19.0.10
         version: 19.1.8
@@ -154,7 +157,7 @@ importers:
         version: 7.7.1
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.6.0(vite@6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))
+        version: 4.6.0(vite@6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))
       eslint:
         specifier: ^9.21.0
         version: 9.31.0(jiti@2.4.2)
@@ -184,13 +187,13 @@ importers:
         version: 8.47.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.7.3)
       vite:
         specifier: ^6.4.0
-        version: 6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
+        version: 6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.7.3)(vite@6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))
+        version: 5.1.4(typescript@5.7.3)(vite@6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))
       vitest:
         specifier: ^4.0.15
-        version: 4.0.15(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
+        version: 4.0.15(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
 
 packages:
 
@@ -2014,6 +2017,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
   '@types/react-dom@19.1.6':
     resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
     peerDependencies:
@@ -3191,6 +3197,9 @@ packages:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   unplugin@2.3.5:
     resolution: {integrity: sha512-RyWSb5AHmGtjjNQ6gIlA67sHOsWpsbWpwDokLwTcejVdOjEkJZh7QKu14J00gDDVSh8kGH4KYC/TNBceXFZhtw==}
@@ -4813,12 +4822,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.11
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.11
 
-  '@tailwindcss/vite@4.1.11(vite@6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.1.11(vite@6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))':
     dependencies:
       '@tailwindcss/node': 4.1.11
       '@tailwindcss/oxide': 4.1.11
       tailwindcss: 4.1.11
-      vite: 6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
 
   '@tanstack/history@1.139.0': {}
 
@@ -4829,13 +4838,13 @@ snapshots:
       '@tanstack/query-core': 5.83.0
       react: 19.1.0
 
-  '@tanstack/react-router-devtools@1.139.13(@tanstack/react-router@1.139.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@tanstack/router-core@1.139.13)(csstype@3.1.3)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.7)(tsx@4.21.0)':
+  '@tanstack/react-router-devtools@1.139.13(@tanstack/react-router@1.139.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@tanstack/router-core@1.139.13)(@types/node@25.6.0)(csstype@3.1.3)(jiti@2.4.2)(lightningcss@1.30.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(solid-js@1.9.7)(tsx@4.21.0)':
     dependencies:
       '@tanstack/react-router': 1.139.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@tanstack/router-devtools-core': 1.139.13(@tanstack/router-core@1.139.13)(csstype@3.1.3)(jiti@2.4.2)(lightningcss@1.30.1)(solid-js@1.9.7)(tsx@4.21.0)
+      '@tanstack/router-devtools-core': 1.139.13(@tanstack/router-core@1.139.13)(@types/node@25.6.0)(csstype@3.1.3)(jiti@2.4.2)(lightningcss@1.30.1)(solid-js@1.9.7)(tsx@4.21.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      vite: 7.2.6(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
+      vite: 7.2.6(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
     optionalDependencies:
       '@tanstack/router-core': 1.139.13
     transitivePeerDependencies:
@@ -4895,14 +4904,14 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/router-devtools-core@1.139.13(@tanstack/router-core@1.139.13)(csstype@3.1.3)(jiti@2.4.2)(lightningcss@1.30.1)(solid-js@1.9.7)(tsx@4.21.0)':
+  '@tanstack/router-devtools-core@1.139.13(@tanstack/router-core@1.139.13)(@types/node@25.6.0)(csstype@3.1.3)(jiti@2.4.2)(lightningcss@1.30.1)(solid-js@1.9.7)(tsx@4.21.0)':
     dependencies:
       '@tanstack/router-core': 1.139.13
       clsx: 2.1.1
       goober: 2.1.18(csstype@3.1.3)
       solid-js: 1.9.7
       tiny-invariant: 1.3.3
-      vite: 7.2.6(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
+      vite: 7.2.6(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
     optionalDependencies:
       csstype: 3.1.3
     transitivePeerDependencies:
@@ -4931,7 +4940,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.139.13(@tanstack/react-router@1.139.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))':
+  '@tanstack/router-plugin@1.139.13(@tanstack/react-router@1.139.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(vite@6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.0)
@@ -4949,7 +4958,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.139.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      vite: 6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5003,6 +5012,10 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
 
   '@types/react-dom@19.1.6(@types/react@19.1.8)':
     dependencies:
@@ -5107,7 +5120,7 @@ snapshots:
       '@typescript-eslint/types': 8.47.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@4.6.0(vite@6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))':
+  '@vitejs/plugin-react@4.6.0(vite@6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
@@ -5115,7 +5128,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.19
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5128,13 +5141,13 @@ snapshots:
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.15(vite@6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.15(vite@6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.15
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.0.15':
     dependencies:
@@ -6144,6 +6157,8 @@ snapshots:
 
   typescript@5.7.3: {}
 
+  undici-types@7.19.2: {}
+
   unplugin@2.3.5:
     dependencies:
       acorn: 8.15.0
@@ -6179,29 +6194,29 @@ snapshots:
     dependencies:
       react: 19.1.0
 
-  vite-plugin-svgr@4.3.0(rollup@4.53.3)(typescript@5.7.3)(vite@6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)):
+  vite-plugin-svgr@4.3.0(rollup@4.53.3)(typescript@5.7.3)(vite@6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)):
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.53.3)
       '@svgr/core': 8.1.0(typescript@5.7.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.7.3))
-      vite: 6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.7.3)
     optionalDependencies:
-      vite: 6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0):
+  vite@6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.6
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6210,12 +6225,13 @@ snapshots:
       rollup: 4.45.0
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.30.1
       tsx: 4.21.0
 
-  vite@7.2.6(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0):
+  vite@7.2.6(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6224,15 +6240,16 @@ snapshots:
       rollup: 4.53.3
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.30.1
       tsx: 4.21.0
 
-  vitest@4.0.15(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0):
+  vitest@4.0.15(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.15
-      '@vitest/mocker': 4.0.15(vite@6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.15(vite@6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.15
       '@vitest/runner': 4.0.15
       '@vitest/snapshot': 4.0.15
@@ -6249,8 +6266,10 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 6.4.1(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.6.0)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.21.0)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
     transitivePeerDependencies:
       - jiti
       - less

--- a/src/components/sidebar/new-version-card.tsx
+++ b/src/components/sidebar/new-version-card.tsx
@@ -1,0 +1,31 @@
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardFooter,
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+
+type Props = {
+  onReload: () => void
+}
+
+export default function NewVersionCard({ onReload }: Props) {
+  return (
+    <Card className="w-full items-start gap-4 rounded border-none p-4">
+      <CardHeader className="w-full px-0">
+        <CardTitle className="text-sm">A new version is available</CardTitle>
+        <CardDescription className="text-xs">
+          Refresh the page for the latest Portal updates.
+        </CardDescription>
+      </CardHeader>
+
+      <CardFooter className="w-full px-0">
+        <Button size="sm" onClick={onReload}>
+          Refresh
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/src/components/sidebar/panel.tsx
+++ b/src/components/sidebar/panel.tsx
@@ -52,10 +52,14 @@ import {
 } from "lucide-react"
 
 import * as keygen from "@/keygen"
-import { useMobile } from "@/hooks/use-mobile"
+
 import { useCloud } from "@/hooks/use-cloud"
-import Combobox from "./combobox"
+import { useMobile } from "@/hooks/use-mobile"
+import { useAppVersion } from "@/hooks/use-app-version"
+
 import Command from "./command"
+import Combobox from "./combobox"
+import NewVersionCard from "./new-version-card"
 import BillingStatusCard from "./billing-status-card"
 
 enum ViewId {
@@ -246,9 +250,6 @@ function useActiveView(): View {
   return VIEWS.find((view) => view.id === ViewId.Home)!
 }
 
-/**
- * Renders the main app sidebar with a rail sidebar and a content sidebar.
- */
 export default function SidebarPanel(): React.ReactElement {
   const activeView = useActiveView()
   const [selectedView, setSelectedView] = useState(activeView)
@@ -256,6 +257,7 @@ export default function SidebarPanel(): React.ReactElement {
 
   const isMobile = useMobile()
   const { isCloud } = useCloud()
+  const { hasUpdate, reload } = useAppVersion()
 
   const visibleRoutes = isCloud
     ? selectedView.routes
@@ -467,7 +469,11 @@ export default function SidebarPanel(): React.ReactElement {
         </SidebarContent>
 
         <SidebarFooter className="w-60 border-none p-4">
-          <BillingStatusCard />
+          {hasUpdate ? (
+            <NewVersionCard onReload={reload} />
+          ) : (
+            <BillingStatusCard />
+          )}
         </SidebarFooter>
       </Sidebar>
     </div>

--- a/src/hooks/use-app-version.ts
+++ b/src/hooks/use-app-version.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react"
+
+const CURRENT_VERSION = __APP_VERSION__
+const POLL_INTERVAL_MS = 60 * 60 * 1000
+
+export function useAppVersion(): {
+  hasUpdate: boolean
+  reload: () => void
+} {
+  const [hasUpdate, setHasUpdate] = useState(false)
+
+  useEffect(() => {
+    if (!import.meta.env.PROD || hasUpdate) return
+
+    let cancelled = false
+
+    async function check() {
+      try {
+        const response = await fetch("/version.json", { cache: "no-store" })
+        if (!response.ok) return
+        const { version } = (await response.json()) as { version?: string }
+        if (!cancelled && version && version !== CURRENT_VERSION) {
+          setHasUpdate(true)
+        }
+      } catch (error) {
+        console.warn("Version check failed:", error)
+      }
+    }
+
+    const onVisibility = async () => {
+      if (document.visibilityState === "visible") await check()
+    }
+
+    ;(async () => await check())()
+    const id = setInterval(check, POLL_INTERVAL_MS)
+    document.addEventListener("visibilitychange", onVisibility)
+
+    return () => {
+      cancelled = true
+      clearInterval(id)
+      document.removeEventListener("visibilitychange", onVisibility)
+    }
+  }, [hasUpdate])
+
+  return { hasUpdate, reload: () => window.location.reload() }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,43 @@
-import { defineConfig } from "vite"
+import { defineConfig, type PluginOption } from "vite"
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite"
 import tsconfigPaths from "vite-tsconfig-paths"
+import { execSync } from "node:child_process"
 import tailwindcss from "@tailwindcss/vite"
 import react from "@vitejs/plugin-react"
 import svgr from "vite-plugin-svgr"
 
+function resolveAppVersion(): string {
+  try {
+    return execSync("git rev-parse --short HEAD", {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim()
+  } catch {
+    return String(Date.now())
+  }
+}
+
+function appVersion(): PluginOption {
+  const version = resolveAppVersion()
+  return {
+    name: "app-version",
+    config: () => ({
+      define: { __APP_VERSION__: JSON.stringify(version) },
+    }),
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: "version.json",
+        source: JSON.stringify({ version }),
+      })
+    },
+  }
+}
+
 export default defineConfig({
   plugins: [
+    appVersion(),
     TanStackRouterVite({ target: "react", autoCodeSplitting: true }),
     tsconfigPaths(),
     tailwindcss(),


### PR DESCRIPTION
Closes #179. Detects when a user is on an outdated Portal version and prompts them to refresh the page for the latest version by comparing the current build hash to a `version.json` file, which contains the last build hash, and is polled hourly and on tab focus.

You can test this by:
* Running `pnpm build`
* Running `pnpm preview`
* Editing `dist/version.json` to something random so the version change is recognized
* Switching away from the Portal `preview` instance tab and back, which triggers a version re-check

<img width="516" height="695" src="https://github.com/user-attachments/assets/7e028662-6f07-4e80-b9bd-4635055f5dd1" />