### PR TITLE
feat: add CE (Community Edition) support

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_KEYGEN_MODE: string
   readonly VITE_KEYGEN_VERSION: string
   readonly VITE_KEYGEN_ACCOUNT_ID: string
+  readonly VITE_KEYGEN_EDITION?: string
 }
 
 interface ImportMeta {

--- a/src/components/sidebar/combobox.tsx
+++ b/src/components/sidebar/combobox.tsx
@@ -20,6 +20,7 @@ import { Environment } from "@/types/environments"
 
 import { useListEnvironments } from "@/queries/environments"
 import { useEnvironment } from "@/hooks/use-environment"
+import { useEdition } from "@/hooks/use-edition"
 
 import * as Environments from "@/components/environments"
 
@@ -29,7 +30,20 @@ const GLOBAL_ENVIRONMENT = {
   name: "Global",
 }
 
-export default function SidebarCombobox(): React.ReactElement {
+function CeCombobox(): React.ReactElement {
+  return (
+    <div className="flex h-9 items-center px-1">
+      {/* TODO(cazden) Use company logo */}
+      <Droplet className="mr-2 size-6 rounded-sm bg-content-loud p-1 text-background" />
+      <div className="flex max-w-32 flex-col text-left text-content-loud">
+        {/* TODO(cazden) Get company name */}
+        <span className="truncate">Umbral</span>
+      </div>
+    </div>
+  )
+}
+
+function EeCombobox(): React.ReactElement {
   const { code, select } = useEnvironment()
 
   const [openModal, setOpenModal] = useState(false)
@@ -156,4 +170,9 @@ export default function SidebarCombobox(): React.ReactElement {
       />
     </>
   )
+}
+
+export default function SidebarCombobox(): React.ReactElement {
+  const { isCE } = useEdition()
+  return isCE ? <CeCombobox /> : <EeCombobox />
 }

--- a/src/hooks/use-edition.ts
+++ b/src/hooks/use-edition.ts
@@ -1,0 +1,5 @@
+import config from "@/keygen/config"
+
+export function useEdition(): { isCE: boolean; isEE: boolean } {
+  return { isCE: config.isCE, isEE: !config.isCE }
+}

--- a/src/keygen/config.ts
+++ b/src/keygen/config.ts
@@ -3,6 +3,7 @@ const CLOUD_HOSTS = ["api.keygen.sh", "api.keygen.dev"]
 const config = {
   host: import.meta.env.VITE_KEYGEN_HOST,
   mode: import.meta.env.VITE_KEYGEN_MODE,
+  isCE: import.meta.env.VITE_KEYGEN_EDITION !== "EE",
   isCloud:
     import.meta.env.VITE_KEYGEN_EDITION === "EE" &&
     import.meta.env.VITE_KEYGEN_MODE === "multiplayer" &&

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -2,7 +2,13 @@ import type { QueryClient } from "@tanstack/react-query"
 
 import { currentUserQueryOptions } from "@/queries/users"
 
-import { Permissions, Permission } from "@/types/users"
+import {
+  Permissions,
+  Permission,
+  DefaultPermissionsByRole,
+} from "@/types/users"
+
+import config from "@/keygen/config"
 
 const PERMISSION_SET: ReadonlySet<Permission> = new Set(Permissions)
 
@@ -14,7 +20,17 @@ async function effectivePermissions(
   queryClient: QueryClient,
 ): Promise<ReadonlySet<Permission>> {
   const me = await queryClient.ensureQueryData(currentUserQueryOptions())
-  return new Set((me.attributes.permissions ?? []).filter(isPermission))
+  const raw = me.attributes.permissions
+
+  if (raw != null) {
+    return new Set(raw.filter(isPermission))
+  }
+
+  if (config.isCE) {
+    return new Set(DefaultPermissionsByRole[me.attributes.role] ?? [])
+  }
+
+  return new Set()
 }
 
 export async function requirePermission(

--- a/src/providers/environment-provider.tsx
+++ b/src/providers/environment-provider.tsx
@@ -5,13 +5,27 @@ import { EnvironmentContext } from "@/contexts/environment-context"
 import { useCreateEnvironmentToken } from "@/queries/tokens"
 
 import * as keygen from "@/keygen"
+import config from "@/keygen/config"
 import { toast } from "@/lib/toast"
 
-export function EnvironmentProvider({
+function CeEnvironmentProvider({
   children,
 }: {
   children: React.ReactNode
-}) {
+}): React.ReactElement {
+  const value = useMemo(() => ({ code: null, select: async () => {} }), [])
+  return (
+    <EnvironmentContext.Provider value={value}>
+      {children}
+    </EnvironmentContext.Provider>
+  )
+}
+
+function EeEnvironmentProvider({
+  children,
+}: {
+  children: React.ReactNode
+}): React.ReactElement {
   const [code, setCode] = useState<string | null>(null)
   const queryClient = useQueryClient()
   const { mutateAsync: createEnvironmentToken } = useCreateEnvironmentToken()
@@ -68,4 +82,15 @@ export function EnvironmentProvider({
       {children}
     </EnvironmentContext.Provider>
   )
+}
+
+export function EnvironmentProvider({
+  children,
+}: {
+  children: React.ReactNode
+}): React.ReactElement {
+  if (config.isCE) {
+    return <CeEnvironmentProvider>{children}</CeEnvironmentProvider>
+  }
+  return <EeEnvironmentProvider>{children}</EeEnvironmentProvider>
 }

--- a/src/providers/permissions-provider.tsx
+++ b/src/providers/permissions-provider.tsx
@@ -4,9 +4,11 @@ import { PermissionsContext } from "@/contexts/permissions-context"
 
 import { useGetCurrentUser } from "@/queries/users"
 
-import { type Permission } from "@/types/users"
+import { type Permission, DefaultPermissionsByRole } from "@/types/users"
 
 import { isPermission } from "@/lib/permissions"
+
+import config from "@/keygen/config"
 
 import * as Loading from "@/components/loading"
 
@@ -20,9 +22,18 @@ export function PermissionsProvider({
   const { data: currentUser, isLoading } = useGetCurrentUser()
 
   const value = useMemo(() => {
-    const permissions: ReadonlySet<Permission> = new Set(
-      (currentUser?.attributes.permissions ?? []).filter(isPermission),
-    )
+    const raw = currentUser?.attributes.permissions
+
+    let permissions: ReadonlySet<Permission>
+    if (raw != null) {
+      permissions = new Set(raw.filter(isPermission))
+    } else if (config.isCE && currentUser?.attributes.role != null) {
+      permissions = new Set(
+        DefaultPermissionsByRole[currentUser.attributes.role] ?? [],
+      )
+    } else {
+      permissions = new Set()
+    }
 
     return {
       permissions,

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -339,6 +339,94 @@ export const PortalRequiredPermissions: readonly Permission[] = [
   "token.revoke",
 ]
 
+const BillingPermissions: readonly Permission[] = [
+  "account.billing.read",
+  "account.billing.update",
+  "account.plan.read",
+  "account.plan.update",
+  "account.subscription.read",
+  "account.subscription.update",
+]
+
+const ReadOnlyPermissions: readonly Permission[] = [
+  "account.analytics.read",
+  "account.plan.read",
+  "account.read",
+  "account.subscription.read",
+  "admin.read",
+  "arch.read",
+  "artifact.read",
+  "channel.read",
+  "component.read",
+  "constraint.read",
+  "engine.read",
+  "entitlement.read",
+  "environment.read",
+  "event-log.read",
+  "group.licenses.read",
+  "group.machines.read",
+  "group.owners.read",
+  "group.read",
+  "group.users.read",
+  "key.read",
+  "license.read",
+  "license.validate",
+  "machine.read",
+  "package.read",
+  "platform.read",
+  "policy.read",
+  "process.read",
+  "product.read",
+  "release.download",
+  "release.read",
+  "release.upgrade",
+  "request-log.read",
+  "token.read",
+  "user.read",
+  "webhook-endpoint.read",
+  "webhook-event.read",
+]
+
+const SalesAgentPermissions: readonly Permission[] = [
+  ...ReadOnlyPermissions,
+  "license.check-in",
+  "license.check-out",
+  "license.create",
+  "license.delete",
+  "license.reinstate",
+  "license.renew",
+  "license.revoke",
+  "license.suspend",
+  "license.update",
+  "machine.create",
+  "machine.delete",
+  "machine.update",
+  "token.generate",
+  "token.regenerate",
+  "token.revoke",
+  "user.create",
+  "user.delete",
+  "user.invite",
+  "user.update",
+]
+
+const BillingPermissionSet = new Set<string>(BillingPermissions)
+
+const DeveloperPermissions: readonly Permission[] = Permissions.filter(
+  (p) => !BillingPermissionSet.has(p),
+)
+
+export const DefaultPermissionsByRole: Readonly<
+  Record<UserRole, readonly Permission[]>
+> = {
+  [UserRole.Admin]: [...Permissions],
+  [UserRole.Developer]: DeveloperPermissions,
+  [UserRole.ReadOnly]: ReadOnlyPermissions,
+  [UserRole.SalesAgent]: SalesAgentPermissions,
+  [UserRole.SupportAgent]: ReadOnlyPermissions,
+  [UserRole.User]: [],
+}
+
 export const UserPermissions: readonly Permission[] = [
   "account.read",
   "arch.read",


### PR DESCRIPTION
## Summary

Adds initial CE (Community Edition) support as described in #192.

- **Stop relying on `data.attributes.permissions` in CE** — when the `permissions` attribute is absent (null), the provider and `effectivePermissions()` now fall back to a role-based default permission set (`DefaultPermissionsByRole`) instead of returning an empty set.
- **Disable environments in CE** — the `EnvironmentProvider` is split into a CE no-op variant and the existing EE variant; the sidebar environment switcher and "Manage Environments" option are hidden when `VITE_KEYGEN_EDITION !== "EE"`.
- **Request logs / event logs** — not yet implemented; will be gated via `config.isCE` when added, as planned in #192.

## Changes

| File | Change |
|------|--------|
| `env.d.ts` | Added `VITE_KEYGEN_EDITION?` to `ImportMetaEnv` |
| `src/keygen/config.ts` | Added `isCE` flag (`VITE_KEYGEN_EDITION !== "EE"`) |
| `src/hooks/use-edition.ts` | New `useEdition()` hook, mirrors existing `useCloud` pattern |
| `src/types/users.ts` | Added `DefaultPermissionsByRole` — role-based permission sets for CE fallback |
| `src/lib/permissions.ts` | `effectivePermissions()` falls back to role defaults when `permissions` is null in CE |
| `src/providers/permissions-provider.tsx` | CE-aware permission resolution using same fallback logic |
| `src/providers/environment-provider.tsx` | CE variant is a no-op; EE variant preserves existing behavior |
| `src/components/sidebar/combobox.tsx` | Environment switcher hidden in CE |

## Test plan

- [ ] Set `VITE_KEYGEN_EDITION=CE` and start the dev server (`pnpm run dev`)
- [ ] Log in — environment switcher should not appear in the sidebar
- [ ] Navigate to `/environments` if routed — no crash, environments not accessible
- [ ] Verify that users with different roles get the expected permissions via the `can()` helper
- [ ] Set `VITE_KEYGEN_EDITION=EE` — environment switcher and full permission behavior should be unchanged
- [ ] `pnpm lint:check` and `pnpm format:check` pass