### PR TITLE
Add permission-gating to Portal

### DIFF
--- a/src/components/account/form/fields.tsx
+++ b/src/components/account/form/fields.tsx
@@ -153,7 +153,7 @@ function AccountSlugField({
             label="Account slug"
             variant={fieldVariant}
             tooltip={AccountFormFieldDescriptions.slug}
-            tooltipVariant="warning"
+            tooltipVariant="destructive"
           >
             <FormControl>
               <Input

--- a/src/components/can.tsx
+++ b/src/components/can.tsx
@@ -1,0 +1,56 @@
+import { usePermissions } from "@/hooks/use-permissions"
+
+import type { Permission } from "@/types/users"
+
+interface CanProps {
+  permission: Permission
+  fallback?: React.ReactNode
+  children: React.ReactNode
+}
+
+interface CanAnyProps {
+  permissions: readonly Permission[]
+  fallback?: React.ReactNode
+  children: React.ReactNode
+}
+
+interface CanAllProps {
+  permissions: readonly Permission[]
+  fallback?: React.ReactNode
+  children: React.ReactNode
+}
+
+function Can({
+  permission,
+  fallback = null,
+  children,
+}: CanProps): React.ReactNode {
+  const { can, isLoading } = usePermissions()
+  if (isLoading) return fallback
+  return can(permission) ? children : fallback
+}
+
+function Any({
+  permissions,
+  fallback = null,
+  children,
+}: CanAnyProps): React.ReactNode {
+  const { canAny, isLoading } = usePermissions()
+  if (isLoading) return fallback
+  return canAny(permissions) ? children : fallback
+}
+
+function All({
+  permissions,
+  fallback = null,
+  children,
+}: CanAllProps): React.ReactNode {
+  const { canAll, isLoading } = usePermissions()
+  if (isLoading) return fallback
+  return canAll(permissions) ? children : fallback
+}
+
+Can.Any = Any
+Can.All = All
+
+export default Can

--- a/src/components/forms/field/header.tsx
+++ b/src/components/forms/field/header.tsx
@@ -9,19 +9,20 @@ import {
   PopoverContent,
 } from "@/components/ui/popover"
 
-import { Info } from "lucide-react"
+import { Info, TriangleAlert } from "lucide-react"
 
 import { cn, splitLastWord } from "@/lib/utils"
 
 import { useMobile } from "@/hooks/use-mobile"
 
 export type FieldVariant = "row" | "stacking" | "inline" | "none"
-type TooltipVariant = "default" | "warning"
+type TooltipVariant = "default" | "destructive"
 
 interface FieldHeaderProps {
   label: string
   tooltip?: string | null
   tooltipVariant?: TooltipVariant
+  warning?: string | React.ReactNode
   variant?: FieldVariant
   optional?: boolean
   hint?: string
@@ -33,6 +34,7 @@ export default function FieldHeader({
   label,
   tooltip = null,
   tooltipVariant = "default",
+  warning,
   variant = "row",
   optional = false,
   hint,
@@ -58,7 +60,7 @@ export default function FieldHeader({
             {head && <>{head} </>}
             <span className="inline-flex gap-2 whitespace-nowrap">
               {tail}
-              {tooltip && (
+              {(tooltip || warning) && (
                 <>
                   <span className="inline-flex md:hidden">
                     <Popover>
@@ -66,34 +68,42 @@ export default function FieldHeader({
                         onClick={(e) => e.stopPropagation()}
                         asChild
                       >
-                        <Info
-                          className={cn(
-                            "inline size-5",
-                            tooltipVariant === "warning"
-                              ? "text-destructive"
-                              : "text-content-subdued",
-                          )}
-                        />
+                        {warning ? (
+                          <TriangleAlert className="inline size-5 text-warning" />
+                        ) : (
+                          <Info
+                            className={cn(
+                              "inline size-5",
+                              tooltipVariant === "destructive"
+                                ? "text-destructive"
+                                : "text-content-subdued",
+                            )}
+                          />
+                        )}
                       </PopoverTrigger>
                       <PopoverContent className="m-1 max-w-64 bg-background-4 text-pretty text-content-muted">
-                        {tooltip}
+                        {warning ? warning : tooltip}
                       </PopoverContent>
                     </Popover>
                   </span>
                   <span className="hidden md:inline-flex">
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <Info
-                          className={cn(
-                            "inline size-4 self-center transition-all duration-200",
-                            tooltipVariant === "warning"
-                              ? "text-destructive"
-                              : "translate-x-2 text-content-subdued opacity-0 group-hover:translate-x-0 group-hover:opacity-100 data-[state=delayed-open]:translate-x-0 data-[state=delayed-open]:opacity-100 data-[state=open]:translate-x-0 data-[state=open]:opacity-100",
-                          )}
-                        />
+                        {warning ? (
+                          <TriangleAlert className="inline size-4 self-center text-warning" />
+                        ) : (
+                          <Info
+                            className={cn(
+                              "inline size-4 self-center transition-all duration-200",
+                              tooltipVariant === "destructive"
+                                ? "text-destructive"
+                                : "translate-x-2 text-content-subdued opacity-0 group-hover:translate-x-0 group-hover:opacity-100 data-[state=delayed-open]:translate-x-0 data-[state=delayed-open]:opacity-100 data-[state=open]:translate-x-0 data-[state=open]:opacity-100",
+                            )}
+                          />
+                        )}
                       </TooltipTrigger>
                       <TooltipContent className="m-1 max-w-80 bg-background-4 text-pretty text-content-muted">
-                        {tooltip}
+                        {warning ? warning : tooltip}
                       </TooltipContent>
                     </Tooltip>
                   </span>

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, KeyboardEvent, useMemo } from "react"
-import { Info } from "lucide-react"
+import { Info, TriangleAlert } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
@@ -62,18 +62,15 @@ export default function MultiSelect({
   className,
 }: MultiSelectProps) {
   const items = value ?? []
-  const hasNoneOption = !!includeNone && requiredOptions.length === 0
+  const hasNoneOption = !!includeNone
   const isNoneSelected = hasNoneOption && value != null && value.length === 0
+  const isWildcardSelected = !!includeWildcard && items.includes("*")
   const [query, setQuery] = useState("")
   const [open, setOpen] = useState(false)
 
   const inputRef = useRef<HTMLInputElement>(null)
   const triggerRef = useRef<HTMLDivElement>(null)
 
-  const requiredSet = useMemo(
-    () => new Set(requiredOptions.map((o) => o.value)),
-    [requiredOptions],
-  )
   const requiredTooltipMap = useMemo(
     () => new Map(requiredOptions.map((o) => [o.value, o.tooltip])),
     [requiredOptions],
@@ -110,8 +107,6 @@ export default function MultiSelect({
       return
     }
 
-    if (requiredSet.has(value)) return
-
     if (includeWildcard && value === "*") {
       emit(items.includes(value) ? null : [value], focus)
       return
@@ -124,7 +119,6 @@ export default function MultiSelect({
   }
 
   const remove = (value: string) => {
-    if (requiredSet.has(value)) return
     toggle(value, open)
   }
 
@@ -160,18 +154,6 @@ export default function MultiSelect({
           )}
         >
           <div className="flex min-h-9 w-full flex-wrap items-center gap-x-2 gap-y-2 p-2 text-sm">
-            {requiredOptions.map(({ label, value, tooltip }) => (
-              <Tooltip key={value}>
-                <TooltipTrigger asChild>
-                  <Badge className="h-5 cursor-default text-content-subdued">
-                    {label}
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent className="text-conent-muted max-w-64 bg-background-5 text-pretty">
-                  {tooltip}
-                </TooltipContent>
-              </Tooltip>
-            ))}
             {isNoneSelected && (
               <Badge
                 className="h-5 cursor-pointer text-content-muted"
@@ -183,12 +165,15 @@ export default function MultiSelect({
                 None <span className="ml-1">&times;</span>
               </Badge>
             )}
-            {items
-              .filter((v) => !requiredSet.has(v))
-              .map((value) => (
+            {items.map((value) => {
+              const tooltip = requiredTooltipMap.get(value)
+              const badge = (
                 <Badge
                   key={value}
-                  className="h-5 cursor-pointer text-content-muted"
+                  className={cn(
+                    "h-5 cursor-pointer text-content-muted",
+                    tooltip != null && "hover:bg-warning/20 hover:text-warning",
+                  )}
                   onClick={(e) => {
                     e.stopPropagation()
                     remove(value)
@@ -197,18 +182,30 @@ export default function MultiSelect({
                   {labelMap.get(value) ?? value}{" "}
                   <span className="ml-1">&times;</span>
                 </Badge>
-              ))}
+              )
+
+              if (tooltip == null) return badge
+
+              return (
+                <Tooltip key={value}>
+                  <TooltipTrigger asChild>{badge}</TooltipTrigger>
+                  <TooltipContent
+                    side="top"
+                    sideOffset={4}
+                    className="pointer-events-none max-w-56 bg-background-5 text-pretty text-content-muted"
+                  >
+                    {tooltip}
+                  </TooltipContent>
+                </Tooltip>
+              )
+            })}
 
             <Input
               ref={inputRef}
               value={query}
               disabled={disabled}
               autoFocus={autoFocus}
-              placeholder={
-                items.length || isNoneSelected || requiredOptions.length
-                  ? ""
-                  : placeholder
-              }
+              placeholder={items.length || isNoneSelected ? "" : placeholder}
               fieldSize="sm"
               className="h-5 flex-1 border-none"
               onChange={(e) => {
@@ -265,24 +262,24 @@ export default function MultiSelect({
                 </CommandItem>
               )}
               {visibleOptions.map(({ label, value }) => {
-                const isRequired = requiredSet.has(value)
+                const tooltip = requiredTooltipMap.get(value)
+                const isCovered =
+                  items.includes(value) || (isWildcardSelected && value !== "*")
+                const showWarning = tooltip != null && !isCovered
 
                 return (
                   <CommandItem
                     key={value}
                     tabIndex={-1}
                     onSelect={() => toggle(value)}
-                    className={cn(
-                      isRequired ? "cursor-default" : "cursor-pointer",
-                    )}
+                    className="cursor-pointer"
                   >
                     <Checkbox
-                      checked={isRequired || items.includes(value)}
-                      disabled={isRequired}
+                      checked={items.includes(value)}
                       className="pointer-events-none mr-2"
                     />
                     {label}
-                    {isRequired && (
+                    {tooltip != null && (
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <span
@@ -290,7 +287,11 @@ export default function MultiSelect({
                             onClick={(e) => e.stopPropagation()}
                             onPointerDown={(e) => e.stopPropagation()}
                           >
-                            <Info className="size-3.5 text-muted-foreground" />
+                            {showWarning ? (
+                              <TriangleAlert className="size-3.5 text-warning" />
+                            ) : (
+                              <Info className="size-3.5 text-muted-foreground" />
+                            )}
                           </span>
                         </TooltipTrigger>
                         <TooltipContent
@@ -298,7 +299,7 @@ export default function MultiSelect({
                           sideOffset={8}
                           className="pointer-events-none max-w-56 bg-background-5 text-pretty text-content-muted"
                         >
-                          {requiredTooltipMap.get(value)}
+                          {tooltip}
                         </TooltipContent>
                       </Tooltip>
                     )}

--- a/src/components/sidebar/panel.tsx
+++ b/src/components/sidebar/panel.tsx
@@ -236,7 +236,7 @@ const VIEWS: View[] = [
         to: "/$accountId/app/team",
         label: "Team",
         params: { accountId: keygen.config.id },
-        requires: ["admin.read", "user.read"],
+        requires: ["user.read"],
       },
       {
         to: "/$accountId/app/permissions",
@@ -277,10 +277,10 @@ function useActiveView(): View {
 }
 
 function useVisibleViews(): View[] {
-  const { canAny } = usePermissions()
+  const { canAll } = usePermissions()
 
   const isRouteVisible = (route: ViewRoute): boolean =>
-    route.requires == null || canAny(route.requires)
+    route.requires == null || canAll(route.requires)
 
   const filtered = VIEWS.map((view) => ({
     ...view,

--- a/src/components/sidebar/panel.tsx
+++ b/src/components/sidebar/panel.tsx
@@ -56,7 +56,11 @@ import * as keygen from "@/keygen"
 import { useCloud } from "@/hooks/use-cloud"
 import { useMobile } from "@/hooks/use-mobile"
 import { useAppVersion } from "@/hooks/use-app-version"
+import { usePermissions } from "@/hooks/use-permissions"
+
 import { useLogout } from "@/queries/auth"
+
+import type { Permission } from "@/types/users"
 
 import Command from "./command"
 import Combobox from "./combobox"
@@ -77,6 +81,7 @@ type ViewRoute = {
   to: string
   label: string
   params: Record<string, unknown>
+  requires?: readonly Permission[]
 }
 
 type View = {
@@ -108,46 +113,55 @@ const VIEWS: View[] = [
         to: "/$accountId/app/products",
         label: "Products",
         params: { accountId: keygen.config.id },
+        requires: ["product.read"],
       },
       {
         to: "/$accountId/app/entitlements",
         label: "Entitlements",
         params: { accountId: keygen.config.id },
+        requires: ["entitlement.read"],
       },
       {
         to: "/$accountId/app/groups",
         label: "Groups",
         params: { accountId: keygen.config.id },
+        requires: ["group.read"],
       },
       {
         to: "/$accountId/app/policies",
         label: "Policies",
         params: { accountId: keygen.config.id },
+        requires: ["policy.read"],
       },
       {
         to: "/$accountId/app/licenses",
         label: "Licenses",
         params: { accountId: keygen.config.id },
+        requires: ["license.read"],
       },
       {
         to: "/$accountId/app/machines",
         label: "Machines",
         params: { accountId: keygen.config.id },
+        requires: ["machine.read"],
       },
       {
         to: "/$accountId/app/components",
         label: "Components",
         params: { accountId: keygen.config.id },
+        requires: ["component.read"],
       },
       {
         to: "/$accountId/app/processes",
         label: "Processes",
         params: { accountId: keygen.config.id },
+        requires: ["process.read"],
       },
       {
         to: "/$accountId/app/users",
         label: "Users",
         params: { accountId: keygen.config.id },
+        requires: ["user.read"],
       },
     ]),
   },
@@ -160,36 +174,43 @@ const VIEWS: View[] = [
         to: "/$accountId/app/packages",
         label: "Packages",
         params: { accountId: keygen.config.id },
+        requires: ["package.read"],
       },
       {
         to: "/$accountId/app/releases",
         label: "Releases",
         params: { accountId: keygen.config.id },
+        requires: ["release.read"],
       },
       {
         to: "/$accountId/app/artifacts",
         label: "Artifacts",
         params: { accountId: keygen.config.id },
+        requires: ["artifact.read"],
       },
       {
         to: "/$accountId/app/platforms",
         label: "Platforms",
         params: { accountId: keygen.config.id },
+        requires: ["platform.read"],
       },
       {
         to: "/$accountId/app/arches",
         label: "Architectures",
         params: { accountId: keygen.config.id },
+        requires: ["arch.read"],
       },
       {
         to: "/$accountId/app/channels",
         label: "Channels",
         params: { accountId: keygen.config.id },
+        requires: ["channel.read"],
       },
       {
         to: "/$accountId/app/engines",
         label: "Engines",
         params: { accountId: keygen.config.id },
+        requires: ["engine.read"],
       },
     ]),
   },
@@ -215,21 +236,25 @@ const VIEWS: View[] = [
         to: "/$accountId/app/team",
         label: "Team",
         params: { accountId: keygen.config.id },
+        requires: ["admin.read", "user.read"],
       },
       {
         to: "/$accountId/app/permissions",
         label: "Permissions",
         params: { accountId: keygen.config.id },
+        requires: ["account.update"],
       },
       {
         to: "/$accountId/app/developers",
         label: "Developers",
         params: { accountId: keygen.config.id },
+        requires: ["token.read"],
       },
       {
         to: "/$accountId/app/billing",
         label: "Billing",
         params: { accountId: keygen.config.id },
+        requires: ["account.billing.read"],
       },
     ]),
   },
@@ -251,8 +276,29 @@ function useActiveView(): View {
   return VIEWS.find((view) => view.id === ViewId.Home)!
 }
 
+function useVisibleViews(): View[] {
+  const { canAny } = usePermissions()
+
+  const isRouteVisible = (route: ViewRoute): boolean =>
+    route.requires == null || canAny(route.requires)
+
+  const filtered = VIEWS.map((view) => ({
+    ...view,
+    routes: view.routes.filter(isRouteVisible),
+  }))
+
+  return filtered.filter((view) => {
+    if (view.id === ViewId.Home) return true
+    const original = VIEWS.find((v) => v.id === view.id)!
+    if (original.routes.length === 0) return true
+    return view.routes.length > 0
+  })
+}
+
 export default function SidebarPanel(): React.ReactElement {
   const activeView = useActiveView()
+  const visibleViews = useVisibleViews()
+  const { can } = usePermissions()
   const [selectedView, setSelectedView] = useState(activeView)
   const { open, setOpen } = useSidebar()
 
@@ -262,9 +308,14 @@ export default function SidebarPanel(): React.ReactElement {
 
   const logout = useLogout()
 
+  const currentView =
+    visibleViews.find((v) => v.id === selectedView.id) ?? visibleViews[0]
+
   const visibleRoutes = isCloud
-    ? selectedView.routes
-    : selectedView.routes.filter((r) => r.to !== "/$accountId/app/billing")
+    ? (currentView?.routes ?? [])
+    : (currentView?.routes ?? []).filter(
+        (r) => r.to !== "/$accountId/app/billing",
+      )
 
   return (
     <div className={cn("flex h-full", isMobile && "absolute z-50")}>
@@ -301,14 +352,14 @@ export default function SidebarPanel(): React.ReactElement {
           )}
         >
           <RailGroup className="flex flex-col items-center">
-            {VIEWS.map((view) => (
+            {visibleViews.map((view) => (
               <Tooltip key={view.id} delayDuration={300}>
                 <TooltipTrigger asChild>
                   <Button
                     variant="rail"
                     size="rail"
                     className={cn(
-                      selectedView.id === view.id && "bg-background-3",
+                      currentView?.id === view.id && "bg-background-3",
                     )}
                     onClick={() => {
                       setSelectedView(view)
@@ -318,7 +369,7 @@ export default function SidebarPanel(): React.ReactElement {
                     <view.icon
                       className={cn(
                         "size-6 md:size-5",
-                        selectedView.id === view.id
+                        currentView?.id === view.id
                           ? "text-content-loud"
                           : "group-hover:text-primary",
                       )}
@@ -349,7 +400,7 @@ export default function SidebarPanel(): React.ReactElement {
               <DropdownMenuLabel>My Account</DropdownMenuLabel>
               <DropdownMenuSeparator />
               <DropdownMenuGroup>
-                {isCloud && (
+                {isCloud && can("account.billing.read") && (
                   <DropdownMenuItem asChild>
                     <Link
                       to="/$accountId/app/billing"
@@ -441,16 +492,16 @@ export default function SidebarPanel(): React.ReactElement {
                 )}
               </Button>
             </div>
-            <Command routes={VIEWS.flatMap((v) => v.routes)} />
+            <Command routes={visibleViews.flatMap((v) => v.routes)} />
           </SidebarGroup>
         </SidebarHeader>
 
         <SidebarContent className="overflow-hidden">
           <SidebarGroup>
             <SidebarMenu>
-              {selectedView && (
+              {currentView && (
                 <>
-                  <SidebarGroupLabel>{selectedView.label}</SidebarGroupLabel>
+                  <SidebarGroupLabel>{currentView.label}</SidebarGroupLabel>
                   {visibleRoutes.map((route) => (
                     <SidebarMenuItem key={route.to}>
                       <SidebarMenuButton asChild>

--- a/src/components/sidebar/panel.tsx
+++ b/src/components/sidebar/panel.tsx
@@ -236,7 +236,7 @@ const VIEWS: View[] = [
         to: "/$accountId/app/team",
         label: "Team",
         params: { accountId: keygen.config.id },
-        requires: ["user.read"],
+        requires: ["admin.read", "user.read"],
       },
       {
         to: "/$accountId/app/permissions",

--- a/src/components/users/form/edit.tsx
+++ b/src/components/users/form/edit.tsx
@@ -1,12 +1,12 @@
 import { useCallback } from "react"
-import { useForm } from "react-hook-form"
+import { useForm, useWatch } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useParams } from "@tanstack/react-router"
 
 import { Separator } from "@/components/ui/separator"
 
 import * as Schemas from "@/schemas"
-import { UserRole } from "@/types/users"
+import { UserRole, InternalRoles } from "@/types/users"
 
 import { useGetUser, useUpdateUser, useChangeUserGroup } from "@/queries/users"
 
@@ -48,6 +48,9 @@ export default function EditUserForm({
     },
   })
 
+  const role = useWatch({ control: form.control, name: "role" })
+  const isInternal = role != null && InternalRoles.includes(role)
+
   const handleSubmit = useCallback(
     async (values: Schemas.Users.UpdateValues) => {
       const currentGroupId = user?.relationships.group?.data?.id ?? null
@@ -88,7 +91,11 @@ export default function EditUserForm({
             <Forms.Section.Column>
               <Users.Form.Fields
                 schema="edit"
-                include={["password", "permissions", "role"]}
+                include={[
+                  "password",
+                  isInternal ? "internalPermissions" : "permissions",
+                  "role",
+                ]}
                 fieldVariant="stacking"
               />
             </Forms.Section.Column>

--- a/src/components/users/form/fields.tsx
+++ b/src/components/users/form/fields.tsx
@@ -23,13 +23,13 @@ import { useListGroups } from "@/queries/groups"
 import { ProductPermissions } from "@/types/products"
 import {
   UserRole,
+  Permissions,
   ExternalRoles,
   InternalRoles,
   UserRoleLabels,
-  AdminPermissions,
   UserRoleDescriptions,
-  UserFormFieldDescriptions,
   PortalRequiredPermissions,
+  UserFormFieldDescriptions,
   UserEditFormFieldDescriptions,
   UserCreateFormFieldDescriptions,
   UserPasswordFormFieldDescriptions,
@@ -597,7 +597,7 @@ function InternalPermissionsField({
             <MultiSelect
               value={field.value}
               onChange={field.onChange}
-              options={AdminPermissions.map((p) => ({
+              options={Permissions.map((p) => ({
                 label: p,
                 value: p,
               }))}

--- a/src/components/users/form/fields.tsx
+++ b/src/components/users/form/fields.tsx
@@ -293,7 +293,7 @@ function PasswordField({
             variant={fieldVariant}
             optional
             tooltip={descriptions.password}
-            tooltipVariant="warning"
+            tooltipVariant="destructive"
           >
             <FormControl>
               <Input
@@ -587,29 +587,51 @@ function InternalPermissionsField({
     <FormField
       control={form.control}
       name="permissions"
-      render={({ field }) => (
-        <FormItem>
-          <Forms.Field.Header
-            label="Permissions"
-            variant={fieldVariant}
-            tooltip={descriptions.permissions}
-          >
-            <MultiSelect
-              value={field.value}
-              onChange={field.onChange}
-              options={Permissions.map((p) => ({
-                label: p,
-                value: p,
-              }))}
-              includeNone
-              includeWildcard
-              requiredOptions={PORTAL_REQUIRED_OPTIONS}
-              autoFocus={autoFocus}
-            />
-          </Forms.Field.Header>
-          <FormMessage />
-        </FormItem>
-      )}
+      render={({ field }) => {
+        const selected = field.value ?? []
+        const isWildcardSelected = selected.includes("*")
+        const missingPortalPermissions = isWildcardSelected
+          ? []
+          : PortalRequiredPermissions.filter((p) => !selected.includes(p))
+
+        return (
+          <FormItem>
+            <Forms.Field.Header
+              label="Permissions"
+              variant={fieldVariant}
+              tooltip={descriptions.permissions}
+              warning={
+                missingPortalPermissions.length > 0 ? (
+                  <>
+                    <div>
+                      Missing some permissions required for Portal access:
+                    </div>
+                    <ul className="mt-1 list-disc pl-4">
+                      {missingPortalPermissions.map((p) => (
+                        <li key={p}>{p}</li>
+                      ))}
+                    </ul>
+                  </>
+                ) : undefined
+              }
+            >
+              <MultiSelect
+                value={field.value}
+                onChange={field.onChange}
+                options={Permissions.map((p) => ({
+                  label: p,
+                  value: p,
+                }))}
+                includeNone
+                includeWildcard
+                requiredOptions={PORTAL_REQUIRED_OPTIONS}
+                autoFocus={autoFocus}
+              />
+            </Forms.Field.Header>
+            <FormMessage />
+          </FormItem>
+        )
+      }}
     />
   )
 }

--- a/src/contexts/permissions-context.tsx
+++ b/src/contexts/permissions-context.tsx
@@ -1,0 +1,19 @@
+import { createContext } from "react"
+
+import type { Permission } from "@/types/users"
+
+export interface PermissionsContextValue {
+  permissions: ReadonlySet<Permission>
+  isLoading: boolean
+  can: (permission: Permission) => boolean
+  canAny: (permissions: readonly Permission[]) => boolean
+  canAll: (permissions: readonly Permission[]) => boolean
+}
+
+export const PermissionsContext = createContext<PermissionsContextValue>({
+  permissions: new Set(),
+  isLoading: true,
+  can: () => false,
+  canAny: () => false,
+  canAll: () => false,
+})

--- a/src/hooks/use-permissions.ts
+++ b/src/hooks/use-permissions.ts
@@ -1,0 +1,7 @@
+import { useContext } from "react"
+
+import { PermissionsContext } from "@/contexts/permissions-context"
+
+export function usePermissions() {
+  return useContext(PermissionsContext)
+}

--- a/src/layouts/app-layout.tsx
+++ b/src/layouts/app-layout.tsx
@@ -7,6 +7,7 @@ import { useSidebar, SidebarProvider } from "@/components/ui/sidebar"
 import { useMobile } from "@/hooks/use-mobile"
 import { useSession } from "@/hooks/use-session"
 import { EnvironmentProvider } from "@/providers/environment-provider"
+import { PermissionsProvider } from "@/providers/permissions-provider"
 
 import { cn } from "@/lib/utils"
 
@@ -36,15 +37,17 @@ export default function AppLayout() {
 
   return (
     <EnvironmentProvider>
-      <TooltipProvider
-        delayDuration={120}
-        skipDelayDuration={400}
-        disableHoverableContent
-      >
-        <SidebarProvider>
-          <AppLayoutContent />
-        </SidebarProvider>
-      </TooltipProvider>
+      <PermissionsProvider>
+        <TooltipProvider
+          delayDuration={120}
+          skipDelayDuration={400}
+          disableHoverableContent
+        >
+          <SidebarProvider>
+            <AppLayoutContent />
+          </SidebarProvider>
+        </TooltipProvider>
+      </PermissionsProvider>
     </EnvironmentProvider>
   )
 }

--- a/src/layouts/app-layout.tsx
+++ b/src/layouts/app-layout.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react"
 import { Outlet, useNavigate } from "@tanstack/react-router"
 
-import { Toaster } from "@/components/ui/sonner"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { useSidebar, SidebarProvider } from "@/components/ui/sidebar"
 
@@ -65,7 +64,6 @@ function AppLayoutContent() {
       >
         <Outlet />
       </main>
-      <Toaster />
     </div>
   )
 }

--- a/src/layouts/tenant-layout.tsx
+++ b/src/layouts/tenant-layout.tsx
@@ -1,5 +1,7 @@
 import { Outlet } from "@tanstack/react-router"
 
+import { Toaster } from "@/components/ui/sonner"
+
 import { SessionProvider } from "@/providers/session-provider"
 import { useSession } from "@/hooks/use-session"
 
@@ -24,5 +26,10 @@ function TenantLayoutContent() {
     )
   }
 
-  return <Outlet />
+  return (
+    <>
+      <Outlet />
+      <Toaster />
+    </>
+  )
 }

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -2,7 +2,7 @@ import type { QueryClient } from "@tanstack/react-query"
 
 import { currentUserQueryOptions } from "@/queries/users"
 
-import { UserRole, Permissions, Permission } from "@/types/users"
+import { Permissions, Permission } from "@/types/users"
 
 const PERMISSION_SET: ReadonlySet<Permission> = new Set(Permissions)
 
@@ -43,10 +43,4 @@ export async function requireAllPermissions(
   if (!permissions.every((p) => perms.has(p))) {
     throw new Error("Permission denied")
   }
-}
-
-export const PORTAL_DISALLOWED_ROLES: readonly UserRole[] = [UserRole.User]
-
-export function isPortalAllowed(role: UserRole): boolean {
-  return !PORTAL_DISALLOWED_ROLES.includes(role)
 }

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,0 +1,52 @@
+import type { QueryClient } from "@tanstack/react-query"
+
+import { currentUserQueryOptions } from "@/queries/users"
+
+import { UserRole, Permissions, Permission } from "@/types/users"
+
+const PERMISSION_SET: ReadonlySet<Permission> = new Set(Permissions)
+
+export function isPermission(value: string): value is Permission {
+  return PERMISSION_SET.has(value as Permission)
+}
+
+async function effectivePermissions(
+  queryClient: QueryClient,
+): Promise<ReadonlySet<Permission>> {
+  const me = await queryClient.ensureQueryData(currentUserQueryOptions())
+  return new Set((me.attributes.permissions ?? []).filter(isPermission))
+}
+
+export async function requirePermission(
+  queryClient: QueryClient,
+  permission: Permission,
+): Promise<void> {
+  const perms = await effectivePermissions(queryClient)
+  if (!perms.has(permission)) throw new Error("Permission denied")
+}
+
+export async function requireAnyPermission(
+  queryClient: QueryClient,
+  permissions: readonly Permission[],
+): Promise<void> {
+  const perms = await effectivePermissions(queryClient)
+  if (!permissions.some((p) => perms.has(p))) {
+    throw new Error("Permission denied")
+  }
+}
+
+export async function requireAllPermissions(
+  queryClient: QueryClient,
+  permissions: readonly Permission[],
+): Promise<void> {
+  const perms = await effectivePermissions(queryClient)
+  if (!permissions.every((p) => perms.has(p))) {
+    throw new Error("Permission denied")
+  }
+}
+
+export const PORTAL_DISALLOWED_ROLES: readonly UserRole[] = [UserRole.User]
+
+export function isPortalAllowed(role: UserRole): boolean {
+  return !PORTAL_DISALLOWED_ROLES.includes(role)
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,6 +15,7 @@ const queryClient = new QueryClient({
 
 const router = createRouter({
   routeTree,
+  context: { queryClient },
 })
 
 declare module "@tanstack/react-router" {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ const queryClient = new QueryClient({
     queries: {
       staleTime: 1000 * 60 * 5, // don't refetch if data is < 5m old
       refetchOnWindowFocus: false, // disable refetch on refocus
+      retry: false, // disable default retries to prevent cascading failures
     },
   },
 })

--- a/src/pages/app/artifact/details.tsx
+++ b/src/pages/app/artifact/details.tsx
@@ -63,6 +63,7 @@ import { copyToClipboard } from "@/lib/clipboard"
 import * as Artifacts from "@/components/artifacts"
 import * as Property from "@/components/property"
 import * as Attribute from "@/components/attribute"
+import Can from "@/components/can"
 import Metadata from "@/components/metadata"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
@@ -172,25 +173,29 @@ export default function ArtifactDetails() {
                       <DropdownMenuSeparator />
                     </>
                   )}
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("edit", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Edit
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("delete", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Delete
-                </DropdownMenuItem>
+                <Can permission="artifact.update">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("edit", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Edit
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                </Can>
+                <Can permission="artifact.delete">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("delete", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                </Can>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
@@ -206,20 +211,24 @@ export default function ArtifactDetails() {
                     Download
                   </Button>
                 )}
-              <Button
-                variant="outline"
-                disabled={isLoading}
-                onClick={() => toggleOpen("edit", true)}
-              >
-                Edit
-              </Button>
-              <Button
-                variant="outline"
-                disabled={isLoading}
-                onClick={() => toggleOpen("delete", true)}
-              >
-                Delete
-              </Button>
+              <Can permission="artifact.update">
+                <Button
+                  variant="outline"
+                  disabled={isLoading}
+                  onClick={() => toggleOpen("edit", true)}
+                >
+                  Edit
+                </Button>
+              </Can>
+              <Can permission="artifact.delete">
+                <Button
+                  variant="outline"
+                  disabled={isLoading}
+                  onClick={() => toggleOpen("delete", true)}
+                >
+                  Delete
+                </Button>
+              </Can>
             </div>
           )}
         </PageHeader>

--- a/src/pages/app/artifact/list.tsx
+++ b/src/pages/app/artifact/list.tsx
@@ -13,6 +13,7 @@ import { useListArtifacts, type ArtifactFilters } from "@/queries/artifacts"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Artifacts from "@/components/artifacts"
+import Can from "@/components/can"
 import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
@@ -51,13 +52,15 @@ export default function ArtifactsList() {
   return (
     <section className="flex h-screen flex-col">
       <PageHeader title="Artifacts">
-        <Button
-          size="sm"
-          disabled={artifactsLoading}
-          onClick={() => setOpen(true)}
-        >
-          New Artifact
-        </Button>
+        <Can permission="artifact.create">
+          <Button
+            size="sm"
+            disabled={artifactsLoading}
+            onClick={() => setOpen(true)}
+          >
+            New Artifact
+          </Button>
+        </Can>
         <Artifacts.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
 

--- a/src/pages/app/component/details.tsx
+++ b/src/pages/app/component/details.tsx
@@ -57,6 +57,7 @@ import * as keygen from "@/keygen"
 import * as Property from "@/components/property"
 import * as Attribute from "@/components/attribute"
 import * as Components from "@/components/components"
+import Can from "@/components/can"
 import Metadata from "@/components/metadata"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
@@ -170,43 +171,51 @@ export default function ComponentDetails() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent className="mr-4 p-0">
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("edit", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Edit
-                </DropdownMenuItem>
-                <Separator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("delete", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Delete
-                </DropdownMenuItem>
+                <Can permission="component.update">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("edit", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Edit
+                  </DropdownMenuItem>
+                  <Separator />
+                </Can>
+                <Can permission="component.delete">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("delete", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                </Can>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
             <div className="flex items-center space-x-2">
-              <Button
-                variant="outline"
-                disabled={componentLoading}
-                onClick={() => toggleOpen("edit", true)}
-              >
-                Edit
-              </Button>
-              <Button
-                variant="outline"
-                disabled={componentLoading}
-                onClick={() => toggleOpen("delete", true)}
-              >
-                Delete
-              </Button>
+              <Can permission="component.update">
+                <Button
+                  variant="outline"
+                  disabled={componentLoading}
+                  onClick={() => toggleOpen("edit", true)}
+                >
+                  Edit
+                </Button>
+              </Can>
+              <Can permission="component.delete">
+                <Button
+                  variant="outline"
+                  disabled={componentLoading}
+                  onClick={() => toggleOpen("delete", true)}
+                >
+                  Delete
+                </Button>
+              </Can>
             </div>
           )}
         </PageHeader>

--- a/src/pages/app/component/list.tsx
+++ b/src/pages/app/component/list.tsx
@@ -13,6 +13,7 @@ import { useListComponents, type ComponentFilters } from "@/queries/components"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Components from "@/components/components"
+import Can from "@/components/can"
 import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
@@ -51,13 +52,15 @@ export default function ComponentsList() {
   return (
     <section className="flex h-screen flex-col">
       <PageHeader title="Components">
-        <Button
-          size="sm"
-          disabled={componentsLoading}
-          onClick={() => setOpen(true)}
-        >
-          New Component
-        </Button>
+        <Can permission="component.create">
+          <Button
+            size="sm"
+            disabled={componentsLoading}
+            onClick={() => setOpen(true)}
+          >
+            New Component
+          </Button>
+        </Can>
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">

--- a/src/pages/app/entitlement/details.tsx
+++ b/src/pages/app/entitlement/details.tsx
@@ -47,6 +47,7 @@ import { copyToClipboard } from "@/lib/clipboard"
 import * as Property from "@/components/property"
 import * as Attribute from "@/components/attribute"
 import * as Entitlements from "@/components/entitlements"
+import Can from "@/components/can"
 import Metadata from "@/components/metadata"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
@@ -138,43 +139,51 @@ export default function EntitlementDetails() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent className="mr-4 p-0">
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("edit", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Edit
-                </DropdownMenuItem>
-                <Separator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("delete", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Delete
-                </DropdownMenuItem>
+                <Can permission="entitlement.update">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("edit", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Edit
+                  </DropdownMenuItem>
+                  <Separator />
+                </Can>
+                <Can permission="entitlement.delete">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("delete", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                </Can>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
             <div className="flex items-center space-x-2">
-              <Button
-                variant="outline"
-                disabled={entitlementLoading}
-                onClick={() => toggleOpen("edit", true)}
-              >
-                Edit
-              </Button>
-              <Button
-                variant="outline"
-                disabled={entitlementLoading}
-                onClick={() => toggleOpen("delete", true)}
-              >
-                Delete
-              </Button>
+              <Can permission="entitlement.update">
+                <Button
+                  variant="outline"
+                  disabled={entitlementLoading}
+                  onClick={() => toggleOpen("edit", true)}
+                >
+                  Edit
+                </Button>
+              </Can>
+              <Can permission="entitlement.delete">
+                <Button
+                  variant="outline"
+                  disabled={entitlementLoading}
+                  onClick={() => toggleOpen("delete", true)}
+                >
+                  Delete
+                </Button>
+              </Can>
             </div>
           )}
         </PageHeader>

--- a/src/pages/app/entitlement/list.tsx
+++ b/src/pages/app/entitlement/list.tsx
@@ -12,6 +12,7 @@ import { useListEntitlements } from "@/queries/entitlements"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Entitlements from "@/components/entitlements"
+import Can from "@/components/can"
 import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
@@ -39,13 +40,15 @@ export default function EntitlementsList() {
   return (
     <section className="flex h-screen flex-col">
       <PageHeader title="Entitlements">
-        <Button
-          size="sm"
-          disabled={entitlementsLoading}
-          onClick={() => setOpen(true)}
-        >
-          New Entitlement
-        </Button>
+        <Can permission="entitlement.create">
+          <Button
+            size="sm"
+            disabled={entitlementsLoading}
+            onClick={() => setOpen(true)}
+          >
+            New Entitlement
+          </Button>
+        </Can>
         <Entitlements.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
 

--- a/src/pages/app/group/details.tsx
+++ b/src/pages/app/group/details.tsx
@@ -52,6 +52,7 @@ import * as keygen from "@/keygen"
 import * as Groups from "@/components/groups"
 import * as Property from "@/components/property"
 import * as Attribute from "@/components/attribute"
+import Can from "@/components/can"
 import Metadata from "@/components/metadata"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
@@ -142,43 +143,51 @@ export default function GroupDetails() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent className="mr-4 p-0">
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("edit", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Edit
-                </DropdownMenuItem>
-                <Separator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("delete", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Delete
-                </DropdownMenuItem>
+                <Can permission="group.update">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("edit", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Edit
+                  </DropdownMenuItem>
+                  <Separator />
+                </Can>
+                <Can permission="group.delete">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("delete", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                </Can>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
             <div className="flex items-center space-x-2">
-              <Button
-                variant="outline"
-                disabled={groupLoading}
-                onClick={() => toggleOpen("edit", true)}
-              >
-                Edit
-              </Button>
-              <Button
-                variant="outline"
-                disabled={groupLoading}
-                onClick={() => toggleOpen("delete", true)}
-              >
-                Delete
-              </Button>
+              <Can permission="group.update">
+                <Button
+                  variant="outline"
+                  disabled={groupLoading}
+                  onClick={() => toggleOpen("edit", true)}
+                >
+                  Edit
+                </Button>
+              </Can>
+              <Can permission="group.delete">
+                <Button
+                  variant="outline"
+                  disabled={groupLoading}
+                  onClick={() => toggleOpen("delete", true)}
+                >
+                  Delete
+                </Button>
+              </Can>
             </div>
           )}
         </PageHeader>

--- a/src/pages/app/group/list.tsx
+++ b/src/pages/app/group/list.tsx
@@ -12,6 +12,7 @@ import { useListGroups } from "@/queries/groups"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Groups from "@/components/groups"
+import Can from "@/components/can"
 import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
@@ -39,13 +40,15 @@ export default function GroupsList() {
   return (
     <section className="flex h-screen flex-col">
       <PageHeader title="Groups">
-        <Button
-          size="sm"
-          disabled={groupsLoading}
-          onClick={() => setOpen(true)}
-        >
-          New Group
-        </Button>
+        <Can permission="group.create">
+          <Button
+            size="sm"
+            disabled={groupsLoading}
+            onClick={() => setOpen(true)}
+          >
+            New Group
+          </Button>
+        </Can>
         <Groups.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
 

--- a/src/pages/app/license/details.tsx
+++ b/src/pages/app/license/details.tsx
@@ -95,6 +95,7 @@ import * as keygen from "@/keygen"
 import * as Property from "@/components/property"
 import * as Licenses from "@/components/licenses"
 import * as Attribute from "@/components/attribute"
+import Can from "@/components/can"
 import Metadata from "@/components/metadata"
 import TooltipBadge from "@/components/tooltip-badge"
 import PageHeader from "@/components/page-header"
@@ -291,48 +292,62 @@ export default function LicenseDetails() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent className="mr-4 p-0">
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("edit", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
+                <Can permission="license.update">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("edit", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Edit
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                </Can>
+                <Can permission="license.delete">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("delete", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base text-destructive"
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                </Can>
+                <Can permission="license.renew">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("renew", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Renew
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                </Can>
+                <Can
+                  permission={
+                    license?.attributes.suspended
+                      ? "license.reinstate"
+                      : "license.suspend"
+                  }
                 >
-                  Edit
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("delete", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base text-destructive"
-                >
-                  Delete
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("renew", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Renew
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("suspend", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  {license?.attributes.suspended ? "Reinstate" : "Suspend"}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("suspend", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    {license?.attributes.suspended ? "Reinstate" : "Suspend"}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                </Can>
                 {license?.attributes.requireCheckIn && (
-                  <>
+                  <Can permission="license.check-in">
                     <DropdownMenuItem
                       onClick={(e) => {
                         toggleOpen("checkIn", true)
@@ -343,27 +358,31 @@ export default function LicenseDetails() {
                       Check-in
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
-                  </>
+                  </Can>
                 )}
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("checkOut", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Checkout
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("resetUsage", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Reset usage
-                </DropdownMenuItem>
+                <Can permission="license.check-out">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("checkOut", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Checkout
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                </Can>
+                <Can permission="license.usage.reset">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("resetUsage", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Reset usage
+                  </DropdownMenuItem>
+                </Can>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
@@ -376,26 +395,36 @@ export default function LicenseDetails() {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("renew", true)
-                      e.currentTarget.blur()
-                    }}
+                  <Can permission="license.renew">
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        toggleOpen("renew", true)
+                        e.currentTarget.blur()
+                      }}
+                    >
+                      Renew
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                  </Can>
+                  <Can
+                    permission={
+                      license?.attributes.suspended
+                        ? "license.reinstate"
+                        : "license.suspend"
+                    }
                   >
-                    Renew
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("suspend", true)
-                      e.currentTarget.blur()
-                    }}
-                  >
-                    {license?.attributes.suspended ? "Reinstate" : "Suspend"}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        toggleOpen("suspend", true)
+                        e.currentTarget.blur()
+                      }}
+                    >
+                      {license?.attributes.suspended ? "Reinstate" : "Suspend"}
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                  </Can>
                   {license?.attributes.requireCheckIn && (
-                    <>
+                    <Can permission="license.check-in">
                       <DropdownMenuItem
                         onClick={(e) => {
                           toggleOpen("checkIn", true)
@@ -405,41 +434,49 @@ export default function LicenseDetails() {
                         Check-in
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
-                    </>
+                    </Can>
                   )}
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("checkOut", true)
-                      e.currentTarget.blur()
-                    }}
-                  >
-                    Checkout
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("resetUsage", true)
-                      e.currentTarget.blur()
-                    }}
-                  >
-                    Reset usage
-                  </DropdownMenuItem>
+                  <Can permission="license.check-out">
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        toggleOpen("checkOut", true)
+                        e.currentTarget.blur()
+                      }}
+                    >
+                      Checkout
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                  </Can>
+                  <Can permission="license.usage.reset">
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        toggleOpen("resetUsage", true)
+                        e.currentTarget.blur()
+                      }}
+                    >
+                      Reset usage
+                    </DropdownMenuItem>
+                  </Can>
                 </DropdownMenuContent>
               </DropdownMenu>
-              <Button
-                variant="outline"
-                disabled={licenseLoading}
-                onClick={() => toggleOpen("edit", true)}
-              >
-                Edit
-              </Button>
-              <Button
-                variant="outline"
-                disabled={licenseLoading}
-                onClick={() => toggleOpen("delete", true)}
-              >
-                Delete
-              </Button>
+              <Can permission="license.update">
+                <Button
+                  variant="outline"
+                  disabled={licenseLoading}
+                  onClick={() => toggleOpen("edit", true)}
+                >
+                  Edit
+                </Button>
+              </Can>
+              <Can permission="license.delete">
+                <Button
+                  variant="outline"
+                  disabled={licenseLoading}
+                  onClick={() => toggleOpen("delete", true)}
+                >
+                  Delete
+                </Button>
+              </Can>
             </div>
           )}
         </PageHeader>

--- a/src/pages/app/license/details.tsx
+++ b/src/pages/app/license/details.tsx
@@ -281,126 +281,60 @@ export default function LicenseDetails() {
           </Breadcrumb>
 
           {isMobile ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  disabled={licenseLoading}
-                  className="text-content-muted"
-                >
-                  <EllipsisVertical className="size-5" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent className="mr-4 p-0">
-                <Can permission="license.update">
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("edit", true)
-                      e.currentTarget.blur()
-                    }}
-                    className="pb-2 text-base"
+            <Can.Any
+              permissions={[
+                "license.update",
+                "license.delete",
+                "license.renew",
+                "license.suspend",
+                "license.reinstate",
+                "license.check-in",
+                "license.check-out",
+                "license.usage.reset",
+              ]}
+            >
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    disabled={licenseLoading}
+                    className="text-content-muted"
                   >
-                    Edit
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                </Can>
-                <Can permission="license.delete">
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("delete", true)
-                      e.currentTarget.blur()
-                    }}
-                    className="pb-2 text-base text-destructive"
-                  >
-                    Delete
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                </Can>
-                <Can permission="license.renew">
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("renew", true)
-                      e.currentTarget.blur()
-                    }}
-                    className="pb-2 text-base"
-                  >
-                    Renew
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                </Can>
-                <Can
-                  permission={
-                    license?.attributes.suspended
-                      ? "license.reinstate"
-                      : "license.suspend"
-                  }
-                >
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("suspend", true)
-                      e.currentTarget.blur()
-                    }}
-                    className="pb-2 text-base"
-                  >
-                    {license?.attributes.suspended ? "Reinstate" : "Suspend"}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                </Can>
-                {license?.attributes.requireCheckIn && (
-                  <Can permission="license.check-in">
+                    <EllipsisVertical className="size-5" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="mr-4 p-0">
+                  <Can permission="license.update">
                     <DropdownMenuItem
                       onClick={(e) => {
-                        toggleOpen("checkIn", true)
+                        toggleOpen("edit", true)
                         e.currentTarget.blur()
                       }}
                       className="pb-2 text-base"
                     >
-                      Check-in
+                      Edit
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
                   </Can>
-                )}
-                <Can permission="license.check-out">
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("checkOut", true)
-                      e.currentTarget.blur()
-                    }}
-                    className="pb-2 text-base"
-                  >
-                    Checkout
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                </Can>
-                <Can permission="license.usage.reset">
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("resetUsage", true)
-                      e.currentTarget.blur()
-                    }}
-                    className="pb-2 text-base"
-                  >
-                    Reset usage
-                  </DropdownMenuItem>
-                </Can>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : (
-            <div className="flex items-center space-x-2">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="outline" disabled={licenseLoading}>
-                    Actions
-                    <ChevronDown className="size-4 transition-transform duration-200 [[data-state=open]_&]:rotate-180" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
+                  <Can permission="license.delete">
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        toggleOpen("delete", true)
+                        e.currentTarget.blur()
+                      }}
+                      className="pb-2 text-base text-destructive"
+                    >
+                      Delete
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                  </Can>
                   <Can permission="license.renew">
                     <DropdownMenuItem
                       onClick={(e) => {
                         toggleOpen("renew", true)
                         e.currentTarget.blur()
                       }}
+                      className="pb-2 text-base"
                     >
                       Renew
                     </DropdownMenuItem>
@@ -418,6 +352,7 @@ export default function LicenseDetails() {
                         toggleOpen("suspend", true)
                         e.currentTarget.blur()
                       }}
+                      className="pb-2 text-base"
                     >
                       {license?.attributes.suspended ? "Reinstate" : "Suspend"}
                     </DropdownMenuItem>
@@ -430,6 +365,7 @@ export default function LicenseDetails() {
                           toggleOpen("checkIn", true)
                           e.currentTarget.blur()
                         }}
+                        className="pb-2 text-base"
                       >
                         Check-in
                       </DropdownMenuItem>
@@ -442,6 +378,7 @@ export default function LicenseDetails() {
                         toggleOpen("checkOut", true)
                         e.currentTarget.blur()
                       }}
+                      className="pb-2 text-base"
                     >
                       Checkout
                     </DropdownMenuItem>
@@ -453,12 +390,101 @@ export default function LicenseDetails() {
                         toggleOpen("resetUsage", true)
                         e.currentTarget.blur()
                       }}
+                      className="pb-2 text-base"
                     >
                       Reset usage
                     </DropdownMenuItem>
                   </Can>
                 </DropdownMenuContent>
               </DropdownMenu>
+            </Can.Any>
+          ) : (
+            <div className="flex items-center space-x-2">
+              <Can.Any
+                permissions={[
+                  "license.renew",
+                  "license.suspend",
+                  "license.reinstate",
+                  "license.check-in",
+                  "license.check-out",
+                  "license.usage.reset",
+                ]}
+              >
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="outline" disabled={licenseLoading}>
+                      Actions
+                      <ChevronDown className="size-4 transition-transform duration-200 [[data-state=open]_&]:rotate-180" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <Can permission="license.renew">
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          toggleOpen("renew", true)
+                          e.currentTarget.blur()
+                        }}
+                      >
+                        Renew
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                    </Can>
+                    <Can
+                      permission={
+                        license?.attributes.suspended
+                          ? "license.reinstate"
+                          : "license.suspend"
+                      }
+                    >
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          toggleOpen("suspend", true)
+                          e.currentTarget.blur()
+                        }}
+                      >
+                        {license?.attributes.suspended
+                          ? "Reinstate"
+                          : "Suspend"}
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                    </Can>
+                    {license?.attributes.requireCheckIn && (
+                      <Can permission="license.check-in">
+                        <DropdownMenuItem
+                          onClick={(e) => {
+                            toggleOpen("checkIn", true)
+                            e.currentTarget.blur()
+                          }}
+                        >
+                          Check-in
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                      </Can>
+                    )}
+                    <Can permission="license.check-out">
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          toggleOpen("checkOut", true)
+                          e.currentTarget.blur()
+                        }}
+                      >
+                        Checkout
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                    </Can>
+                    <Can permission="license.usage.reset">
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          toggleOpen("resetUsage", true)
+                          e.currentTarget.blur()
+                        }}
+                      >
+                        Reset usage
+                      </DropdownMenuItem>
+                    </Can>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </Can.Any>
               <Can permission="license.update">
                 <Button
                   variant="outline"

--- a/src/pages/app/license/list.tsx
+++ b/src/pages/app/license/list.tsx
@@ -12,6 +12,7 @@ import { useListLicenses, type LicenseFilters } from "@/queries/licenses"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Licenses from "@/components/licenses"
+import Can from "@/components/can"
 import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
@@ -51,13 +52,15 @@ export default function LicensesList() {
   return (
     <section className="flex h-screen flex-col">
       <PageHeader title="Licenses">
-        <Button
-          size="sm"
-          disabled={licensesLoading}
-          onClick={() => setOpen(true)}
-        >
-          New License
-        </Button>
+        <Can permission="license.create">
+          <Button
+            size="sm"
+            disabled={licensesLoading}
+            onClick={() => setOpen(true)}
+          >
+            New License
+          </Button>
+        </Can>
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">

--- a/src/pages/app/machine/details.tsx
+++ b/src/pages/app/machine/details.tsx
@@ -64,6 +64,7 @@ import * as keygen from "@/keygen"
 import * as Machines from "@/components/machines"
 import * as Property from "@/components/property"
 import * as Attribute from "@/components/attribute"
+import Can from "@/components/can"
 import Metadata from "@/components/metadata"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
@@ -196,7 +197,7 @@ export default function MachineDetails() {
               </DropdownMenuTrigger>
               <DropdownMenuContent className="mr-4 p-0">
                 {machine?.attributes.requireHeartbeat && (
-                  <>
+                  <Can permission="machine.heartbeat.reset">
                     <DropdownMenuItem
                       onClick={(e) => {
                         toggleOpen("resetHeartbeat", true)
@@ -207,71 +208,85 @@ export default function MachineDetails() {
                       Reset heartbeat
                     </DropdownMenuItem>
                     <Separator />
-                  </>
+                  </Can>
                 )}
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("checkOut", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Checkout
-                </DropdownMenuItem>
-                <Separator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("edit", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Edit
-                </DropdownMenuItem>
-                <Separator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("delete", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Deactivate
-                </DropdownMenuItem>
+                <Can permission="machine.check-out">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("checkOut", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Checkout
+                  </DropdownMenuItem>
+                  <Separator />
+                </Can>
+                <Can permission="machine.update">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("edit", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Edit
+                  </DropdownMenuItem>
+                  <Separator />
+                </Can>
+                <Can permission="machine.delete">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("delete", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Deactivate
+                  </DropdownMenuItem>
+                </Can>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
             <div className="flex items-center space-x-2">
               {machine?.attributes.requireHeartbeat && (
+                <Can permission="machine.heartbeat.reset">
+                  <Button
+                    variant="outline"
+                    disabled={machineLoading}
+                    onClick={() => toggleOpen("resetHeartbeat", true)}
+                  >
+                    Reset heartbeat
+                  </Button>
+                </Can>
+              )}
+              <Can permission="machine.check-out">
                 <Button
                   variant="outline"
                   disabled={machineLoading}
-                  onClick={() => toggleOpen("resetHeartbeat", true)}
+                  onClick={() => toggleOpen("checkOut", true)}
                 >
-                  Reset heartbeat
+                  Checkout
                 </Button>
-              )}
-              <Button
-                variant="outline"
-                disabled={machineLoading}
-                onClick={() => toggleOpen("checkOut", true)}
-              >
-                Checkout
-              </Button>
-              <Button
-                variant="outline"
-                disabled={machineLoading}
-                onClick={() => toggleOpen("edit", true)}
-              >
-                Edit
-              </Button>
-              <Button
-                variant="outline"
-                disabled={machineLoading}
-                onClick={() => toggleOpen("delete", true)}
-              >
-                Deactivate
-              </Button>
+              </Can>
+              <Can permission="machine.update">
+                <Button
+                  variant="outline"
+                  disabled={machineLoading}
+                  onClick={() => toggleOpen("edit", true)}
+                >
+                  Edit
+                </Button>
+              </Can>
+              <Can permission="machine.delete">
+                <Button
+                  variant="outline"
+                  disabled={machineLoading}
+                  onClick={() => toggleOpen("delete", true)}
+                >
+                  Deactivate
+                </Button>
+              </Can>
             </div>
           )}
         </PageHeader>

--- a/src/pages/app/machine/list.tsx
+++ b/src/pages/app/machine/list.tsx
@@ -13,6 +13,7 @@ import { useListMachines, type MachineFilters } from "@/queries/machines"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Machines from "@/components/machines"
+import Can from "@/components/can"
 import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
@@ -51,13 +52,15 @@ export default function MachinesList() {
   return (
     <section className="flex h-screen flex-col">
       <PageHeader title="Machines">
-        <Button
-          size="sm"
-          disabled={machinesLoading}
-          onClick={() => setOpen(true)}
-        >
-          New Machine
-        </Button>
+        <Can permission="machine.create">
+          <Button
+            size="sm"
+            disabled={machinesLoading}
+            onClick={() => setOpen(true)}
+          >
+            New Machine
+          </Button>
+        </Can>
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">

--- a/src/pages/app/package/details.tsx
+++ b/src/pages/app/package/details.tsx
@@ -57,6 +57,7 @@ import { copyToClipboard } from "@/lib/clipboard"
 import * as Packages from "@/components/packages"
 import * as Property from "@/components/property"
 import * as Attribute from "@/components/attribute"
+import Can from "@/components/can"
 import Metadata from "@/components/metadata"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
@@ -145,43 +146,51 @@ export default function PackageDetails() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent className="mr-4 p-0">
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("edit", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Edit
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("delete", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Delete
-                </DropdownMenuItem>
+                <Can permission="package.update">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("edit", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Edit
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                </Can>
+                <Can permission="package.delete">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("delete", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                </Can>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
             <div className="flex items-center space-x-2">
-              <Button
-                variant="outline"
-                disabled={isLoading}
-                onClick={() => toggleOpen("edit", true)}
-              >
-                Edit
-              </Button>
-              <Button
-                variant="outline"
-                disabled={isLoading}
-                onClick={() => toggleOpen("delete", true)}
-              >
-                Delete
-              </Button>
+              <Can permission="package.update">
+                <Button
+                  variant="outline"
+                  disabled={isLoading}
+                  onClick={() => toggleOpen("edit", true)}
+                >
+                  Edit
+                </Button>
+              </Can>
+              <Can permission="package.delete">
+                <Button
+                  variant="outline"
+                  disabled={isLoading}
+                  onClick={() => toggleOpen("delete", true)}
+                >
+                  Delete
+                </Button>
+              </Can>
             </div>
           )}
         </PageHeader>

--- a/src/pages/app/package/list.tsx
+++ b/src/pages/app/package/list.tsx
@@ -13,6 +13,7 @@ import { useListPackages, type PackageFilters } from "@/queries/packages"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Packages from "@/components/packages"
+import Can from "@/components/can"
 import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
@@ -51,13 +52,15 @@ export default function PackagesList() {
   return (
     <section className="flex h-screen flex-col">
       <PageHeader title="Packages">
-        <Button
-          size="sm"
-          disabled={packagesLoading}
-          onClick={() => setOpen(true)}
-        >
-          New Package
-        </Button>
+        <Can permission="package.create">
+          <Button
+            size="sm"
+            disabled={packagesLoading}
+            onClick={() => setOpen(true)}
+          >
+            New Package
+          </Button>
+        </Can>
         <Packages.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
 

--- a/src/pages/app/policy/details.tsx
+++ b/src/pages/app/policy/details.tsx
@@ -74,6 +74,7 @@ import * as keygen from "@/keygen"
 import * as Policies from "@/components/policies"
 import * as Property from "@/components/property"
 import * as Attribute from "@/components/attribute"
+import Can from "@/components/can"
 import Metadata from "@/components/metadata"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
@@ -180,59 +181,71 @@ export default function PolicyDetails() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent className="mr-4 p-0">
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("duplicate", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Duplicate
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("edit", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Edit
-                </DropdownMenuItem>
-                <Separator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("delete", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Delete
-                </DropdownMenuItem>
+                <Can permission="policy.create">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("duplicate", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Duplicate
+                  </DropdownMenuItem>
+                </Can>
+                <Can permission="policy.update">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("edit", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Edit
+                  </DropdownMenuItem>
+                  <Separator />
+                </Can>
+                <Can permission="policy.delete">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("delete", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                </Can>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
             <div className="flex items-center space-x-2">
-              <Button
-                variant="outline"
-                disabled={policyLoading}
-                onClick={() => toggleOpen("duplicate", true)}
-              >
-                Duplicate
-              </Button>
-              <Button
-                variant="outline"
-                disabled={policyLoading}
-                onClick={() => toggleOpen("edit", true)}
-              >
-                Edit
-              </Button>
-              <Button
-                variant="outline"
-                disabled={policyLoading}
-                onClick={() => toggleOpen("delete", true)}
-              >
-                Delete
-              </Button>
+              <Can permission="policy.create">
+                <Button
+                  variant="outline"
+                  disabled={policyLoading}
+                  onClick={() => toggleOpen("duplicate", true)}
+                >
+                  Duplicate
+                </Button>
+              </Can>
+              <Can permission="policy.update">
+                <Button
+                  variant="outline"
+                  disabled={policyLoading}
+                  onClick={() => toggleOpen("edit", true)}
+                >
+                  Edit
+                </Button>
+              </Can>
+              <Can permission="policy.delete">
+                <Button
+                  variant="outline"
+                  disabled={policyLoading}
+                  onClick={() => toggleOpen("delete", true)}
+                >
+                  Delete
+                </Button>
+              </Can>
             </div>
           )}
         </PageHeader>

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -13,6 +13,7 @@ import { useListPolicies, type PolicyFilters } from "@/queries/policies"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Policies from "@/components/policies"
+import Can from "@/components/can"
 import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
@@ -51,13 +52,15 @@ export default function PoliciesList() {
   return (
     <section className="flex h-screen flex-col">
       <PageHeader title="Policies">
-        <Button
-          size="sm"
-          disabled={policiesLoading}
-          onClick={() => setOpen(true)}
-        >
-          New Policy
-        </Button>
+        <Can permission="policy.create">
+          <Button
+            size="sm"
+            disabled={policiesLoading}
+            onClick={() => setOpen(true)}
+          >
+            New Policy
+          </Button>
+        </Can>
 
         <Policies.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>

--- a/src/pages/app/process/details.tsx
+++ b/src/pages/app/process/details.tsx
@@ -66,6 +66,7 @@ import * as keygen from "@/keygen"
 import * as Processes from "@/components/processes"
 import * as Property from "@/components/property"
 import * as Attribute from "@/components/attribute"
+import Can from "@/components/can"
 import Metadata from "@/components/metadata"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
@@ -185,43 +186,51 @@ export default function ProcessDetails() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent className="mr-4 p-0">
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("edit", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Edit
-                </DropdownMenuItem>
-                <Separator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("delete", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Delete
-                </DropdownMenuItem>
+                <Can permission="process.update">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("edit", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Edit
+                  </DropdownMenuItem>
+                  <Separator />
+                </Can>
+                <Can permission="process.delete">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("delete", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                </Can>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
             <div className="flex items-center space-x-2">
-              <Button
-                variant="outline"
-                disabled={processLoading}
-                onClick={() => toggleOpen("edit", true)}
-              >
-                Edit
-              </Button>
-              <Button
-                variant="outline"
-                disabled={processLoading}
-                onClick={() => toggleOpen("delete", true)}
-              >
-                Delete
-              </Button>
+              <Can permission="process.update">
+                <Button
+                  variant="outline"
+                  disabled={processLoading}
+                  onClick={() => toggleOpen("edit", true)}
+                >
+                  Edit
+                </Button>
+              </Can>
+              <Can permission="process.delete">
+                <Button
+                  variant="outline"
+                  disabled={processLoading}
+                  onClick={() => toggleOpen("delete", true)}
+                >
+                  Delete
+                </Button>
+              </Can>
             </div>
           )}
         </PageHeader>

--- a/src/pages/app/process/list.tsx
+++ b/src/pages/app/process/list.tsx
@@ -13,6 +13,7 @@ import { useListProcesses, type ProcessFilters } from "@/queries/processes"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Processes from "@/components/processes"
+import Can from "@/components/can"
 import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
@@ -51,13 +52,15 @@ export default function ProcessesList() {
   return (
     <section className="flex h-screen flex-col">
       <PageHeader title="Processes">
-        <Button
-          size="sm"
-          disabled={processesLoading}
-          onClick={() => setOpen(true)}
-        >
-          Spawn Process
-        </Button>
+        <Can permission="process.create">
+          <Button
+            size="sm"
+            disabled={processesLoading}
+            onClick={() => setOpen(true)}
+          >
+            Spawn Process
+          </Button>
+        </Can>
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">

--- a/src/pages/app/product/details.tsx
+++ b/src/pages/app/product/details.tsx
@@ -52,6 +52,7 @@ import { copyToClipboard } from "@/lib/clipboard"
 import * as Products from "@/components/products"
 import * as Property from "@/components/property"
 import * as Attribute from "@/components/attribute"
+import Can from "@/components/can"
 import Metadata from "@/components/metadata"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
@@ -134,43 +135,51 @@ export default function ProductDetails() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent className="mr-4 p-0">
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("edit", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Edit
-                </DropdownMenuItem>
-                <Separator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("delete", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Delete
-                </DropdownMenuItem>
+                <Can permission="product.update">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("edit", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Edit
+                  </DropdownMenuItem>
+                  <Separator />
+                </Can>
+                <Can permission="product.delete">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("delete", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                </Can>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
             <div className="flex items-center space-x-2">
-              <Button
-                variant="outline"
-                disabled={isLoading}
-                onClick={() => toggleOpen("edit", true)}
-              >
-                Edit
-              </Button>
-              <Button
-                variant="outline"
-                disabled={isLoading}
-                onClick={() => toggleOpen("delete", true)}
-              >
-                Delete
-              </Button>
+              <Can permission="product.update">
+                <Button
+                  variant="outline"
+                  disabled={isLoading}
+                  onClick={() => toggleOpen("edit", true)}
+                >
+                  Edit
+                </Button>
+              </Can>
+              <Can permission="product.delete">
+                <Button
+                  variant="outline"
+                  disabled={isLoading}
+                  onClick={() => toggleOpen("delete", true)}
+                >
+                  Delete
+                </Button>
+              </Can>
             </div>
           )}
         </PageHeader>

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -12,6 +12,7 @@ import { useListProducts } from "@/queries/products"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Products from "@/components/products"
+import Can from "@/components/can"
 import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
@@ -39,13 +40,15 @@ export default function ProductsList() {
   return (
     <section className="flex h-screen flex-col">
       <PageHeader title="Products">
-        <Button
-          size="sm"
-          disabled={productsLoading}
-          onClick={() => setOpen(true)}
-        >
-          New Product
-        </Button>
+        <Can permission="product.create">
+          <Button
+            size="sm"
+            disabled={productsLoading}
+            onClick={() => setOpen(true)}
+          >
+            New Product
+          </Button>
+        </Can>
         <Products.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
 

--- a/src/pages/app/release/details.tsx
+++ b/src/pages/app/release/details.tsx
@@ -5,6 +5,7 @@ import { formatDate } from "date-fns"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Separator } from "@/components/ui/separator"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Tabs, TabsContent } from "@/components/ui/tabs"
 import {
@@ -84,6 +85,7 @@ import { copyToClipboard } from "@/lib/clipboard"
 import * as Releases from "@/components/releases"
 import * as Property from "@/components/property"
 import * as Attribute from "@/components/attribute"
+import Can from "@/components/can"
 import Metadata from "@/components/metadata"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
@@ -91,7 +93,6 @@ import BackButton from "@/components/back-button"
 import GoToButton from "@/components/go-to-button"
 import TooltipBadge from "@/components/tooltip-badge"
 import CollapsibleCard from "@/components/collapsible-card"
-import { Separator } from "@/components/ui/separator"
 import ConfirmationModal from "@/components/confirmation-modal"
 
 const ReleaseChannelIcons: Record<ReleaseChannel, React.ReactNode> = {
@@ -279,7 +280,7 @@ export default function ReleaseDetails() {
               </DropdownMenuTrigger>
               <DropdownMenuContent className="mr-4 p-0">
                 {release?.attributes.status === ReleaseStatus.Draft && (
-                  <>
+                  <Can permission="release.publish">
                     <DropdownMenuItem
                       onClick={(e) => {
                         toggleOpen("publish", true)
@@ -290,10 +291,10 @@ export default function ReleaseDetails() {
                       Publish
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
-                  </>
+                  </Can>
                 )}
                 {release?.attributes.status === ReleaseStatus.Published && (
-                  <>
+                  <Can permission="release.yank">
                     <DropdownMenuItem
                       onClick={(e) => {
                         toggleOpen("yank", true)
@@ -304,63 +305,75 @@ export default function ReleaseDetails() {
                       Yank
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
-                  </>
+                  </Can>
                 )}
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("edit", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Edit
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("delete", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Delete
-                </DropdownMenuItem>
+                <Can permission="release.update">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("edit", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Edit
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                </Can>
+                <Can permission="release.delete">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("delete", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                </Can>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
             <div className="flex items-center space-x-2">
               {release?.attributes.status === ReleaseStatus.Draft && (
-                <Button
-                  variant="outline"
-                  disabled={isLoading}
-                  onClick={() => toggleOpen("publish", true)}
-                >
-                  Publish
-                </Button>
+                <Can permission="release.publish">
+                  <Button
+                    variant="outline"
+                    disabled={isLoading}
+                    onClick={() => toggleOpen("publish", true)}
+                  >
+                    Publish
+                  </Button>
+                </Can>
               )}
               {release?.attributes.status === ReleaseStatus.Published && (
+                <Can permission="release.yank">
+                  <Button
+                    variant="outline"
+                    disabled={isLoading}
+                    onClick={() => toggleOpen("yank", true)}
+                  >
+                    Yank
+                  </Button>
+                </Can>
+              )}
+              <Can permission="release.update">
                 <Button
                   variant="outline"
                   disabled={isLoading}
-                  onClick={() => toggleOpen("yank", true)}
+                  onClick={() => toggleOpen("edit", true)}
                 >
-                  Yank
+                  Edit
                 </Button>
-              )}
-              <Button
-                variant="outline"
-                disabled={isLoading}
-                onClick={() => toggleOpen("edit", true)}
-              >
-                Edit
-              </Button>
-              <Button
-                variant="outline"
-                disabled={isLoading}
-                onClick={() => toggleOpen("delete", true)}
-              >
-                Delete
-              </Button>
+              </Can>
+              <Can permission="release.delete">
+                <Button
+                  variant="outline"
+                  disabled={isLoading}
+                  onClick={() => toggleOpen("delete", true)}
+                >
+                  Delete
+                </Button>
+              </Can>
             </div>
           )}
         </PageHeader>

--- a/src/pages/app/release/list.tsx
+++ b/src/pages/app/release/list.tsx
@@ -13,6 +13,7 @@ import { useListReleases, type ReleaseFilters } from "@/queries/releases"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Releases from "@/components/releases"
+import Can from "@/components/can"
 import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
@@ -51,13 +52,15 @@ export default function ReleasesList() {
   return (
     <section className="flex h-screen flex-col">
       <PageHeader title="Releases">
-        <Button
-          size="sm"
-          disabled={releasesLoading}
-          onClick={() => setOpen(true)}
-        >
-          New Release
-        </Button>
+        <Can permission="release.create">
+          <Button
+            size="sm"
+            disabled={releasesLoading}
+            onClick={() => setOpen(true)}
+          >
+            New Release
+          </Button>
+        </Can>
         <Releases.Form.Create open={open} onOpenChange={setOpen} />
       </PageHeader>
 

--- a/src/pages/app/settings/developers.tsx
+++ b/src/pages/app/settings/developers.tsx
@@ -57,8 +57,8 @@ export default function DevelopersPage() {
                     />
                   ) : (
                     <div className="flex flex-col">
-                      <div className="flex items-center justify-end border-b border-accent p-2">
-                        <Can permission="account.update">
+                      <Can permission="account.update">
+                        <div className="flex items-center justify-end border-b border-accent p-2">
                           <Button
                             variant="outline"
                             size="sm"
@@ -67,8 +67,8 @@ export default function DevelopersPage() {
                           >
                             Edit Settings
                           </Button>
-                        </Can>
-                      </div>
+                        </div>
+                      </Can>
                       <div className="flex flex-col gap-4 p-4">
                         <Attribute.Field
                           label="API version"

--- a/src/pages/app/settings/developers.tsx
+++ b/src/pages/app/settings/developers.tsx
@@ -16,6 +16,7 @@ import {
 import * as Motion from "@/components/motion"
 import * as Account from "@/components/account"
 import * as Attribute from "@/components/attribute"
+import Can from "@/components/can"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
 import TooltipBadge from "@/components/tooltip-badge"
@@ -41,8 +42,13 @@ export default function DevelopersPage() {
                 Configure API version and account protection.
               </p>
             </div>
-            <div className="overflow-hidden rounded bg-background-1">
-              {account && (
+            <div className="overflow-hidden rounded bg-background-1 p-4">
+              {accountLoading ? (
+                <div className="space-y-4">
+                  <Skeleton className="h-12 w-full" />
+                  <Skeleton className="h-12 w-3/4" />
+                </div>
+              ) : account ? (
                 <Motion.Resize layoutKey={editingSettings ? "edit" : "view"}>
                   {editingSettings ? (
                     <Account.Form.Developer
@@ -52,14 +58,16 @@ export default function DevelopersPage() {
                   ) : (
                     <div className="flex flex-col">
                       <div className="flex items-center justify-end border-b border-accent p-2">
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => setEditingSettings(true)}
-                          className="border-none bg-background-2"
-                        >
-                          Edit Settings
-                        </Button>
+                        <Can permission="account.update">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setEditingSettings(true)}
+                            className="border-none bg-background-2"
+                          >
+                            Edit Settings
+                          </Button>
+                        </Can>
                       </div>
                       <div className="flex flex-col gap-4 p-4">
                         <Attribute.Field
@@ -88,6 +96,12 @@ export default function DevelopersPage() {
                     </div>
                   )}
                 </Motion.Resize>
+              ) : (
+                <span className="text-sm text-content-subdued">
+                  Cannot access developer settings. This could be due to
+                  insufficient permissions or an issue with your account. Please
+                  contact your administrator for assistance.
+                </span>
               )}
             </div>
 
@@ -125,8 +139,10 @@ export default function DevelopersPage() {
                     <RsaKeyField base64Value={account.meta.keys.rsa2048} />
                   </div>
                 ) : (
-                  <span className="text-sm text-content-muted">
-                    No public keys available.
+                  <span className="text-sm text-content-subdued">
+                    Cannot access public keys. This could be due to insufficient
+                    permissions or an issue with your account. Please contact
+                    your administrator for assistance.
                   </span>
                 )}
               </div>

--- a/src/pages/app/settings/general.tsx
+++ b/src/pages/app/settings/general.tsx
@@ -55,8 +55,8 @@ export default function General() {
                     />
                   ) : (
                     <div className="flex flex-col">
-                      <div className="flex items-center justify-end border-b border-accent p-2">
-                        <Can permission="account.update">
+                      <Can permission="account.update">
+                        <div className="flex items-center justify-end border-b border-accent p-2">
                           <Button
                             variant="outline"
                             size="sm"
@@ -65,8 +65,8 @@ export default function General() {
                           >
                             Edit Account
                           </Button>
-                        </Can>
-                      </div>
+                        </div>
+                      </Can>
                       <div className="flex flex-col gap-4 p-4">
                         <Attribute.Field
                           label="ID"

--- a/src/pages/app/settings/general.tsx
+++ b/src/pages/app/settings/general.tsx
@@ -17,6 +17,7 @@ import * as Users from "@/components/users"
 import * as Motion from "@/components/motion"
 import * as Account from "@/components/account"
 import * as Attribute from "@/components/attribute"
+import Can from "@/components/can"
 import PageHeader from "@/components/page-header"
 import ClipboardButton from "@/components/clipboard-button"
 
@@ -55,14 +56,16 @@ export default function General() {
                   ) : (
                     <div className="flex flex-col">
                       <div className="flex items-center justify-end border-b border-accent p-2">
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => setEditingAccount(true)}
-                          className="border-none bg-background-2"
-                        >
-                          Edit Account
-                        </Button>
+                        <Can permission="account.update">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setEditingAccount(true)}
+                            className="border-none bg-background-2"
+                          >
+                            Edit Account
+                          </Button>
+                        </Can>
                       </div>
                       <div className="flex flex-col gap-4 p-4">
                         <Attribute.Field

--- a/src/pages/app/settings/permissions.tsx
+++ b/src/pages/app/settings/permissions.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react"
 
-import { ScrollArea } from "@/components/ui/scroll-area"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { useGetAccountSettings } from "@/queries/accounts"
 
@@ -11,8 +12,8 @@ import { AccountFormFieldDescriptions } from "@/types/accounts"
 import * as Motion from "@/components/motion"
 import * as Account from "@/components/account"
 import * as Attribute from "@/components/attribute"
+import Can from "@/components/can"
 import PageHeader from "@/components/page-header"
-import { Separator } from "@radix-ui/react-separator"
 
 export default function PermissionsPage() {
   const { data: settings } = useGetAccountSettings()
@@ -51,14 +52,16 @@ export default function PermissionsPage() {
                 ) : (
                   <div className="flex flex-col">
                     <div className="flex items-center justify-end border-b border-accent p-2">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setEditingPermissions(true)}
-                        className="border-none bg-background-2"
-                      >
-                        Edit Permissions
-                      </Button>
+                      <Can permission="account.update">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setEditingPermissions(true)}
+                          className="border-none bg-background-2"
+                        >
+                          Edit Permissions
+                        </Button>
+                      </Can>
                     </div>
                     <div className="flex flex-col gap-4 p-4">
                       <Attribute.Field

--- a/src/pages/app/settings/team.tsx
+++ b/src/pages/app/settings/team.tsx
@@ -46,7 +46,7 @@ export default function TeamPage() {
   const requestRoles = useMemo(
     () =>
       (filters.roles?.length ? filters.roles : InternalRoles).filter(
-        (r) => can("admin.read") || r !== UserRole.Admin,
+        (r) => can("admin.read") || (r as UserRole) !== UserRole.Admin,
       ),
     [filters.roles, can],
   )

--- a/src/pages/app/settings/team.tsx
+++ b/src/pages/app/settings/team.tsx
@@ -17,6 +17,7 @@ import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 import { User, InternalRoles, type UserFilters } from "@/types/users"
 
 import * as Users from "@/components/users"
+import Can from "@/components/can"
 import DataTable from "@/components/data-table"
 import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
@@ -96,9 +97,11 @@ export default function TeamPage() {
             </p>
           )}
         </div>
-        <Button size="sm" onClick={() => setOpen({ inviteTeammate: true })}>
-          Invite Teammate
-        </Button>
+        <Can permission="admin.invite">
+          <Button size="sm" onClick={() => setOpen({ inviteTeammate: true })}>
+            Invite Teammate
+          </Button>
+        </Can>
       </PageHeader>
 
       {/* Mobile */}

--- a/src/pages/app/settings/team.tsx
+++ b/src/pages/app/settings/team.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react"
+import { useState, useCallback, useMemo } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -11,10 +11,11 @@ import { useGetAccount, useGetAccountPlan } from "@/queries/accounts"
 import { useMobile } from "@/hooks/use-mobile"
 import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
+import { usePermissions } from "@/hooks/use-permissions"
 import { useTeamTableColumns } from "@/hooks/use-team-table-columns"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
-import { User, InternalRoles, type UserFilters } from "@/types/users"
+import { User, UserRole, InternalRoles, type UserFilters } from "@/types/users"
 
 import * as Users from "@/components/users"
 import Can from "@/components/can"
@@ -28,6 +29,7 @@ export default function TeamPage() {
 
   const table = useDataTable()
   const columns = useTeamTableColumns()
+  const { can } = usePermissions()
 
   const [filters, setFilters] = useFilterSearch<UserFilters>()
 
@@ -39,6 +41,16 @@ export default function TeamPage() {
     [table, setFilters],
   )
 
+  // NB(cazden) API requires 'admin.read' whenever an admin appears in the response,
+  // remove it from the request if current user can't read admins to avoid 403.
+  const requestRoles = useMemo(
+    () =>
+      (filters.roles?.length ? filters.roles : InternalRoles).filter(
+        (r) => can("admin.read") || r !== UserRole.Admin,
+      ),
+    [filters.roles, can],
+  )
+
   const {
     data: users,
     links,
@@ -48,7 +60,7 @@ export default function TeamPage() {
     pageSize: table.pageSize,
     filters: {
       ...filters,
-      roles: filters.roles?.length ? filters.roles : InternalRoles,
+      roles: requestRoles,
     },
   })
 

--- a/src/pages/app/user/details.tsx
+++ b/src/pages/app/user/details.tsx
@@ -70,6 +70,7 @@ import * as keygen from "@/keygen"
 import * as Users from "@/components/users"
 import * as Property from "@/components/property"
 import * as Attribute from "@/components/attribute"
+import Can from "@/components/can"
 import Metadata from "@/components/metadata"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
@@ -207,56 +208,67 @@ export default function UserDetails() {
               </DropdownMenuTrigger>
               <DropdownMenuContent className="mr-4 p-0">
                 {user?.attributes.status === UserStatus.Banned ? (
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("unban", true)
-                      e.currentTarget.blur()
-                    }}
-                    className="pb-2 text-base"
-                  >
-                    Unban
-                  </DropdownMenuItem>
+                  <Can permission="user.unban">
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        toggleOpen("unban", true)
+                        e.currentTarget.blur()
+                      }}
+                      className="pb-2 text-base"
+                    >
+                      Unban
+                    </DropdownMenuItem>
+                    <Separator />
+                  </Can>
                 ) : (
+                  <Can permission="user.ban">
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        toggleOpen("ban", true)
+                        e.currentTarget.blur()
+                      }}
+                      className="pb-2 text-base"
+                    >
+                      Ban
+                    </DropdownMenuItem>
+                    <Separator />
+                  </Can>
+                )}
+                <Can permission="user.password.reset">
                   <DropdownMenuItem
                     onClick={(e) => {
-                      toggleOpen("ban", true)
+                      toggleOpen("resetPassword", true)
                       e.currentTarget.blur()
                     }}
                     className="pb-2 text-base"
                   >
-                    Ban
+                    Reset password
                   </DropdownMenuItem>
-                )}
-                <Separator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("resetPassword", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Reset password
-                </DropdownMenuItem>
-                <Separator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("edit", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Edit
-                </DropdownMenuItem>
-                <Separator />
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    toggleOpen("delete", true)
-                    e.currentTarget.blur()
-                  }}
-                  className="pb-2 text-base"
-                >
-                  Delete
-                </DropdownMenuItem>
+                  <Separator />
+                </Can>
+                <Can permission="user.update">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("edit", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Edit
+                  </DropdownMenuItem>
+                  <Separator />
+                </Can>
+                <Can permission="user.delete">
+                  <DropdownMenuItem
+                    onClick={(e) => {
+                      toggleOpen("delete", true)
+                      e.currentTarget.blur()
+                    }}
+                    className="pb-2 text-base"
+                  >
+                    Delete
+                  </DropdownMenuItem>
+                </Can>
               </DropdownMenuContent>
             </DropdownMenu>
           ) : (
@@ -270,49 +282,59 @@ export default function UserDetails() {
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
                   {user?.attributes.status === UserStatus.Banned ? (
-                    <DropdownMenuItem
-                      onClick={(e) => {
-                        toggleOpen("unban", true)
-                        e.currentTarget.blur()
-                      }}
-                    >
-                      Unban
-                    </DropdownMenuItem>
+                    <Can permission="user.unban">
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          toggleOpen("unban", true)
+                          e.currentTarget.blur()
+                        }}
+                      >
+                        Unban
+                      </DropdownMenuItem>
+                    </Can>
                   ) : (
+                    <Can permission="user.ban">
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          toggleOpen("ban", true)
+                          e.currentTarget.blur()
+                        }}
+                      >
+                        Ban
+                      </DropdownMenuItem>
+                    </Can>
+                  )}
+                  <Can permission="user.password.reset">
+                    <DropdownMenuSeparator />
                     <DropdownMenuItem
                       onClick={(e) => {
-                        toggleOpen("ban", true)
+                        toggleOpen("resetPassword", true)
                         e.currentTarget.blur()
                       }}
                     >
-                      Ban
+                      Reset password
                     </DropdownMenuItem>
-                  )}
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("resetPassword", true)
-                      e.currentTarget.blur()
-                    }}
-                  >
-                    Reset password
-                  </DropdownMenuItem>
+                  </Can>
                 </DropdownMenuContent>
               </DropdownMenu>
-              <Button
-                variant="outline"
-                disabled={userLoading}
-                onClick={() => toggleOpen("edit", true)}
-              >
-                Edit
-              </Button>
-              <Button
-                variant="outline"
-                disabled={userLoading}
-                onClick={() => toggleOpen("delete", true)}
-              >
-                Delete
-              </Button>
+              <Can permission="user.update">
+                <Button
+                  variant="outline"
+                  disabled={userLoading}
+                  onClick={() => toggleOpen("edit", true)}
+                >
+                  Edit
+                </Button>
+              </Can>
+              <Can permission="user.delete">
+                <Button
+                  variant="outline"
+                  disabled={userLoading}
+                  onClick={() => toggleOpen("delete", true)}
+                >
+                  Delete
+                </Button>
+              </Can>
             </div>
           )}
         </PageHeader>

--- a/src/pages/app/user/details.tsx
+++ b/src/pages/app/user/details.tsx
@@ -196,91 +196,25 @@ export default function UserDetails() {
           </Breadcrumb>
 
           {isMobile ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  disabled={userLoading}
-                  className="text-content-muted"
-                >
-                  <EllipsisVertical className="size-5" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent className="mr-4 p-0">
-                {user?.attributes.status === UserStatus.Banned ? (
-                  <Can permission="user.unban">
-                    <DropdownMenuItem
-                      onClick={(e) => {
-                        toggleOpen("unban", true)
-                        e.currentTarget.blur()
-                      }}
-                      className="pb-2 text-base"
-                    >
-                      Unban
-                    </DropdownMenuItem>
-                    <Separator />
-                  </Can>
-                ) : (
-                  <Can permission="user.ban">
-                    <DropdownMenuItem
-                      onClick={(e) => {
-                        toggleOpen("ban", true)
-                        e.currentTarget.blur()
-                      }}
-                      className="pb-2 text-base"
-                    >
-                      Ban
-                    </DropdownMenuItem>
-                    <Separator />
-                  </Can>
-                )}
-                <Can permission="user.password.reset">
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("resetPassword", true)
-                      e.currentTarget.blur()
-                    }}
-                    className="pb-2 text-base"
-                  >
-                    Reset password
-                  </DropdownMenuItem>
-                  <Separator />
-                </Can>
-                <Can permission="user.update">
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("edit", true)
-                      e.currentTarget.blur()
-                    }}
-                    className="pb-2 text-base"
-                  >
-                    Edit
-                  </DropdownMenuItem>
-                  <Separator />
-                </Can>
-                <Can permission="user.delete">
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      toggleOpen("delete", true)
-                      e.currentTarget.blur()
-                    }}
-                    className="pb-2 text-base"
-                  >
-                    Delete
-                  </DropdownMenuItem>
-                </Can>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : (
-            <div className="flex items-center space-x-2">
+            <Can.Any
+              permissions={[
+                "user.ban",
+                "user.password.reset",
+                "user.update",
+                "user.delete",
+              ]}
+            >
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="outline" disabled={userLoading}>
-                    Actions
-                    <ChevronDown className="size-4 transition-transform duration-200 [[data-state=open]_&]:rotate-180" />
+                  <Button
+                    variant="ghost"
+                    disabled={userLoading}
+                    className="text-content-muted"
+                  >
+                    <EllipsisVertical className="size-5" />
                   </Button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
+                <DropdownMenuContent className="mr-4 p-0">
                   {user?.attributes.status === UserStatus.Banned ? (
                     <Can permission="user.unban">
                       <DropdownMenuItem
@@ -288,9 +222,11 @@ export default function UserDetails() {
                           toggleOpen("unban", true)
                           e.currentTarget.blur()
                         }}
+                        className="pb-2 text-base"
                       >
                         Unban
                       </DropdownMenuItem>
+                      <Separator />
                     </Can>
                   ) : (
                     <Can permission="user.ban">
@@ -299,24 +235,99 @@ export default function UserDetails() {
                           toggleOpen("ban", true)
                           e.currentTarget.blur()
                         }}
+                        className="pb-2 text-base"
                       >
                         Ban
                       </DropdownMenuItem>
+                      <Separator />
                     </Can>
                   )}
                   <Can permission="user.password.reset">
-                    <DropdownMenuSeparator />
                     <DropdownMenuItem
                       onClick={(e) => {
                         toggleOpen("resetPassword", true)
                         e.currentTarget.blur()
                       }}
+                      className="pb-2 text-base"
                     >
                       Reset password
+                    </DropdownMenuItem>
+                    <Separator />
+                  </Can>
+                  <Can permission="user.update">
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        toggleOpen("edit", true)
+                        e.currentTarget.blur()
+                      }}
+                      className="pb-2 text-base"
+                    >
+                      Edit
+                    </DropdownMenuItem>
+                    <Separator />
+                  </Can>
+                  <Can permission="user.delete">
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        toggleOpen("delete", true)
+                        e.currentTarget.blur()
+                      }}
+                      className="pb-2 text-base"
+                    >
+                      Delete
                     </DropdownMenuItem>
                   </Can>
                 </DropdownMenuContent>
               </DropdownMenu>
+            </Can.Any>
+          ) : (
+            <div className="flex items-center space-x-2">
+              <Can.Any permissions={["user.ban", "user.password.reset"]}>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="outline" disabled={userLoading}>
+                      Actions
+                      <ChevronDown className="size-4 transition-transform duration-200 [[data-state=open]_&]:rotate-180" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {user?.attributes.status === UserStatus.Banned ? (
+                      <Can permission="user.unban">
+                        <DropdownMenuItem
+                          onClick={(e) => {
+                            toggleOpen("unban", true)
+                            e.currentTarget.blur()
+                          }}
+                        >
+                          Unban
+                        </DropdownMenuItem>
+                      </Can>
+                    ) : (
+                      <Can permission="user.ban">
+                        <DropdownMenuItem
+                          onClick={(e) => {
+                            toggleOpen("ban", true)
+                            e.currentTarget.blur()
+                          }}
+                        >
+                          Ban
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                      </Can>
+                    )}
+                    <Can permission="user.password.reset">
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          toggleOpen("resetPassword", true)
+                          e.currentTarget.blur()
+                        }}
+                      >
+                        Reset password
+                      </DropdownMenuItem>
+                    </Can>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </Can.Any>
               <Can permission="user.update">
                 <Button
                   variant="outline"

--- a/src/pages/app/user/list.tsx
+++ b/src/pages/app/user/list.tsx
@@ -13,6 +13,7 @@ import { useListUsers } from "@/queries/users"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import * as Users from "@/components/users"
+import Can from "@/components/can"
 import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageHeader from "@/components/page-header"
@@ -53,9 +54,15 @@ export default function UsersList() {
   return (
     <section className="flex h-screen flex-col">
       <PageHeader title="Users">
-        <Button size="sm" disabled={usersLoading} onClick={() => setOpen(true)}>
-          New User
-        </Button>
+        <Can.Any permissions={["user.create", "user.invite"]}>
+          <Button
+            size="sm"
+            disabled={usersLoading}
+            onClick={() => setOpen(true)}
+          >
+            New User
+          </Button>
+        </Can.Any>
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">

--- a/src/pages/auth/password.tsx
+++ b/src/pages/auth/password.tsx
@@ -24,8 +24,6 @@ import { AuthErrorCode } from "@/types/auth"
 import { useAuth } from "@/hooks/use-auth"
 import { useSession } from "@/hooks/use-session"
 
-import { isPortalAllowed } from "@/lib/permissions"
-
 import * as Loading from "@/components/loading"
 import BackButton from "@/components/back-button"
 
@@ -91,21 +89,6 @@ export default function Password() {
       const { id: tokenId, attributes, relationships } = data!
       const { token } = attributes
       const userId = relationships.bearer.data.id
-
-      keygen.client.setRootToken(token)
-      keygen.client.setTokenId(tokenId)
-
-      const meResponse = await keygen.profiles.me()
-      if (
-        !meResponse.data ||
-        !isPortalAllowed(meResponse.data.attributes.role)
-      ) {
-        await keygen.logout()
-        setLocalError(
-          "This account does not have access to the portal. Please contact your administrator.",
-        )
-        return
-      }
 
       const storage = remember ? localStorage : sessionStorage
       storage.setItem("tokenId", tokenId)

--- a/src/pages/auth/password.tsx
+++ b/src/pages/auth/password.tsx
@@ -24,6 +24,8 @@ import { AuthErrorCode } from "@/types/auth"
 import { useAuth } from "@/hooks/use-auth"
 import { useSession } from "@/hooks/use-session"
 
+import { isPortalAllowed } from "@/lib/permissions"
+
 import * as Loading from "@/components/loading"
 import BackButton from "@/components/back-button"
 
@@ -86,11 +88,26 @@ export default function Password() {
         return
       }
 
-      const storage = remember ? localStorage : sessionStorage
       const { id: tokenId, attributes, relationships } = data!
       const { token } = attributes
       const userId = relationships.bearer.data.id
 
+      keygen.client.setRootToken(token)
+      keygen.client.setTokenId(tokenId)
+
+      const meResponse = await keygen.profiles.me()
+      if (
+        !meResponse.data ||
+        !isPortalAllowed(meResponse.data.attributes.role)
+      ) {
+        await keygen.logout()
+        setLocalError(
+          "This account does not have access to the portal. Please contact your administrator.",
+        )
+        return
+      }
+
+      const storage = remember ? localStorage : sessionStorage
       storage.setItem("tokenId", tokenId)
       keygen.client.setTokenId(tokenId)
 

--- a/src/pages/auth/verify.tsx
+++ b/src/pages/auth/verify.tsx
@@ -1,14 +1,18 @@
 import { useState, useCallback } from "react"
 import { useNavigate } from "@tanstack/react-router"
 
-import { OtpInput } from "@/components/otp-input"
-
 import * as keygen from "@/keygen"
+
 import { AuthErrorCode } from "@/types/auth"
+
 import { useAuth } from "@/hooks/use-auth"
 import { useSession } from "@/hooks/use-session"
-import BackButton from "@/components/back-button"
+
+import { isPortalAllowed } from "@/lib/permissions"
+
 import * as Loading from "@/components/loading"
+import { OtpInput } from "@/components/otp-input"
+import BackButton from "@/components/back-button"
 
 export default function Verify() {
   const [loading, setLoading] = useState(false)
@@ -55,11 +59,30 @@ export default function Verify() {
           return
         }
 
-        const storage = auth.remember ? localStorage : sessionStorage
         const { id: tokenId, attributes, relationships } = data!
         const { token } = attributes
         const userId = relationships.bearer.data.id
 
+        keygen.client.setRootToken(token)
+        keygen.client.setTokenId(tokenId)
+
+        const meResponse = await keygen.profiles.me()
+        if (
+          !meResponse.data ||
+          !isPortalAllowed(meResponse.data.attributes.role)
+        ) {
+          await keygen.logout()
+          auth.setError(
+            "This account does not have access to the portal. Please contact your administrator.",
+          )
+          void navigate({
+            to: "/$accountId/auth/login",
+            params: { accountId: keygen.config.id },
+          })
+          return
+        }
+
+        const storage = auth.remember ? localStorage : sessionStorage
         storage.setItem("tokenId", tokenId)
         keygen.client.setTokenId(tokenId)
 

--- a/src/pages/auth/verify.tsx
+++ b/src/pages/auth/verify.tsx
@@ -8,8 +8,6 @@ import { AuthErrorCode } from "@/types/auth"
 import { useAuth } from "@/hooks/use-auth"
 import { useSession } from "@/hooks/use-session"
 
-import { isPortalAllowed } from "@/lib/permissions"
-
 import * as Loading from "@/components/loading"
 import { OtpInput } from "@/components/otp-input"
 import BackButton from "@/components/back-button"
@@ -62,25 +60,6 @@ export default function Verify() {
         const { id: tokenId, attributes, relationships } = data!
         const { token } = attributes
         const userId = relationships.bearer.data.id
-
-        keygen.client.setRootToken(token)
-        keygen.client.setTokenId(tokenId)
-
-        const meResponse = await keygen.profiles.me()
-        if (
-          !meResponse.data ||
-          !isPortalAllowed(meResponse.data.attributes.role)
-        ) {
-          await keygen.logout()
-          auth.setError(
-            "This account does not have access to the portal. Please contact your administrator.",
-          )
-          void navigate({
-            to: "/$accountId/auth/login",
-            params: { accountId: keygen.config.id },
-          })
-          return
-        }
 
         const storage = auth.remember ? localStorage : sessionStorage
         storage.setItem("tokenId", tokenId)

--- a/src/providers/permissions-provider.tsx
+++ b/src/providers/permissions-provider.tsx
@@ -1,15 +1,12 @@
-import { useEffect, useMemo } from "react"
+import { useMemo } from "react"
 
 import { PermissionsContext } from "@/contexts/permissions-context"
 
-import { useLogout } from "@/queries/auth"
 import { useGetCurrentUser } from "@/queries/users"
 
 import { type Permission } from "@/types/users"
 
-import { toast } from "@/lib/toast"
 import { isPermission } from "@/lib/permissions"
-import { isPortalAllowed } from "@/lib/permissions"
 
 import * as Loading from "@/components/loading"
 
@@ -21,7 +18,6 @@ export function PermissionsProvider({
   children,
 }: PermissionsProviderProps): React.ReactElement {
   const { data: currentUser, isLoading } = useGetCurrentUser()
-  const logout = useLogout()
 
   const value = useMemo(() => {
     const permissions: ReadonlySet<Permission> = new Set(
@@ -39,25 +35,7 @@ export function PermissionsProvider({
     }
   }, [currentUser, isLoading])
 
-  useEffect(() => {
-    if (currentUser && !isPortalAllowed(currentUser.attributes.role)) {
-      toast({
-        message: "This account does not have access to the portal.",
-        variant: "error",
-      })
-      logout.mutate()
-    }
-  }, [currentUser, logout])
-
   if (!currentUser) {
-    return (
-      <div className="flex h-screen w-screen items-center justify-center">
-        <Loading.Dots />
-      </div>
-    )
-  }
-
-  if (!isPortalAllowed(currentUser.attributes.role)) {
     return (
       <div className="flex h-screen w-screen items-center justify-center">
         <Loading.Dots />

--- a/src/providers/permissions-provider.tsx
+++ b/src/providers/permissions-provider.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useMemo } from "react"
+
+import { PermissionsContext } from "@/contexts/permissions-context"
+
+import { useLogout } from "@/queries/auth"
+import { useGetCurrentUser } from "@/queries/users"
+
+import { type Permission } from "@/types/users"
+
+import { toast } from "@/lib/toast"
+import { isPermission } from "@/lib/permissions"
+import { isPortalAllowed } from "@/lib/permissions"
+
+import * as Loading from "@/components/loading"
+
+interface PermissionsProviderProps {
+  children: React.ReactNode
+}
+
+export function PermissionsProvider({
+  children,
+}: PermissionsProviderProps): React.ReactElement {
+  const { data: currentUser, isLoading } = useGetCurrentUser()
+  const logout = useLogout()
+
+  const value = useMemo(() => {
+    const permissions: ReadonlySet<Permission> = new Set(
+      (currentUser?.attributes.permissions ?? []).filter(isPermission),
+    )
+
+    return {
+      permissions,
+      isLoading,
+      can: (perm: Permission) => permissions.has(perm),
+      canAny: (perms: readonly Permission[]) =>
+        perms.some((p) => permissions.has(p)),
+      canAll: (perms: readonly Permission[]) =>
+        perms.every((p) => permissions.has(p)),
+    }
+  }, [currentUser, isLoading])
+
+  useEffect(() => {
+    if (currentUser && !isPortalAllowed(currentUser.attributes.role)) {
+      toast({
+        message: "This account does not have access to the portal.",
+        variant: "error",
+      })
+      logout.mutate()
+    }
+  }, [currentUser, logout])
+
+  if (!currentUser) {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center">
+        <Loading.Dots />
+      </div>
+    )
+  }
+
+  if (!isPortalAllowed(currentUser.attributes.role)) {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center">
+        <Loading.Dots />
+      </div>
+    )
+  }
+
+  return (
+    <PermissionsContext.Provider value={value}>
+      {children}
+    </PermissionsContext.Provider>
+  )
+}

--- a/src/providers/session-provider.tsx
+++ b/src/providers/session-provider.tsx
@@ -6,9 +6,6 @@ import { UserRole } from "@/types/users"
 
 import { SessionContext } from "@/contexts/session-context"
 
-import { toast } from "@/lib/toast"
-import { isPortalAllowed } from "@/lib/permissions"
-
 import * as keygen from "@/keygen"
 
 const STORAGE_KEYS = ["token", "tokenId"] as const
@@ -68,27 +65,6 @@ export function SessionProvider({
 
         if (!meResponse.data) {
           setInitializing(false)
-          return
-        }
-
-        // Reject portal-disallowed roles, e.g. end-users
-        //
-        // FIXME(cazden) We don't have an endpoint to invalidate a session yet, so if
-        // the browser holds a disallowed role session (i.e. logging in as a User via SSO),
-        // there's no way to clear it except by manually clearing storage etc.,
-        // putting the user in a redirect loop if they try to go back to the login page.
-        if (!isPortalAllowed(meResponse.data.attributes.role)) {
-          await keygen.logout()
-
-          if (window.location.pathname.includes("/auth/")) {
-            setInitializing(false)
-          } else {
-            toast({
-              message: "This account does not have access to the portal.",
-              variant: "error",
-            })
-            void navigate({ to: "/sso/error", replace: true })
-          }
           return
         }
 

--- a/src/providers/session-provider.tsx
+++ b/src/providers/session-provider.tsx
@@ -2,11 +2,8 @@ import { useCallback, useEffect, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import { useQueryClient } from "@tanstack/react-query"
 
-import { UserRole } from "@/types/users"
-
-import { SessionContext } from "@/contexts/session-context"
-
 import * as keygen from "@/keygen"
+import { SessionContext } from "@/contexts/session-context"
 
 const STORAGE_KEYS = ["token", "tokenId"] as const
 
@@ -47,44 +44,36 @@ export function SessionProvider({
       )
 
       try {
-        let verified = false
-
         if (token && tokenId) {
           const { data } = await keygen.verify({ token, tokenId })
           if (data) {
+            const userId = data.relationships.bearer?.data?.id ?? null
             keygen.client.setRootToken(token)
             keygen.client.setTokenId(tokenId)
-            verified = true
+            setUser(userId)
+            return
           }
         }
 
         const meResponse = (await keygen.profiles.me()) as {
-          data?: { id: string; attributes: { role: UserRole } }
+          data?: { id: string }
           included?: { type: string; id: string }[]
         }
-
-        if (!meResponse.data) {
-          setInitializing(false)
-          return
-        }
-
-        if (!verified) {
+        if (meResponse.data) {
           const tokenResource = meResponse.included?.find(
             (r) => r.type === "tokens",
           )
           keygen.client.setTokenId(tokenResource?.id ?? null)
+          setUser(meResponse.data.id)
+          return
         }
-
-        queryClient.setQueryData(["users", "me"], meResponse.data)
-
-        setUser(meResponse.data.id)
-        setInitializing(false)
       } catch (error) {
         console.error(error)
+      } finally {
         setInitializing(false)
       }
     })()
-  }, [setUser, navigate, queryClient])
+  }, [setUser])
 
   // Sync logout when another tab clears the token for multitab cases
   useEffect(() => {

--- a/src/providers/session-provider.tsx
+++ b/src/providers/session-provider.tsx
@@ -2,8 +2,14 @@ import { useCallback, useEffect, useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import { useQueryClient } from "@tanstack/react-query"
 
-import * as keygen from "@/keygen"
+import { UserRole } from "@/types/users"
+
 import { SessionContext } from "@/contexts/session-context"
+
+import { toast } from "@/lib/toast"
+import { isPortalAllowed } from "@/lib/permissions"
+
+import * as keygen from "@/keygen"
 
 const STORAGE_KEYS = ["token", "tokenId"] as const
 
@@ -44,36 +50,65 @@ export function SessionProvider({
       )
 
       try {
+        let verified = false
+
         if (token && tokenId) {
           const { data } = await keygen.verify({ token, tokenId })
           if (data) {
-            const userId = data.relationships.bearer?.data?.id ?? null
             keygen.client.setRootToken(token)
             keygen.client.setTokenId(tokenId)
-            setUser(userId)
-            return
+            verified = true
           }
         }
 
         const meResponse = (await keygen.profiles.me()) as {
-          data?: { id: string }
+          data?: { id: string; attributes: { role: UserRole } }
           included?: { type: string; id: string }[]
         }
-        if (meResponse.data) {
+
+        if (!meResponse.data) {
+          setInitializing(false)
+          return
+        }
+
+        // Reject portal-disallowed roles, e.g. end-users
+        //
+        // FIXME(cazden) We don't have an endpoint to invalidate a session yet, so if
+        // the browser holds a disallowed role session (i.e. logging in as a User via SSO),
+        // there's no way to clear it except by manually clearing storage etc.,
+        // putting the user in a redirect loop if they try to go back to the login page.
+        if (!isPortalAllowed(meResponse.data.attributes.role)) {
+          await keygen.logout()
+
+          if (window.location.pathname.includes("/auth/")) {
+            setInitializing(false)
+          } else {
+            toast({
+              message: "This account does not have access to the portal.",
+              variant: "error",
+            })
+            void navigate({ to: "/sso/error", replace: true })
+          }
+          return
+        }
+
+        if (!verified) {
           const tokenResource = meResponse.included?.find(
             (r) => r.type === "tokens",
           )
           keygen.client.setTokenId(tokenResource?.id ?? null)
-          setUser(meResponse.data.id)
-          return
         }
+
+        queryClient.setQueryData(["users", "me"], meResponse.data)
+
+        setUser(meResponse.data.id)
+        setInitializing(false)
       } catch (error) {
         console.error(error)
-      } finally {
         setInitializing(false)
       }
     })()
-  }, [setUser])
+  }, [setUser, navigate, queryClient])
 
   // Sync logout when another tab clears the token for multitab cases
   useEffect(() => {

--- a/src/queries/users.ts
+++ b/src/queries/users.ts
@@ -287,19 +287,21 @@ export function useResetPassword() {
   })
 }
 
+export const currentUserQueryOptions = () => ({
+  queryKey: ["users", "me"] as const,
+  queryFn: async () => {
+    const response = await keygen.profiles.me()
+
+    if (!response.data) {
+      throw new Error("Current user not found")
+    }
+
+    return response.data
+  },
+})
+
 export function useGetCurrentUser() {
-  return useQuery({
-    queryKey: ["users", "me"],
-    queryFn: async () => {
-      const response = await keygen.profiles.me()
-
-      if (!response.data) {
-        throw new Error("Current user not found")
-      }
-
-      return response.data
-    },
-  })
+  return useQuery(currentUserQueryOptions())
 }
 
 export function useUpdateCurrentUser() {

--- a/src/routes/$accountId/app.arches.tsx
+++ b/src/routes/$accountId/app.arches.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 export const Route = createFileRoute("/$accountId/app/arches")({
   component: () => <Page.App.Arches />,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "arch.read"),
 })

--- a/src/routes/$accountId/app.artifacts.tsx
+++ b/src/routes/$accountId/app.artifacts.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 export const Route = createFileRoute("/$accountId/app/artifacts")({
   component: () => <Page.App.Artifacts />,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "artifact.read"),
 })

--- a/src/routes/$accountId/app.billing.tsx
+++ b/src/routes/$accountId/app.billing.tsx
@@ -4,6 +4,7 @@ import { useCloud } from "@/hooks/use-cloud"
 
 import * as keygen from "@/keygen"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 function BillingRoute() {
   const { isCloud } = useCloud()
@@ -23,4 +24,6 @@ function BillingRoute() {
 
 export const Route = createFileRoute("/$accountId/app/billing")({
   component: BillingRoute,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "account.billing.read"),
 })

--- a/src/routes/$accountId/app.channels.tsx
+++ b/src/routes/$accountId/app.channels.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 export const Route = createFileRoute("/$accountId/app/channels")({
   component: () => <Page.App.Channels />,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "channel.read"),
 })

--- a/src/routes/$accountId/app.components.tsx
+++ b/src/routes/$accountId/app.components.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { type ComponentFilters } from "@/queries/components"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 function validateSearch(search: Record<string, unknown>): ComponentFilters {
   const filters: ComponentFilters = {}
@@ -17,4 +18,6 @@ function validateSearch(search: Record<string, unknown>): ComponentFilters {
 export const Route = createFileRoute("/$accountId/app/components")({
   component: () => <Page.App.Components />,
   validateSearch,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "component.read"),
 })

--- a/src/routes/$accountId/app.developers.tsx
+++ b/src/routes/$accountId/app.developers.tsx
@@ -1,7 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router"
 
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 export const Route = createFileRoute("/$accountId/app/developers")({
   component: () => <Page.App.Settings.Developers />,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "token.read"),
 })

--- a/src/routes/$accountId/app.engines.tsx
+++ b/src/routes/$accountId/app.engines.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 export const Route = createFileRoute("/$accountId/app/engines")({
   component: () => <Page.App.Engines />,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "engine.read"),
 })

--- a/src/routes/$accountId/app.entitlements.tsx
+++ b/src/routes/$accountId/app.entitlements.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 export const Route = createFileRoute("/$accountId/app/entitlements")({
   component: () => <Page.App.Entitlements />,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "entitlement.read"),
 })

--- a/src/routes/$accountId/app.groups.tsx
+++ b/src/routes/$accountId/app.groups.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 export const Route = createFileRoute("/$accountId/app/groups")({
   component: () => <Page.App.Groups />,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "group.read"),
 })

--- a/src/routes/$accountId/app.licenses.tsx
+++ b/src/routes/$accountId/app.licenses.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { type LicenseFilters } from "@/queries/licenses"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -38,4 +39,6 @@ function validateSearch(search: Record<string, unknown>): LicenseFilters {
 export const Route = createFileRoute("/$accountId/app/licenses")({
   component: () => <Page.App.Licenses />,
   validateSearch,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "license.read"),
 })

--- a/src/routes/$accountId/app.machines.tsx
+++ b/src/routes/$accountId/app.machines.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { type MachineFilters } from "@/queries/machines"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -28,4 +29,6 @@ function validateSearch(search: Record<string, unknown>): MachineFilters {
 export const Route = createFileRoute("/$accountId/app/machines")({
   component: () => <Page.App.Machines />,
   validateSearch,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "machine.read"),
 })

--- a/src/routes/$accountId/app.packages.tsx
+++ b/src/routes/$accountId/app.packages.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 export const Route = createFileRoute("/$accountId/app/packages")({
   component: () => <Page.App.Packages />,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "package.read"),
 })

--- a/src/routes/$accountId/app.permissions.tsx
+++ b/src/routes/$accountId/app.permissions.tsx
@@ -1,7 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router"
 
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 export const Route = createFileRoute("/$accountId/app/permissions")({
   component: () => <Page.App.Settings.Permissions />,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "account.update"),
 })

--- a/src/routes/$accountId/app.platforms.tsx
+++ b/src/routes/$accountId/app.platforms.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 export const Route = createFileRoute("/$accountId/app/platforms")({
   component: () => <Page.App.Platforms />,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "platform.read"),
 })

--- a/src/routes/$accountId/app.policies.tsx
+++ b/src/routes/$accountId/app.policies.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { type PolicyFilters } from "@/queries/policies"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 function validateSearch(search: Record<string, unknown>): PolicyFilters {
   const filters: PolicyFilters = {}
@@ -13,4 +14,6 @@ function validateSearch(search: Record<string, unknown>): PolicyFilters {
 export const Route = createFileRoute("/$accountId/app/policies")({
   component: () => <Page.App.Policies />,
   validateSearch,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "policy.read"),
 })

--- a/src/routes/$accountId/app.processes.tsx
+++ b/src/routes/$accountId/app.processes.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { type ProcessFilters } from "@/queries/processes"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 function validateSearch(search: Record<string, unknown>): ProcessFilters {
   const filters: ProcessFilters = {}
@@ -17,4 +18,6 @@ function validateSearch(search: Record<string, unknown>): ProcessFilters {
 export const Route = createFileRoute("/$accountId/app/processes")({
   component: () => <Page.App.Processes />,
   validateSearch,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "process.read"),
 })

--- a/src/routes/$accountId/app.products.tsx
+++ b/src/routes/$accountId/app.products.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 export const Route = createFileRoute("/$accountId/app/products")({
   component: () => <Page.App.Products />,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "product.read"),
 })

--- a/src/routes/$accountId/app.releases.tsx
+++ b/src/routes/$accountId/app.releases.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 export const Route = createFileRoute("/$accountId/app/releases")({
   component: () => <Page.App.Releases />,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "release.read"),
 })

--- a/src/routes/$accountId/app.team.tsx
+++ b/src/routes/$accountId/app.team.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { type UserFilters } from "@/types/users"
 import * as Page from "@/pages/index"
-import { requireAnyPermission } from "@/lib/permissions"
+import { requirePermission } from "@/lib/permissions"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -22,5 +22,5 @@ export const Route = createFileRoute("/$accountId/app/team")({
   component: () => <Page.App.Settings.Team />,
   validateSearch,
   beforeLoad: ({ context }) =>
-    requireAnyPermission(context.queryClient, ["admin.read", "user.read"]),
+    requirePermission(context.queryClient, "user.read"),
 })

--- a/src/routes/$accountId/app.team.tsx
+++ b/src/routes/$accountId/app.team.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { type UserFilters } from "@/types/users"
 import * as Page from "@/pages/index"
-import { requirePermission } from "@/lib/permissions"
+import { requireAllPermissions } from "@/lib/permissions"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -22,5 +22,5 @@ export const Route = createFileRoute("/$accountId/app/team")({
   component: () => <Page.App.Settings.Team />,
   validateSearch,
   beforeLoad: ({ context }) =>
-    requirePermission(context.queryClient, "user.read"),
+    requireAllPermissions(context.queryClient, ["admin.read", "user.read"]),
 })

--- a/src/routes/$accountId/app.team.tsx
+++ b/src/routes/$accountId/app.team.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { type UserFilters } from "@/types/users"
 import * as Page from "@/pages/index"
+import { requireAnyPermission } from "@/lib/permissions"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -20,4 +21,6 @@ function validateSearch(search: Record<string, unknown>): UserFilters {
 export const Route = createFileRoute("/$accountId/app/team")({
   component: () => <Page.App.Settings.Team />,
   validateSearch,
+  beforeLoad: ({ context }) =>
+    requireAnyPermission(context.queryClient, ["admin.read", "user.read"]),
 })

--- a/src/routes/$accountId/app.users.tsx
+++ b/src/routes/$accountId/app.users.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { type UserFilters } from "@/queries/users"
 import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -23,4 +24,6 @@ function validateSearch(search: Record<string, unknown>): UserFilters {
 export const Route = createFileRoute("/$accountId/app/users")({
   component: () => <Page.App.Users />,
   validateSearch,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "user.read"),
 })

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,8 +1,13 @@
-import { createRootRoute } from "@tanstack/react-router"
+import { createRootRouteWithContext } from "@tanstack/react-router"
+import type { QueryClient } from "@tanstack/react-query"
 import "@/index.css"
 
 import * as Layout from "@/layouts/index"
 
-export const Route = createRootRoute({
+export interface RouterContext {
+  queryClient: QueryClient
+}
+
+export const Route = createRootRouteWithContext<RouterContext>()({
   component: () => <Layout.Root />,
 })

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -176,7 +176,7 @@ export type UserFilters = {
   metadata?: Record<string, string>
 }
 
-export const AdminPermissions = [
+export const Permissions = [
   "account.analytics.read",
   "account.billing.read",
   "account.billing.update",
@@ -323,7 +323,9 @@ export const AdminPermissions = [
   "webhook-event.retry",
 ] as const
 
-export const PortalRequiredPermissions = [
+export type Permission = (typeof Permissions)[number]
+
+export const PortalRequiredPermissions: readonly Permission[] = [
   "account.read",
   "user.read",
   "user.password.update",
@@ -335,9 +337,9 @@ export const PortalRequiredPermissions = [
   "token.generate",
   "token.read",
   "token.revoke",
-] as const
+]
 
-export const UserPermissions = [
+export const UserPermissions: readonly Permission[] = [
   "account.read",
   "arch.read",
   "artifact.read",


### PR DESCRIPTION
Closes #156, and related to #183. Adds permission gating to Portal in two ways:

1. New components `<Can>` / `<Can.Any>` / `<Can.All>` wrap UI actions (create, edit, delete buttons, etc.) to block rendering if the user lacks permission:
```
<Can permission="policy.update">
  <Button>
    Edit
  </Button>
</Can>
```

2. New utils  `requirePermission` / `requireAnyPermission` / `requireAllPermissions` for cases where we want to block routes if the user lacks permission:
```
export const Route = createFileRoute("/$accountId/app/arches")({
  component: () => <Page.App.Arches />,
  beforeLoad: ({ context }) =>
    requirePermission(context.queryClient, "arch.read"),
})
```

Also, filters the sidebar based on user permissions, so resources that the user doesn't have read permissions for won't be listed, and subsequently if they don't have permissions to read any resources under a sidebar category, the entire category will be hidden. Finally, also blocks end-users (external `User` role) from authenticating into the Portal dashboard.