### PR TITLE
Add cursor-based pagination

### DIFF
--- a/src/components/artifacts/filter-bar.tsx
+++ b/src/components/artifacts/filter-bar.tsx
@@ -39,19 +39,19 @@ export default function ArtifactFilterBar({
   }, [])
 
   const { data: products = [] } = useListProducts(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.products },
   )
   const { data: releases = [] } = useListReleases(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.releases },
   )
   const { data: platforms = [] } = useListPlatforms(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.platforms },
   )
   const { data: arches = [] } = useListArches(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.arches },
   )
 

--- a/src/components/components/filter-bar.tsx
+++ b/src/components/components/filter-bar.tsx
@@ -27,19 +27,19 @@ export default function ComponentFilterBar({
   }, [])
 
   const { data: machines = [] } = useListMachines(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.machines },
   )
   const { data: licenses = [] } = useListLicenses(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.licenses },
   )
   const { data: users = [] } = useListUsers(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.users },
   )
   const { data: products = [] } = useListProducts(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.products },
   )
 

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -46,7 +46,6 @@ type DataTableProps<T extends TableResource> = {
   columns: TableColumns<T>
   onRowClick?: (row: T) => void
   staticColumns?: number
-  pageCount: number
   isLoading?: boolean
   className?: string
 }
@@ -57,7 +56,6 @@ export default function DataTable<T extends TableResource>({
   columns,
   onRowClick,
   staticColumns = 1,
-  pageCount,
   isLoading = false,
   className,
 }: DataTableProps<T>): React.ReactElement {
@@ -97,7 +95,7 @@ export default function DataTable<T extends TableResource>({
       pagination: { pageIndex: table.page - 1, pageSize: table.pageSize },
     },
     manualPagination: true,
-    pageCount,
+    pageCount: -1,
     onPaginationChange: (updater) => {
       const current = {
         pageIndex: table.page - 1,

--- a/src/components/environments/view/list.tsx
+++ b/src/components/environments/view/list.tsx
@@ -39,7 +39,6 @@ export default function EnvironmentsList({
         data={environments}
         table={table}
         columns={columns}
-        pageCount={-1}
         isLoading={isLoading}
         onRowClick={onViewDetails}
       />

--- a/src/components/environments/view/list.tsx
+++ b/src/components/environments/view/list.tsx
@@ -2,6 +2,7 @@ import { Environment } from "@/types/environments"
 
 import { useListEnvironments } from "@/queries/environments"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useDataTable } from "@/hooks/use-data-table"
 import { useEnvironmentTableColumns } from "@/hooks/use-environment-table-columns"
 
@@ -17,6 +18,8 @@ export default function EnvironmentsList({
   onViewDetails,
 }: EnvironmentsListProps) {
   const table = useDataTable()
+  const { page, setPage } = table
+  const { cursor, goToPage } = useCursors(page, setPage)
   const columns = useEnvironmentTableColumns()
 
   const {
@@ -24,11 +27,11 @@ export default function EnvironmentsList({
     links,
     isLoading,
   } = useListEnvironments({
-    page: table.page,
+    cursor,
     pageSize: 15, // Ignore hook value since we're in a dialog
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   return (
     <>
@@ -36,16 +39,16 @@ export default function EnvironmentsList({
         data={environments}
         table={table}
         columns={columns}
-        pageCount={totalPages}
+        pageCount={-1}
         isLoading={isLoading}
         onRowClick={onViewDetails}
       />
 
       <PageFooter className="border-none">
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={isLoading}
         />
       </PageFooter>

--- a/src/components/licenses/filter-bar.tsx
+++ b/src/components/licenses/filter-bar.tsx
@@ -107,19 +107,19 @@ export default function LicenseFilterBar({
   }, [])
 
   const { data: products = [] } = useListProducts(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.products },
   )
   const { data: policies = [] } = useListPolicies(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.policies },
   )
   const { data: users = [] } = useListUsers(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.users },
   )
   const { data: groups = [] } = useListGroups(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.groups },
   )
 

--- a/src/components/machines/filter-bar.tsx
+++ b/src/components/machines/filter-bar.tsx
@@ -46,23 +46,23 @@ export default function MachineFilterBar({
   }, [])
 
   const { data: products = [] } = useListProducts(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.products },
   )
   const { data: policies = [] } = useListPolicies(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.policies },
   )
   const { data: licenses = [] } = useListLicenses(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.licenses },
   )
   const { data: users = [] } = useListUsers(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.users },
   )
   const { data: groups = [] } = useListGroups(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.groups },
   )
 

--- a/src/components/packages/filter-bar.tsx
+++ b/src/components/packages/filter-bar.tsx
@@ -31,7 +31,7 @@ export default function PackageFilterBar({
   }, [])
 
   const { data: products = [] } = useListProducts(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.products },
   )
 

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -4,9 +4,6 @@ import { ChevronLeft, ChevronRight } from "lucide-react"
 
 interface PaginationProps {
   page: number
-  // FIXME(cazden) refactor based on cursor-based pagination,
-  // but for now support both cursor and page-based
-  pageCount?: number
   hasNext?: boolean
   onPageChange: (page: number) => void
   isLoading?: boolean
@@ -14,13 +11,10 @@ interface PaginationProps {
 
 export default function Pagination({
   page,
-  pageCount,
   hasNext,
   onPageChange,
   isLoading = false,
 }: PaginationProps) {
-  const canNext = pageCount == null ? !!hasNext : page < pageCount
-
   if (isLoading) {
     return (
       <div className="flex items-center gap-2">
@@ -33,10 +27,7 @@ export default function Pagination({
 
   return (
     <div className="flex items-center gap-2">
-      <span className="text-sm text-muted-foreground">
-        Page {page}
-        {pageCount != null && ` of ${Math.max(1, pageCount)}`}
-      </span>
+      <span className="text-sm text-muted-foreground">Page {page}</span>
 
       <Button
         variant="outline"
@@ -53,7 +44,7 @@ export default function Pagination({
         size="icon"
         className="h-8 w-8"
         onClick={() => onPageChange(page + 1)}
-        disabled={!canNext}
+        disabled={!hasNext}
       >
         <ChevronRight className="h-4 w-4" />
       </Button>

--- a/src/components/policies/filter-bar.tsx
+++ b/src/components/policies/filter-bar.tsx
@@ -24,7 +24,7 @@ export default function PolicyFilterBar({
   }, [])
 
   const { data: products = [] } = useListProducts(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.products },
   )
 

--- a/src/components/processes/filter-bar.tsx
+++ b/src/components/processes/filter-bar.tsx
@@ -27,19 +27,19 @@ export default function ProcessFilterBar({
   }, [])
 
   const { data: machines = [] } = useListMachines(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.machines },
   )
   const { data: licenses = [] } = useListLicenses(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.licenses },
   )
   const { data: users = [] } = useListUsers(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.users },
   )
   const { data: products = [] } = useListProducts(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.products },
   )
 

--- a/src/components/releases/filter-bar.tsx
+++ b/src/components/releases/filter-bar.tsx
@@ -48,15 +48,15 @@ export default function ReleaseFilterBar({
   }, [])
 
   const { data: products = [] } = useListProducts(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.products },
   )
   const { data: packages = [] } = useListPackages(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.packages },
   )
   const { data: entitlements = [] } = useListEntitlements(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.entitlements },
   )
 

--- a/src/components/users/filter-bar.tsx
+++ b/src/components/users/filter-bar.tsx
@@ -60,11 +60,11 @@ export default function UserFilterBar({
   }, [])
 
   const { data: products = [] } = useListProducts(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.products },
   )
   const { data: groups = [] } = useListGroups(
-    { page: 1, pageSize: 10 },
+    { cursor: "", pageSize: 10 },
     { enabled: !!enabled.groups },
   )
 

--- a/src/keygen/arches/list.ts
+++ b/src/keygen/arches/list.ts
@@ -6,24 +6,22 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
 }: ListProps): Promise<ArchesListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
 
   const result = (await client.request(

--- a/src/keygen/artifacts/list.ts
+++ b/src/keygen/artifacts/list.ts
@@ -6,14 +6,14 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
   filters?: ArtifactFilters
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
   filters,
 }: ListProps): Promise<ArtifactsListResponse> {
@@ -21,11 +21,9 @@ export default async function list({
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
   if (filters?.product) {
     params.set("product", filters.product)

--- a/src/keygen/channels/list.ts
+++ b/src/keygen/channels/list.ts
@@ -6,24 +6,22 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
 }: ListProps): Promise<ChannelsListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
 
   const result = (await client.request(

--- a/src/keygen/components/list.ts
+++ b/src/keygen/components/list.ts
@@ -9,14 +9,14 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
   filters?: ComponentFilters
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
   filters,
 }: ListProps): Promise<ComponentListResponse> {
@@ -24,11 +24,9 @@ export default async function list({
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
   if (filters?.machine) {
     params.set("machine", filters.machine)

--- a/src/keygen/engines/list.ts
+++ b/src/keygen/engines/list.ts
@@ -6,24 +6,22 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
 }: ListProps): Promise<EnginesListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
 
   const result = (await client.request(

--- a/src/keygen/entitlements/list.ts
+++ b/src/keygen/entitlements/list.ts
@@ -6,24 +6,22 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
 }: ListProps): Promise<EntitlementListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
 
   const result = (await client.request(

--- a/src/keygen/environments/list.ts
+++ b/src/keygen/environments/list.ts
@@ -6,24 +6,22 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
 }: ListProps): Promise<EnvironmentsListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
 
   const result = (await client.request(

--- a/src/keygen/groups/list.ts
+++ b/src/keygen/groups/list.ts
@@ -6,24 +6,22 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
 }: ListProps): Promise<GroupListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
 
   const result = (await client.request(

--- a/src/keygen/licenses/list-entitlements.ts
+++ b/src/keygen/licenses/list-entitlements.ts
@@ -7,25 +7,23 @@ config.validate()
 interface ListEntitlementsProps {
   licenseId: string
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
 }
 
 export default async function listEntitlements({
   licenseId,
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
 }: ListEntitlementsProps): Promise<EntitlementListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
 
   const result = (await client.request(

--- a/src/keygen/licenses/list-users.ts
+++ b/src/keygen/licenses/list-users.ts
@@ -7,25 +7,23 @@ config.validate()
 interface ListUsersProps {
   licenseId: string
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
 }
 
 export default async function listUsers({
   licenseId,
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
 }: ListUsersProps): Promise<UserListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
 
   const result = (await client.request(

--- a/src/keygen/licenses/list.ts
+++ b/src/keygen/licenses/list.ts
@@ -6,14 +6,14 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
   filters?: LicenseFilters
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
   filters,
 }: ListProps): Promise<LicenseListResponse> {
@@ -21,11 +21,9 @@ export default async function list({
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
   if (filters?.status) {
     params.set("status", filters.status)

--- a/src/keygen/machines/list.ts
+++ b/src/keygen/machines/list.ts
@@ -6,14 +6,14 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
   filters?: MachineFilters
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
   filters,
 }: ListProps): Promise<MachineListResponse> {
@@ -21,11 +21,9 @@ export default async function list({
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
   if (filters?.status) {
     params.set("status", filters.status)

--- a/src/keygen/packages/list.ts
+++ b/src/keygen/packages/list.ts
@@ -6,14 +6,14 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
   filters?: PackageFilters
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
   filters,
 }: ListProps): Promise<PackagesListResponse> {
@@ -21,11 +21,9 @@ export default async function list({
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
   if (filters?.product) {
     params.set("product", filters.product)

--- a/src/keygen/platforms/list.ts
+++ b/src/keygen/platforms/list.ts
@@ -6,24 +6,22 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
 }: ListProps): Promise<PlatformsListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
 
   const result = (await client.request(

--- a/src/keygen/policies/list-entitlements.ts
+++ b/src/keygen/policies/list-entitlements.ts
@@ -7,25 +7,23 @@ config.validate()
 interface ListEntitlementsProps {
   policyId: string
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
 }
 
 export default async function listEntitlements({
   policyId,
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
 }: ListEntitlementsProps): Promise<EntitlementListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
 
   const result = (await client.request(

--- a/src/keygen/policies/list.ts
+++ b/src/keygen/policies/list.ts
@@ -6,14 +6,14 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
   filters?: PolicyFilters
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
   filters,
 }: ListProps): Promise<PoliciesListResponse> {
@@ -21,11 +21,9 @@ export default async function list({
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
   if (filters?.product) {
     params.set("product", filters.product)

--- a/src/keygen/processes/list.ts
+++ b/src/keygen/processes/list.ts
@@ -6,14 +6,14 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
   filters?: ProcessFilters
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
   filters,
 }: ListProps): Promise<ProcessListResponse> {
@@ -21,11 +21,9 @@ export default async function list({
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
   if (filters?.machine) {
     params.set("machine", filters.machine)

--- a/src/keygen/products/list.ts
+++ b/src/keygen/products/list.ts
@@ -6,24 +6,22 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
 }: ListProps): Promise<ProductsListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
 
   const result = (await client.request(

--- a/src/keygen/releases/list-artifacts.ts
+++ b/src/keygen/releases/list-artifacts.ts
@@ -7,25 +7,23 @@ config.validate()
 interface ListArtifactsProps {
   releaseId: string
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
 }
 
 export default async function listArtifacts({
   releaseId,
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
 }: ListArtifactsProps): Promise<ArtifactsListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
 
   const result = (await client.request(

--- a/src/keygen/releases/list-constraints.ts
+++ b/src/keygen/releases/list-constraints.ts
@@ -7,25 +7,23 @@ config.validate()
 interface ListConstraintsProps {
   releaseId: string
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
 }
 
 export default async function listConstraints({
   releaseId,
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
 }: ListConstraintsProps): Promise<ReleaseConstraintListResponse> {
   const params = new URLSearchParams()
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
 
   const result = (await client.request(

--- a/src/keygen/releases/list.ts
+++ b/src/keygen/releases/list.ts
@@ -6,14 +6,14 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
   filters?: ReleaseFilters
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
   filters,
 }: ListProps): Promise<ReleasesListResponse> {
@@ -21,11 +21,9 @@ export default async function list({
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
   if (filters?.status) {
     params.set("status", filters.status)

--- a/src/keygen/users/list.ts
+++ b/src/keygen/users/list.ts
@@ -6,14 +6,14 @@ config.validate()
 
 interface ListProps {
   limit?: number
-  pageNumber?: number
+  pageCursor?: string | null
   pageSize?: number
   filters?: UserFilters
 }
 
 export default async function list({
   limit,
-  pageNumber,
+  pageCursor,
   pageSize,
   filters,
 }: ListProps): Promise<UserListResponse> {
@@ -21,11 +21,9 @@ export default async function list({
   if (limit != null) {
     params.set("limit", limit.toString())
   }
-  if (pageNumber != null) {
-    params.set("page[number]", pageNumber.toString())
-  }
   if (pageSize != null) {
     params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
   }
   if (filters?.status) {
     params.set("status", filters.status)

--- a/src/pages/app/arch/list.tsx
+++ b/src/pages/app/arch/list.tsx
@@ -1,5 +1,6 @@
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useArchTableColumns } from "@/hooks/use-arch-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { Arch } from "@/types/arches"
@@ -13,6 +14,8 @@ import PageFooter from "@/components/page-footer"
 
 export default function ArchesList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
+  const { cursor, goToPage } = useCursors(page, setPage)
   const columns = useArchTableColumns()
 
   const {
@@ -20,11 +23,11 @@ export default function ArchesList() {
     links,
     isLoading: archesLoading,
   } = useListArches({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   return (
     <section className="flex h-screen flex-col">
@@ -35,16 +38,16 @@ export default function ArchesList() {
           data={arches}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={archesLoading}
         />
       </ScrollArea>
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={archesLoading}
         />
       </PageFooter>

--- a/src/pages/app/arch/list.tsx
+++ b/src/pages/app/arch/list.tsx
@@ -38,7 +38,6 @@ export default function ArchesList() {
           data={arches}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={archesLoading}
         />
       </ScrollArea>

--- a/src/pages/app/artifact/list.tsx
+++ b/src/pages/app/artifact/list.tsx
@@ -76,7 +76,6 @@ export default function ArtifactsList() {
           data={artifacts}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={artifactsLoading}
           onRowClick={(artifact) => navigateToResource(artifact)}
         />

--- a/src/pages/app/artifact/list.tsx
+++ b/src/pages/app/artifact/list.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useArtifactTableColumns } from "@/hooks/use-artifact-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
@@ -21,16 +22,18 @@ import PageFooter from "@/components/page-footer"
 
 export default function ArtifactsList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
   const columns = useArtifactTableColumns()
 
   const [filters, setFilters] = useFilterSearch<ArtifactFilters>()
+  const { cursor, reset, goToPage } = useCursors(page, setPage)
 
   const handleFiltersChange = useCallback(
     (next: ArtifactFilters) => {
       setFilters(next)
-      table.setPage(1)
+      reset()
     },
-    [table, setFilters],
+    [setFilters, reset],
   )
 
   const {
@@ -38,12 +41,12 @@ export default function ArtifactsList() {
     links,
     isLoading: artifactsLoading,
   } = useListArtifacts({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
     filters,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   const navigateToResource = useResourceNavigate()
 
@@ -73,7 +76,7 @@ export default function ArtifactsList() {
           data={artifacts}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={artifactsLoading}
           onRowClick={(artifact) => navigateToResource(artifact)}
         />
@@ -81,9 +84,9 @@ export default function ArtifactsList() {
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={artifactsLoading}
         />
       </PageFooter>

--- a/src/pages/app/channel/list.tsx
+++ b/src/pages/app/channel/list.tsx
@@ -1,5 +1,6 @@
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useChannelTableColumns } from "@/hooks/use-channel-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { Channel } from "@/types/channels"
@@ -13,6 +14,8 @@ import PageFooter from "@/components/page-footer"
 
 export default function ChannelsList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
+  const { cursor, goToPage } = useCursors(page, setPage)
   const columns = useChannelTableColumns()
 
   const {
@@ -20,11 +23,11 @@ export default function ChannelsList() {
     links,
     isLoading: channelsLoading,
   } = useListChannels({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   return (
     <section className="flex h-screen flex-col">
@@ -35,16 +38,16 @@ export default function ChannelsList() {
           data={channels}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={channelsLoading}
         />
       </ScrollArea>
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={channelsLoading}
         />
       </PageFooter>

--- a/src/pages/app/channel/list.tsx
+++ b/src/pages/app/channel/list.tsx
@@ -38,7 +38,6 @@ export default function ChannelsList() {
           data={channels}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={channelsLoading}
         />
       </ScrollArea>

--- a/src/pages/app/component/list.tsx
+++ b/src/pages/app/component/list.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useComponentTableColumns } from "@/hooks/use-component-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
@@ -21,16 +22,18 @@ import PageFooter from "@/components/page-footer"
 
 export default function ComponentsList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
   const columns = useComponentTableColumns()
 
   const [filters, setFilters] = useFilterSearch<ComponentFilters>()
+  const { cursor, reset, goToPage } = useCursors(page, setPage)
 
   const handleFiltersChange = useCallback(
     (next: ComponentFilters) => {
       setFilters(next)
-      table.setPage(1)
+      reset()
     },
-    [table, setFilters],
+    [setFilters, reset],
   )
 
   const {
@@ -38,12 +41,12 @@ export default function ComponentsList() {
     links,
     isLoading: componentsLoading,
   } = useListComponents({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
     filters,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   const navigateToResource = useResourceNavigate()
 
@@ -77,7 +80,7 @@ export default function ComponentsList() {
           data={components}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={componentsLoading}
           onRowClick={(component) => navigateToResource(component)}
         />
@@ -85,9 +88,9 @@ export default function ComponentsList() {
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={componentsLoading}
         />
       </PageFooter>

--- a/src/pages/app/component/list.tsx
+++ b/src/pages/app/component/list.tsx
@@ -80,7 +80,6 @@ export default function ComponentsList() {
           data={components}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={componentsLoading}
           onRowClick={(component) => navigateToResource(component)}
         />

--- a/src/pages/app/engine/list.tsx
+++ b/src/pages/app/engine/list.tsx
@@ -38,7 +38,6 @@ export default function EnginesList() {
           data={engines}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={enginesLoading}
         />
       </ScrollArea>

--- a/src/pages/app/engine/list.tsx
+++ b/src/pages/app/engine/list.tsx
@@ -1,5 +1,6 @@
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useEngineTableColumns } from "@/hooks/use-engine-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { Engine } from "@/types/engines"
@@ -13,6 +14,8 @@ import PageFooter from "@/components/page-footer"
 
 export default function EnginesList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
+  const { cursor, goToPage } = useCursors(page, setPage)
   const columns = useEngineTableColumns()
 
   const {
@@ -20,11 +23,11 @@ export default function EnginesList() {
     links,
     isLoading: enginesLoading,
   } = useListEngines({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   return (
     <section className="flex h-screen flex-col">
@@ -35,16 +38,16 @@ export default function EnginesList() {
           data={engines}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={enginesLoading}
         />
       </ScrollArea>
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={enginesLoading}
         />
       </PageFooter>

--- a/src/pages/app/entitlement/list.tsx
+++ b/src/pages/app/entitlement/list.tsx
@@ -60,7 +60,6 @@ export default function EntitlementsList() {
           data={entitlements}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={entitlementsLoading}
           onRowClick={(entitlement) => navigateToResource(entitlement)}
         />

--- a/src/pages/app/entitlement/list.tsx
+++ b/src/pages/app/entitlement/list.tsx
@@ -3,6 +3,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useEntitlementTableColumns } from "@/hooks/use-entitlement-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { Entitlement } from "@/types/entitlements"
@@ -20,6 +21,8 @@ import PageFooter from "@/components/page-footer"
 
 export default function EntitlementsList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
+  const { cursor, goToPage } = useCursors(page, setPage)
   const columns = useEntitlementTableColumns()
 
   const {
@@ -27,11 +30,11 @@ export default function EntitlementsList() {
     links,
     isLoading: entitlementsLoading,
   } = useListEntitlements({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   const navigateToResource = useResourceNavigate()
 
@@ -57,7 +60,7 @@ export default function EntitlementsList() {
           data={entitlements}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={entitlementsLoading}
           onRowClick={(entitlement) => navigateToResource(entitlement)}
         />
@@ -65,9 +68,9 @@ export default function EntitlementsList() {
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={entitlementsLoading}
         />
       </PageFooter>

--- a/src/pages/app/event-log/list.tsx
+++ b/src/pages/app/event-log/list.tsx
@@ -207,7 +207,6 @@ export default function EventLogList() {
         data={eventLogs}
         table={table}
         columns={columns}
-        pageCount={-1}
         isLoading={loading}
         onRowClick={(eventLog) =>
           navigate({

--- a/src/pages/app/group/list.tsx
+++ b/src/pages/app/group/list.tsx
@@ -60,7 +60,6 @@ export default function GroupsList() {
           data={groups}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={groupsLoading}
           onRowClick={(group) => navigateToResource(group)}
         />

--- a/src/pages/app/group/list.tsx
+++ b/src/pages/app/group/list.tsx
@@ -3,6 +3,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useGroupTableColumns } from "@/hooks/use-group-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { Group } from "@/types/groups"
@@ -20,6 +21,8 @@ import PageFooter from "@/components/page-footer"
 
 export default function GroupsList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
+  const { cursor, goToPage } = useCursors(page, setPage)
   const columns = useGroupTableColumns()
 
   const {
@@ -27,11 +30,11 @@ export default function GroupsList() {
     links,
     isLoading: groupsLoading,
   } = useListGroups({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   const navigateToResource = useResourceNavigate()
 
@@ -57,7 +60,7 @@ export default function GroupsList() {
           data={groups}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={groupsLoading}
           onRowClick={(group) => navigateToResource(group)}
         />
@@ -65,9 +68,9 @@ export default function GroupsList() {
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={groupsLoading}
         />
       </PageFooter>

--- a/src/pages/app/license/list.tsx
+++ b/src/pages/app/license/list.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react"
 
 import { Button } from "@/components/ui/button"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useLicenseTableColumns } from "@/hooks/use-license-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
@@ -21,16 +22,18 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 
 export default function LicensesList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
   const columns = useLicenseTableColumns()
 
   const [filters, setFilters] = useFilterSearch<LicenseFilters>()
+  const { cursor, reset, goToPage } = useCursors(page, setPage)
 
   const handleFiltersChange = useCallback(
     (next: LicenseFilters) => {
       setFilters(next)
-      table.setPage(1)
+      reset()
     },
-    [table, setFilters],
+    [setFilters, reset],
   )
 
   const {
@@ -38,12 +41,12 @@ export default function LicensesList() {
     links,
     isLoading: licensesLoading,
   } = useListLicenses({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
     filters,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   const navigateToResource = useResourceNavigate()
 
@@ -74,7 +77,7 @@ export default function LicensesList() {
           data={licenses}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={licensesLoading}
           onRowClick={(license) => navigateToResource(license)}
         />
@@ -82,9 +85,9 @@ export default function LicensesList() {
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={licensesLoading}
         />
       </PageFooter>

--- a/src/pages/app/license/list.tsx
+++ b/src/pages/app/license/list.tsx
@@ -77,7 +77,6 @@ export default function LicensesList() {
           data={licenses}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={licensesLoading}
           onRowClick={(license) => navigateToResource(license)}
         />

--- a/src/pages/app/machine/list.tsx
+++ b/src/pages/app/machine/list.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useMachineTableColumns } from "@/hooks/use-machine-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
@@ -21,16 +22,18 @@ import PageFooter from "@/components/page-footer"
 
 export default function MachinesList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
   const columns = useMachineTableColumns()
 
   const [filters, setFilters] = useFilterSearch<MachineFilters>()
+  const { cursor, reset, goToPage } = useCursors(page, setPage)
 
   const handleFiltersChange = useCallback(
     (next: MachineFilters) => {
       setFilters(next)
-      table.setPage(1)
+      reset()
     },
-    [table, setFilters],
+    [setFilters, reset],
   )
 
   const {
@@ -38,12 +41,12 @@ export default function MachinesList() {
     links,
     isLoading: machinesLoading,
   } = useListMachines({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
     filters,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   const navigateToResource = useResourceNavigate()
 
@@ -74,7 +77,7 @@ export default function MachinesList() {
           data={machines}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={machinesLoading}
           onRowClick={(machine) => navigateToResource(machine)}
         />
@@ -82,9 +85,9 @@ export default function MachinesList() {
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={machinesLoading}
         />
       </PageFooter>

--- a/src/pages/app/machine/list.tsx
+++ b/src/pages/app/machine/list.tsx
@@ -77,7 +77,6 @@ export default function MachinesList() {
           data={machines}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={machinesLoading}
           onRowClick={(machine) => navigateToResource(machine)}
         />

--- a/src/pages/app/package/list.tsx
+++ b/src/pages/app/package/list.tsx
@@ -76,7 +76,6 @@ export default function PackagesList() {
           data={packages}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={packagesLoading}
           onRowClick={(pkg) => navigateToResource(pkg)}
         />

--- a/src/pages/app/package/list.tsx
+++ b/src/pages/app/package/list.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { usePackageTableColumns } from "@/hooks/use-package-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
@@ -21,16 +22,18 @@ import PageFooter from "@/components/page-footer"
 
 export default function PackagesList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
   const columns = usePackageTableColumns()
 
   const [filters, setFilters] = useFilterSearch<PackageFilters>()
+  const { cursor, reset, goToPage } = useCursors(page, setPage)
 
   const handleFiltersChange = useCallback(
     (next: PackageFilters) => {
       setFilters(next)
-      table.setPage(1)
+      reset()
     },
-    [table, setFilters],
+    [setFilters, reset],
   )
 
   const {
@@ -38,12 +41,12 @@ export default function PackagesList() {
     links,
     isLoading: packagesLoading,
   } = useListPackages({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
     filters,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   const navigateToResource = useResourceNavigate()
 
@@ -73,7 +76,7 @@ export default function PackagesList() {
           data={packages}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={packagesLoading}
           onRowClick={(pkg) => navigateToResource(pkg)}
         />
@@ -81,9 +84,9 @@ export default function PackagesList() {
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={packagesLoading}
         />
       </PageFooter>

--- a/src/pages/app/platform/list.tsx
+++ b/src/pages/app/platform/list.tsx
@@ -38,7 +38,6 @@ export default function PlatformsList() {
           data={platforms}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={platformsLoading}
         />
       </ScrollArea>

--- a/src/pages/app/platform/list.tsx
+++ b/src/pages/app/platform/list.tsx
@@ -1,5 +1,6 @@
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { usePlatformTableColumns } from "@/hooks/use-platform-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { Platform } from "@/types/platforms"
@@ -13,6 +14,8 @@ import PageFooter from "@/components/page-footer"
 
 export default function PlatformsList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
+  const { cursor, goToPage } = useCursors(page, setPage)
   const columns = usePlatformTableColumns()
 
   const {
@@ -20,11 +23,11 @@ export default function PlatformsList() {
     links,
     isLoading: platformsLoading,
   } = useListPlatforms({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   return (
     <section className="flex h-screen flex-col">
@@ -35,16 +38,16 @@ export default function PlatformsList() {
           data={platforms}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={platformsLoading}
         />
       </ScrollArea>
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={platformsLoading}
         />
       </PageFooter>

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -77,7 +77,6 @@ export default function PoliciesList() {
           data={policies}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={policiesLoading}
           onRowClick={(policy) => navigateToResource(policy)}
         />

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { usePolicyTableColumns } from "@/hooks/use-policy-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
@@ -21,16 +22,18 @@ import PageFooter from "@/components/page-footer"
 
 export default function PoliciesList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
   const columns = usePolicyTableColumns()
 
   const [filters, setFilters] = useFilterSearch<PolicyFilters>()
+  const { cursor, reset, goToPage } = useCursors(page, setPage)
 
   const handleFiltersChange = useCallback(
     (next: PolicyFilters) => {
       setFilters(next)
-      table.setPage(1)
+      reset()
     },
-    [table, setFilters],
+    [setFilters, reset],
   )
 
   const {
@@ -38,12 +41,12 @@ export default function PoliciesList() {
     links,
     isLoading: policiesLoading,
   } = useListPolicies({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
     filters,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   const navigateToResource = useResourceNavigate()
 
@@ -74,7 +77,7 @@ export default function PoliciesList() {
           data={policies}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={policiesLoading}
           onRowClick={(policy) => navigateToResource(policy)}
         />
@@ -82,9 +85,9 @@ export default function PoliciesList() {
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={policiesLoading}
         />
       </PageFooter>

--- a/src/pages/app/process/list.tsx
+++ b/src/pages/app/process/list.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useProcessTableColumns } from "@/hooks/use-process-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
@@ -21,16 +22,18 @@ import PageFooter from "@/components/page-footer"
 
 export default function ProcessesList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
   const columns = useProcessTableColumns()
 
   const [filters, setFilters] = useFilterSearch<ProcessFilters>()
+  const { cursor, reset, goToPage } = useCursors(page, setPage)
 
   const handleFiltersChange = useCallback(
     (next: ProcessFilters) => {
       setFilters(next)
-      table.setPage(1)
+      reset()
     },
-    [table, setFilters],
+    [setFilters, reset],
   )
 
   const {
@@ -38,12 +41,12 @@ export default function ProcessesList() {
     links,
     isLoading: processesLoading,
   } = useListProcesses({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
     filters,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   const navigateToResource = useResourceNavigate()
 
@@ -74,7 +77,7 @@ export default function ProcessesList() {
           data={processes}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={processesLoading}
           onRowClick={(process) => navigateToResource(process)}
         />
@@ -82,9 +85,9 @@ export default function ProcessesList() {
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={processesLoading}
         />
       </PageFooter>

--- a/src/pages/app/process/list.tsx
+++ b/src/pages/app/process/list.tsx
@@ -77,7 +77,6 @@ export default function ProcessesList() {
           data={processes}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={processesLoading}
           onRowClick={(process) => navigateToResource(process)}
         />

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -3,6 +3,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useProductTableColumns } from "@/hooks/use-product-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { Product } from "@/types/products"
@@ -20,6 +21,8 @@ import PageFooter from "@/components/page-footer"
 
 export default function ProductsList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
+  const { cursor, goToPage } = useCursors(page, setPage)
   const columns = useProductTableColumns()
 
   const {
@@ -27,11 +30,11 @@ export default function ProductsList() {
     links,
     isLoading: productsLoading,
   } = useListProducts({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   const navigateToResource = useResourceNavigate()
 
@@ -57,7 +60,7 @@ export default function ProductsList() {
           data={products}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={productsLoading}
           onRowClick={(product) => navigateToResource(product)}
         />
@@ -65,9 +68,9 @@ export default function ProductsList() {
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={productsLoading}
         />
       </PageFooter>

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -60,7 +60,6 @@ export default function ProductsList() {
           data={products}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={productsLoading}
           onRowClick={(product) => navigateToResource(product)}
         />

--- a/src/pages/app/release/list.tsx
+++ b/src/pages/app/release/list.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useReleaseTableColumns } from "@/hooks/use-release-table-columns"
 import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
@@ -21,16 +22,18 @@ import PageFooter from "@/components/page-footer"
 
 export default function ReleasesList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
   const columns = useReleaseTableColumns()
 
   const [filters, setFilters] = useFilterSearch<ReleaseFilters>()
+  const { cursor, reset, goToPage } = useCursors(page, setPage)
 
   const handleFiltersChange = useCallback(
     (next: ReleaseFilters) => {
       setFilters(next)
-      table.setPage(1)
+      reset()
     },
-    [table, setFilters],
+    [setFilters, reset],
   )
 
   const {
@@ -38,12 +41,12 @@ export default function ReleasesList() {
     links,
     isLoading: releasesLoading,
   } = useListReleases({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
     filters,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   const navigateToResource = useResourceNavigate()
 
@@ -73,7 +76,7 @@ export default function ReleasesList() {
           data={releases}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={releasesLoading}
           onRowClick={(release) => navigateToResource(release)}
         />
@@ -81,9 +84,9 @@ export default function ReleasesList() {
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={releasesLoading}
         />
       </PageFooter>

--- a/src/pages/app/release/list.tsx
+++ b/src/pages/app/release/list.tsx
@@ -76,7 +76,6 @@ export default function ReleasesList() {
           data={releases}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={releasesLoading}
           onRowClick={(release) => navigateToResource(release)}
         />

--- a/src/pages/app/settings/team.tsx
+++ b/src/pages/app/settings/team.tsx
@@ -10,6 +10,7 @@ import { useGetAccount, useGetAccountPlan } from "@/queries/accounts"
 
 import { useMobile } from "@/hooks/use-mobile"
 import { useDataTable } from "@/hooks/use-data-table"
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { usePermissions } from "@/hooks/use-permissions"
 import { useTeamTableColumns } from "@/hooks/use-team-table-columns"
@@ -28,17 +29,19 @@ export default function TeamPage() {
   const isMobile = useMobile()
 
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
   const columns = useTeamTableColumns()
   const { can } = usePermissions()
 
   const [filters, setFilters] = useFilterSearch<UserFilters>()
+  const { cursor, reset, goToPage } = useCursors(page, setPage)
 
   const handleFiltersChange = useCallback(
     (next: UserFilters) => {
       setFilters(next)
-      table.setPage(1)
+      reset()
     },
-    [table, setFilters],
+    [setFilters, reset],
   )
 
   // NB(cazden) API requires 'admin.read' whenever an admin appears in the response,
@@ -56,8 +59,8 @@ export default function TeamPage() {
     links,
     isLoading: usersLoading,
   } = useListUsers({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
     filters: {
       ...filters,
       roles: requestRoles,
@@ -69,8 +72,7 @@ export default function TeamPage() {
     account?.relationships.plan?.data?.id,
   )
 
-  const totalPages = links?.meta?.pages ?? 1
-  const totalUsers = links?.meta?.count
+  const nextCursor = cursorFromLink(links?.next)
 
   const maxAdmins = plan?.attributes?.maxAdmins
   const planName = plan?.attributes?.name
@@ -85,27 +87,17 @@ export default function TeamPage() {
         <div className="flex w-full items-center gap-3">
           <h1 className="font-semibold text-content-muted">Team</h1>
           <Separator orientation="vertical" className="mt-0.5 ml-1 min-h-4" />
-          {totalUsers != null && !isMobile && (
+          {plan != null && !isMobile && (
             <p className="mt-0.25 text-sm text-content-subdued">
-              You currently have
+              Invite up to
               <Badge className="mx-1.5 min-h-4 min-w-4 text-xs text-content-muted">
-                {totalUsers}
+                {maxAdmins ?? "Unlimited"}
               </Badge>
-              {totalUsers === 1 ? "teammate" : "teammates"}.
-              {plan && (
-                <>
-                  {" "}
-                  Invite up to
-                  <Badge className="mx-1.5 min-h-4 min-w-4 text-xs text-content-muted">
-                    {maxAdmins ?? "Unlimited"}
-                  </Badge>
-                  while on the
-                  <Badge className="mx-1.5 min-h-4 min-w-4 text-xs text-content-muted">
-                    {planName}
-                  </Badge>
-                  tier.
-                </>
-              )}
+              while on the
+              <Badge className="mx-1.5 min-h-4 min-w-4 text-xs text-content-muted">
+                {planName}
+              </Badge>
+              tier.
             </p>
           )}
         </div>
@@ -117,29 +109,19 @@ export default function TeamPage() {
       </PageHeader>
 
       {/* Mobile */}
-      {totalUsers != null && isMobile && (
+      {plan != null && isMobile && (
         <div className="flex min-w-0 flex-col border-b border-accent p-2 text-sm text-content-subdued">
           <span>
-            You currently have
+            Invite up to
             <Badge className="mx-1.5 min-h-4 min-w-4 text-xs text-content-muted">
-              {totalUsers}
+              {maxAdmins ?? "Unlimited"}
             </Badge>
-            {totalUsers === 1 ? "teammate" : "teammates"}.
+            while on the
+            <Badge className="mx-1.5 min-h-4 min-w-4 text-xs text-content-muted">
+              {planName}
+            </Badge>
+            tier.
           </span>
-          {plan && (
-            <span>
-              {" "}
-              Invite up to
-              <Badge className="mx-1.5 min-h-4 min-w-4 text-xs text-content-muted">
-                {maxAdmins ?? "Unlimited"}
-              </Badge>
-              while on the
-              <Badge className="mx-1.5 min-h-4 min-w-4 text-xs text-content-muted">
-                {planName}
-              </Badge>
-              tier.
-            </span>
-          )}
         </div>
       )}
 
@@ -152,7 +134,7 @@ export default function TeamPage() {
           data={users}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={usersLoading}
           onRowClick={(user) => navigateToResource(user)}
         />
@@ -160,9 +142,9 @@ export default function TeamPage() {
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={usersLoading}
         />
       </PageFooter>

--- a/src/pages/app/settings/team.tsx
+++ b/src/pages/app/settings/team.tsx
@@ -134,7 +134,6 @@ export default function TeamPage() {
           data={users}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={usersLoading}
           onRowClick={(user) => navigateToResource(user)}
         />

--- a/src/pages/app/user/list.tsx
+++ b/src/pages/app/user/list.tsx
@@ -79,7 +79,6 @@ export default function UsersList() {
           data={users}
           table={table}
           columns={columns}
-          pageCount={-1}
           isLoading={usersLoading}
           onRowClick={(user) => navigateToResource(user)}
         />

--- a/src/pages/app/user/list.tsx
+++ b/src/pages/app/user/list.tsx
@@ -3,6 +3,7 @@ import { useState, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useUserTableColumns } from "@/hooks/use-user-table-columns"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { useDataTable } from "@/hooks/use-data-table"
@@ -21,18 +22,20 @@ import PageFooter from "@/components/page-footer"
 
 export default function UsersList() {
   const table = useDataTable()
+  const { page, pageSize, setPage } = table
   const columns = useUserTableColumns()
 
   const [filters, setFilters] = useFilterSearch<UserFilters>({
     roles: [UserRole.User],
   })
+  const { cursor, reset, goToPage } = useCursors(page, setPage)
 
   const handleFiltersChange = useCallback(
     (next: UserFilters) => {
       setFilters(next)
-      table.setPage(1)
+      reset()
     },
-    [table, setFilters],
+    [setFilters, reset],
   )
 
   const {
@@ -40,12 +43,12 @@ export default function UsersList() {
     links,
     isLoading: usersLoading,
   } = useListUsers({
-    page: table.page,
-    pageSize: table.pageSize,
+    cursor,
+    pageSize,
     filters,
   })
 
-  const totalPages = links?.meta?.pages ?? 1
+  const nextCursor = cursorFromLink(links?.next)
 
   const navigateToResource = useResourceNavigate()
 
@@ -76,7 +79,7 @@ export default function UsersList() {
           data={users}
           table={table}
           columns={columns}
-          pageCount={totalPages}
+          pageCount={-1}
           isLoading={usersLoading}
           onRowClick={(user) => navigateToResource(user)}
         />
@@ -84,9 +87,9 @@ export default function UsersList() {
 
       <PageFooter>
         <Pagination
-          page={table.page}
-          pageCount={totalPages}
-          onPageChange={table.setPage}
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
           isLoading={usersLoading}
         />
       </PageFooter>

--- a/src/queries/arches.ts
+++ b/src/queries/arches.ts
@@ -25,7 +25,7 @@ export function useGetArch(archId: string) {
 }
 
 export function useListArches(
-  params?: { page: number; pageSize: number },
+  params?: { cursor?: string | null; pageSize?: number },
   options?: { enabled?: boolean },
 ) {
   const { code } = useEnvironment()
@@ -34,7 +34,7 @@ export function useListArches(
     queryKey: ["arches", { environment: code, ...params }],
     queryFn: async () => {
       const response = await keygen.arches.list(
-        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+        params ? { pageCursor: params.cursor, pageSize: params.pageSize } : {},
       )
 
       if (response.errors) {

--- a/src/queries/artifacts.ts
+++ b/src/queries/artifacts.ts
@@ -36,8 +36,8 @@ export function useGetArtifact(artifactId: string) {
 
 export function useListArtifacts(
   params?: {
-    page: number
-    pageSize: number
+    cursor?: string | null
+    pageSize?: number
     filters?: ArtifactFilters
   },
   options?: { enabled?: boolean },
@@ -50,7 +50,7 @@ export function useListArtifacts(
       const response = await keygen.artifacts.list(
         params
           ? {
-              pageNumber: params.page,
+              pageCursor: params.cursor,
               pageSize: params.pageSize,
               filters: params.filters,
             }

--- a/src/queries/channels.ts
+++ b/src/queries/channels.ts
@@ -24,14 +24,17 @@ export function useGetChannel(channelId: string) {
   })
 }
 
-export function useListChannels(params?: { page: number; pageSize: number }) {
+export function useListChannels(params?: {
+  cursor?: string | null
+  pageSize?: number
+}) {
   const { code } = useEnvironment()
 
   const query = useQuery({
     queryKey: ["channels", { environment: code, ...params }],
     queryFn: async () => {
       const response = await keygen.channels.list(
-        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+        params ? { pageCursor: params.cursor, pageSize: params.pageSize } : {},
       )
 
       if (response.errors) {

--- a/src/queries/components.ts
+++ b/src/queries/components.ts
@@ -31,8 +31,8 @@ export function useGetComponent(componentId: string) {
 }
 
 export function useListComponents(params?: {
-  page: number
-  pageSize: number
+  cursor?: string | null
+  pageSize?: number
   filters?: ComponentFilters
 }) {
   const { code } = useEnvironment()
@@ -43,7 +43,7 @@ export function useListComponents(params?: {
       const response = await keygen.components.list(
         params
           ? {
-              pageNumber: params.page,
+              pageCursor: params.cursor,
               pageSize: params.pageSize,
               filters: params.filters,
             }

--- a/src/queries/engines.ts
+++ b/src/queries/engines.ts
@@ -24,14 +24,17 @@ export function useGetEngine(engineId: string) {
   })
 }
 
-export function useListEngines(params?: { page: number; pageSize: number }) {
+export function useListEngines(params?: {
+  cursor?: string | null
+  pageSize?: number
+}) {
   const { code } = useEnvironment()
 
   const query = useQuery({
     queryKey: ["engines", { environment: code, ...params }],
     queryFn: async () => {
       const response = await keygen.engines.list(
-        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+        params ? { pageCursor: params.cursor, pageSize: params.pageSize } : {},
       )
 
       if (response.errors) {

--- a/src/queries/entitlements.ts
+++ b/src/queries/entitlements.ts
@@ -30,8 +30,8 @@ export function useGetEntitlement(entitlementId: string) {
 
 export function useListEntitlements(
   params?: {
-    page: number
-    pageSize: number
+    cursor?: string | null
+    pageSize?: number
   },
   options?: { enabled?: boolean },
 ) {
@@ -41,7 +41,7 @@ export function useListEntitlements(
     queryKey: ["entitlements", { environment: code, ...params }],
     queryFn: async () => {
       const response = await keygen.entitlements.list(
-        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+        params ? { pageCursor: params.cursor, pageSize: params.pageSize } : {},
       )
 
       if (response.errors) {

--- a/src/queries/environments.ts
+++ b/src/queries/environments.ts
@@ -19,14 +19,14 @@ export function useGetEnvironment(environmentId: string) {
 }
 
 export function useListEnvironments(params?: {
-  page: number
-  pageSize: number
+  cursor?: string | null
+  pageSize?: number
 }) {
   const query = useQuery({
     queryKey: ["environments", { ...params }],
     queryFn: async () => {
       const response = await keygen.environments.list(
-        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+        params ? { pageCursor: params.cursor, pageSize: params.pageSize } : {},
       )
 
       if (response.errors) {

--- a/src/queries/groups.ts
+++ b/src/queries/groups.ts
@@ -31,7 +31,7 @@ export function useGetGroup(groupId: string) {
 }
 
 export function useListGroups(
-  params?: { page: number; pageSize: number },
+  params?: { cursor?: string | null; pageSize?: number },
   options?: { enabled?: boolean },
 ) {
   const { code } = useEnvironment()
@@ -40,7 +40,7 @@ export function useListGroups(
     queryKey: ["groups", { environment: code, ...params }],
     queryFn: async () => {
       const response = await keygen.groups.list(
-        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+        params ? { pageCursor: params.cursor, pageSize: params.pageSize } : {},
       )
 
       if (response.errors) {

--- a/src/queries/licenses.ts
+++ b/src/queries/licenses.ts
@@ -33,8 +33,8 @@ export function useGetLicense(licenseId: string) {
 
 export function useListLicenses(
   params?: {
-    page: number
-    pageSize: number
+    cursor?: string | null
+    pageSize?: number
     filters?: LicenseFilters
   },
   options?: { enabled?: boolean },
@@ -47,7 +47,7 @@ export function useListLicenses(
       const response = await keygen.licenses.list(
         params
           ? {
-              pageNumber: params.page,
+              pageCursor: params.cursor,
               pageSize: params.pageSize,
               filters: params.filters,
             }

--- a/src/queries/machines.ts
+++ b/src/queries/machines.ts
@@ -33,8 +33,8 @@ export function useGetMachine(machineId: string) {
 
 export function useListMachines(
   params?: {
-    page: number
-    pageSize: number
+    cursor?: string | null
+    pageSize?: number
     filters?: MachineFilters
   },
   options?: { enabled?: boolean },
@@ -47,7 +47,7 @@ export function useListMachines(
       const response = await keygen.machines.list(
         params
           ? {
-              pageNumber: params.page,
+              pageCursor: params.cursor,
               pageSize: params.pageSize,
               filters: params.filters,
             }

--- a/src/queries/packages.ts
+++ b/src/queries/packages.ts
@@ -30,7 +30,11 @@ export function useGetPackage(packageId: string) {
 }
 
 export function useListPackages(
-  params?: { page: number; pageSize: number; filters?: PackageFilters },
+  params?: {
+    cursor?: string | null
+    pageSize?: number
+    filters?: PackageFilters
+  },
   options?: { enabled?: boolean },
 ) {
   const { code } = useEnvironment()
@@ -41,7 +45,7 @@ export function useListPackages(
       const response = await keygen.packages.list(
         params
           ? {
-              pageNumber: params.page,
+              pageCursor: params.cursor,
               pageSize: params.pageSize,
               filters: params.filters,
             }

--- a/src/queries/platforms.ts
+++ b/src/queries/platforms.ts
@@ -25,7 +25,7 @@ export function useGetPlatform(platformId: string) {
 }
 
 export function useListPlatforms(
-  params?: { page: number; pageSize: number },
+  params?: { cursor?: string | null; pageSize?: number },
   options?: { enabled?: boolean },
 ) {
   const { code } = useEnvironment()
@@ -34,7 +34,7 @@ export function useListPlatforms(
     queryKey: ["platforms", { environment: code, ...params }],
     queryFn: async () => {
       const response = await keygen.platforms.list(
-        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+        params ? { pageCursor: params.cursor, pageSize: params.pageSize } : {},
       )
 
       if (response.errors) {

--- a/src/queries/policies.ts
+++ b/src/queries/policies.ts
@@ -31,7 +31,11 @@ export function useGetPolicy(policyId: string) {
 }
 
 export function useListPolicies(
-  params?: { page: number; pageSize: number; filters?: PolicyFilters },
+  params?: {
+    cursor?: string | null
+    pageSize?: number
+    filters?: PolicyFilters
+  },
   options?: { enabled?: boolean },
 ) {
   const { code } = useEnvironment()
@@ -42,7 +46,7 @@ export function useListPolicies(
       const response = await keygen.policies.list(
         params
           ? {
-              pageNumber: params.page,
+              pageCursor: params.cursor,
               pageSize: params.pageSize,
               filters: params.filters,
             }

--- a/src/queries/processes.ts
+++ b/src/queries/processes.ts
@@ -31,8 +31,8 @@ export function useGetProcess(processId: string) {
 }
 
 export function useListProcesses(params?: {
-  page: number
-  pageSize: number
+  cursor?: string | null
+  pageSize?: number
   filters?: ProcessFilters
 }) {
   const { code } = useEnvironment()
@@ -43,7 +43,7 @@ export function useListProcesses(params?: {
       const response = await keygen.processes.list(
         params
           ? {
-              pageNumber: params.page,
+              pageCursor: params.cursor,
               pageSize: params.pageSize,
               filters: params.filters,
             }

--- a/src/queries/products.ts
+++ b/src/queries/products.ts
@@ -28,7 +28,7 @@ export function useGetProduct(productId: string) {
 }
 
 export function useListProducts(
-  params?: { page: number; pageSize: number },
+  params?: { cursor?: string | null; pageSize?: number },
   options?: { enabled?: boolean },
 ) {
   const { code } = useEnvironment()
@@ -37,7 +37,7 @@ export function useListProducts(
     queryKey: ["products", { environment: code, ...params }],
     queryFn: async () => {
       const response = await keygen.products.list(
-        params ? { pageNumber: params.page, pageSize: params.pageSize } : {},
+        params ? { pageCursor: params.cursor, pageSize: params.pageSize } : {},
       )
 
       if (response.errors) {

--- a/src/queries/releases.ts
+++ b/src/queries/releases.ts
@@ -30,7 +30,11 @@ export function useGetRelease(releaseId: string) {
 }
 
 export function useListReleases(
-  params?: { page: number; pageSize: number; filters?: ReleaseFilters },
+  params?: {
+    cursor?: string | null
+    pageSize?: number
+    filters?: ReleaseFilters
+  },
   options?: { enabled?: boolean },
 ) {
   const { code } = useEnvironment()
@@ -41,7 +45,7 @@ export function useListReleases(
       const response = await keygen.releases.list(
         params
           ? {
-              pageNumber: params.page,
+              pageCursor: params.cursor,
               pageSize: params.pageSize,
               filters: params.filters,
             }

--- a/src/queries/users.ts
+++ b/src/queries/users.ts
@@ -31,7 +31,7 @@ export function useGetUser(userId: string) {
 export type { UserFilters }
 
 export function useListUsers(
-  params?: { page: number; pageSize: number; filters?: UserFilters },
+  params?: { cursor?: string | null; pageSize?: number; filters?: UserFilters },
   options?: { enabled?: boolean },
 ) {
   const { code } = useEnvironment()
@@ -42,7 +42,7 @@ export function useListUsers(
       const response = await keygen.users.list(
         params
           ? {
-              pageNumber: params.page,
+              pageCursor: params.cursor,
               pageSize: params.pageSize,
               filters: params.filters,
             }


### PR DESCRIPTION
Closes #129, closes #131. Replaces offset-based pagination with cursor-based across all paginated lists, building off what #203 implemented for event logs.

<img width="700" src="https://github.com/user-attachments/assets/dbb86d76-3514-4571-ae9d-9151811d7af4" />

Worth noting that the team page no longer shows a teammate count in the header, since it was derived from the previous offset-based pagination via `meta.count`.
<img width="300" src="https://github.com/user-attachments/assets/744a3344-2e98-4f88-a9e9-3609dbcf2ad3" />
