### PR TITLE
Fix cookie credentials in non-Cloud environments

### DIFF
--- a/src/keygen/client.ts
+++ b/src/keygen/client.ts
@@ -76,7 +76,9 @@ export class Client {
     const response = await fetch(`${this.url}${endpoint}`, {
       ...fetchOptions,
       headers,
-      credentials: "include",
+      ...(config.isCloud
+        ? { credentials: "include" } // cookies are only supported on cloud
+        : {}),
     })
 
     const data = (await response.json().catch(() => ({}))) as APIResponse<T>


### PR DESCRIPTION
I was encountering CORS issues after #181, which was due to sending credentials in a non-Cloud environment. Browsers reject cross-origin credentials, e.g. `localhost:5173` to `api.keygen.localhost`, so credentials only worked from `portal.keygen.dev` to `api.keygen.dev` since they're the same origin.

This PR disables credentials in non-Cloud environments, aligning with Portal's token vs session logic.