### PR TITLE
Add request logs

### DIFF
--- a/src/components/code.tsx
+++ b/src/components/code.tsx
@@ -1,0 +1,50 @@
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+
+import { Copy } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { copyToClipboard } from "@/lib/clipboard"
+
+interface CodeProps {
+  value: string
+  className?: string
+}
+
+export default function Code({
+  value,
+  className,
+}: CodeProps): React.ReactElement {
+  return (
+    <div className={cn("p-4", className)}>
+      {value ? (
+        <div
+          className="relative w-full min-w-0"
+          style={{ contain: "inline-size" }}
+        >
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => copyToClipboard(value)}
+            className="absolute top-3 right-3 z-10 h-7 w-7 bg-accent/60 md:bg-accent/0"
+          >
+            <Copy className="size-3.5" />
+          </Button>
+
+          <ScrollArea
+            className="max-h-96 rounded border border-accent"
+            orientation="both"
+          >
+            <pre className="w-max min-w-full p-3 pr-12 font-mono text-sm leading-snug whitespace-pre">
+              {value}
+            </pre>
+          </ScrollArea>
+        </div>
+      ) : (
+        <p className="rounded border border-accent p-3 font-mono text-sm text-content-muted">
+          {"{}"}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/diff.tsx
+++ b/src/components/diff.tsx
@@ -91,7 +91,7 @@ export default function Diff({ entries, className }: DiffProps): ReactElement {
   return (
     <div className={cn("p-4", className)}>
       {entries.length > 0 ? (
-        <div className="relative">
+        <div className="relative" style={{ contain: "inline-size" }}>
           <ScrollArea
             className="max-h-64 rounded border border-accent"
             orientation="both"

--- a/src/components/event-logs/feed.tsx
+++ b/src/components/event-logs/feed.tsx
@@ -214,13 +214,6 @@ export default function EventLogFeed({
   const nextCursor = cursorFromLink(links?.next)
   const loading = isLoading || isFetching
 
-  // Scope the per-event "View request logs" link to the resource this feed is
-  // filtered by, so it acts as a pseudo request-log detail view for now.
-  const requestLogsResource =
-    filters?.resource && typeof filters.resource === "object"
-      ? filters.resource
-      : undefined
-
   return (
     <div className={cn("flex min-h-0 flex-1 flex-col", className)}>
       <div className="min-h-0 flex-1 overflow-y-auto">
@@ -241,7 +234,6 @@ export default function EventLogFeed({
                   eventLog={eventLog}
                   isFirst={index === 0}
                   isLast={index === eventLogs.length - 1}
-                  requestLogsResource={requestLogsResource}
                 />
               ))
             ) : (

--- a/src/components/event-logs/feed.tsx
+++ b/src/components/event-logs/feed.tsx
@@ -50,12 +50,10 @@ function EventLogLinkRow({
 function EventLogRow({
   eventLog,
   isFirst,
-  requestLogsResource,
 }: {
   eventLog: EventLog
   isFirst: boolean
   isLast: boolean
-  requestLogsResource?: { type: string; id: string }
 }) {
   const [open, setOpen] = useState(false)
   const toggle = () => setOpen((current) => !current)
@@ -117,21 +115,22 @@ function EventLogRow({
             <Can
               permission="request-log.read"
               fallback={
-                <ResourceLink linkage={request} buttonClassName="text-xs" />
+                <EventLogLinkRow label="Request">
+                  <ResourceLink linkage={request} buttonClassName="text-xs" />
+                </EventLogLinkRow>
               }
             >
               <EventLogLinkRow label="Request">
-                <GoToButton
-                  path="/$accountId/app/request-logs"
-                  params={{ accountId: keygen.config.id }}
-                  search={
-                    requestLogsResource
-                      ? { resource: requestLogsResource }
-                      : undefined
-                  }
-                  label="View request logs"
-                  buttonClassName="text-xs"
-                />
+                {request ? (
+                  <GoToButton
+                    path="/$accountId/app/request-logs/$id"
+                    params={{ accountId: keygen.config.id, id: request.id }}
+                    label="View request log"
+                    buttonClassName="text-xs"
+                  />
+                ) : (
+                  <ResourceLink linkage={request} buttonClassName="text-xs" />
+                )}
               </EventLogLinkRow>
             </Can>
             <EventLogLinkRow label="Details">

--- a/src/components/event-logs/feed.tsx
+++ b/src/components/event-logs/feed.tsx
@@ -19,6 +19,7 @@ import { cn } from "@/lib/utils"
 import * as keygen from "@/keygen"
 import * as Motion from "@/components/motion"
 import * as Skeletons from "@/components/skeletons"
+import Can from "@/components/can"
 import Pagination from "@/components/pagination"
 import GoToButton from "@/components/go-to-button"
 import ResourceLink from "@/components/resource-link"
@@ -49,10 +50,12 @@ function EventLogLinkRow({
 function EventLogRow({
   eventLog,
   isFirst,
+  requestLogsResource,
 }: {
   eventLog: EventLog
   isFirst: boolean
   isLast: boolean
+  requestLogsResource?: { type: string; id: string }
 }) {
   const [open, setOpen] = useState(false)
   const toggle = () => setOpen((current) => !current)
@@ -111,9 +114,26 @@ function EventLogRow({
             <EventLogLinkRow label="Actor">
               <ResourceLink linkage={whodunnit} buttonClassName="text-xs" />
             </EventLogLinkRow>
-            <EventLogLinkRow label="Request">
-              <ResourceLink linkage={request} buttonClassName="text-xs" />
-            </EventLogLinkRow>
+            <Can
+              permission="request-log.read"
+              fallback={
+                <ResourceLink linkage={request} buttonClassName="text-xs" />
+              }
+            >
+              <EventLogLinkRow label="Request">
+                <GoToButton
+                  path="/$accountId/app/request-logs"
+                  params={{ accountId: keygen.config.id }}
+                  search={
+                    requestLogsResource
+                      ? { resource: requestLogsResource }
+                      : undefined
+                  }
+                  label="View request logs"
+                  buttonClassName="text-xs"
+                />
+              </EventLogLinkRow>
+            </Can>
             <EventLogLinkRow label="Details">
               <GoToButton
                 path="/$accountId/app/event-logs/$id"
@@ -194,6 +214,13 @@ export default function EventLogFeed({
   const nextCursor = cursorFromLink(links?.next)
   const loading = isLoading || isFetching
 
+  // Scope the per-event "View request logs" link to the resource this feed is
+  // filtered by, so it acts as a pseudo request-log detail view for now.
+  const requestLogsResource =
+    filters?.resource && typeof filters.resource === "object"
+      ? filters.resource
+      : undefined
+
   return (
     <div className={cn("flex min-h-0 flex-1 flex-col", className)}>
       <div className="min-h-0 flex-1 overflow-y-auto">
@@ -214,6 +241,7 @@ export default function EventLogFeed({
                   eventLog={eventLog}
                   isFirst={index === 0}
                   isLast={index === eventLogs.length - 1}
+                  requestLogsResource={requestLogsResource}
                 />
               ))
             ) : (

--- a/src/components/event-logs/feed.tsx
+++ b/src/components/event-logs/feed.tsx
@@ -112,14 +112,7 @@ function EventLogRow({
             <EventLogLinkRow label="Actor">
               <ResourceLink linkage={whodunnit} buttonClassName="text-xs" />
             </EventLogLinkRow>
-            <Can
-              permission="request-log.read"
-              fallback={
-                <EventLogLinkRow label="Request">
-                  <ResourceLink linkage={request} buttonClassName="text-xs" />
-                </EventLogLinkRow>
-              }
-            >
+            <Can permission="request-log.read">
               <EventLogLinkRow label="Request">
                 {request ? (
                   <GoToButton

--- a/src/components/event-logs/feed.tsx
+++ b/src/components/event-logs/feed.tsx
@@ -12,12 +12,8 @@ import { type EventLog, type EventLogFilters } from "@/types/event-logs"
 
 import { useListEventLogs } from "@/queries/event-logs"
 
-import {
-  eventLogBadgeVariant,
-  metadataDiffEntries,
-  formatEventLogTimestamp,
-  formatEventLogRelativeTime,
-} from "@/lib/event-logs"
+import { eventLogBadgeVariant, metadataDiffEntries } from "@/lib/event-logs"
+import { formatTimestamp, formatRelativeTime } from "@/lib/timestamps"
 import { cn } from "@/lib/utils"
 
 import * as keygen from "@/keygen"
@@ -64,7 +60,7 @@ function EventLogRow({
   const { event, metadata, created } = eventLog.attributes
   const whodunnit = eventLog.relationships.whodunnit?.data
   const request = eventLog.relationships.request?.data
-  const timestamp = formatEventLogTimestamp(created)
+  const timestamp = formatTimestamp(created)
   const changes = metadataDiffEntries(metadata).length
 
   return (
@@ -83,7 +79,7 @@ function EventLogRow({
         </div>
         <div className="mt-1 flex min-w-0 items-center gap-2 text-xs">
           <span className="shrink-0 text-content-muted" title={timestamp}>
-            {formatEventLogRelativeTime(created)}
+            {formatRelativeTime(created)}
           </span>
           <span className="min-w-0 truncate text-content-normal">
             {changes} {changes === 1 ? "change" : "changes"}

--- a/src/components/event-logs/preview.tsx
+++ b/src/components/event-logs/preview.tsx
@@ -1,11 +1,11 @@
 import { Badge } from "@/components/ui/badge"
 
-import { type EventLogZonedTimestamp } from "@/lib/event-logs"
+import { type ZonedTimestamp } from "@/lib/timestamps"
 
 export type EventLogPreview = {
   relative: string
-  utc: EventLogZonedTimestamp
-  local: EventLogZonedTimestamp
+  utc: ZonedTimestamp
+  local: ZonedTimestamp
 }
 
 export interface EventLogPreviewHandlers {

--- a/src/components/filter-bar/enum-filter.tsx
+++ b/src/components/filter-bar/enum-filter.tsx
@@ -16,6 +16,11 @@ export interface EnumFilterProps {
   options: ReadonlyArray<{ value: string; label: string }>
   value?: string
   onChange: (value: string | undefined) => void
+  popoverClassName?: string
+  renderOption?: (
+    option: { value: string; label: string },
+    query: string,
+  ) => React.ReactNode
 }
 
 export default function EnumFilter({
@@ -24,6 +29,8 @@ export default function EnumFilter({
   options,
   value,
   onChange,
+  popoverClassName,
+  renderOption,
 }: EnumFilterProps) {
   const filter = useFilterState(value, options[0]?.value ?? "", onChange)
   const [open, setOpen] = useState(false)
@@ -52,6 +59,8 @@ export default function EnumFilter({
         open={open}
         onOpenChange={setOpen}
         onSelect={filter.handleChange}
+        popoverClassName={popoverClassName}
+        renderOption={renderOption}
       >
         {selected.label}
       </EnumFilterSegment>
@@ -66,6 +75,8 @@ export function EnumFilterSegment({
   onOpenChange,
   onSelect,
   children,
+  popoverClassName = "w-36",
+  renderOption,
 }: {
   options: ReadonlyArray<{ value: string; label: string }>
   value?: string
@@ -73,16 +84,22 @@ export function EnumFilterSegment({
   onOpenChange: (open: boolean) => void
   onSelect: (value: string) => void
   children: React.ReactNode
+  popoverClassName?: string
+  renderOption?: (
+    option: { value: string; label: string },
+    query: string,
+  ) => React.ReactNode
 }) {
   return (
     <FilterPopoverSegment
-      className="w-36"
+      className={popoverClassName}
       open={open}
       onOpenChange={onOpenChange}
       popover={(close) => (
         <FilterOptionList
           options={options}
           value={value}
+          renderOption={renderOption}
           onSelect={(v) => {
             onSelect(v)
             close()

--- a/src/components/filter-bar/filter-segment.tsx
+++ b/src/components/filter-bar/filter-segment.tsx
@@ -197,10 +197,15 @@ export function FilterOptionList({
   options,
   value,
   onSelect,
+  renderOption,
 }: {
   options: ReadonlyArray<{ value: string; label: string }>
   value?: string
   onSelect: (value: string) => void
+  renderOption?: (
+    option: { value: string; label: string },
+    query: string,
+  ) => React.ReactNode
 }) {
   const [query, setQuery] = useState("")
   const [activeIndex, setActiveIndex] = useState(0)
@@ -306,7 +311,9 @@ export function FilterOptionList({
                 onMouseEnter={() => setActiveIndex(index)}
                 onClick={() => onSelect(opt.value)}
               >
-                {renderHighlightedText(opt.label, query.trim())}
+                {renderOption
+                  ? renderOption(opt, query.trim())
+                  : renderHighlightedText(opt.label, query.trim())}
               </button>
             ))
           ) : (

--- a/src/components/metadata.tsx
+++ b/src/components/metadata.tsx
@@ -25,7 +25,7 @@ export default function Metadata({
     <div className={cn("p-4", className)}>
       {resource.attributes.metadata &&
       Object.keys(resource.attributes.metadata).length > 0 ? (
-        <div className="relative">
+        <div className="relative" style={{ contain: "inline-size" }}>
           <Button
             variant="ghost"
             size="icon"

--- a/src/components/request-logs/filter-bar.tsx
+++ b/src/components/request-logs/filter-bar.tsx
@@ -1,0 +1,161 @@
+import {
+  Hash,
+  Globe,
+  Link2,
+  UserRound,
+  MonitorCog,
+  CalendarRange,
+  ArrowLeftRight,
+} from "lucide-react"
+
+import { capitalize } from "@/lib/utils"
+
+import { type SearchableResource } from "@/types/search"
+import {
+  HTTP_METHODS,
+  HTTP_STATUS_CODES,
+  type RequestLogResourceFilter,
+} from "@/types/request-logs"
+
+import { type RequestLogFilters } from "@/queries/request-logs"
+
+import { useEdition } from "@/hooks/use-edition"
+
+import * as Filters from "@/components/filter-bar"
+import { type PolymorphicResourceType } from "@/components/filter-bar/polymorphic-resource-filter"
+
+const METHOD_OPTIONS = HTTP_METHODS.map((method) => ({
+  value: method,
+  label: method,
+}))
+
+const STATUS_OPTIONS = HTTP_STATUS_CODES.map(({ code, text }) => ({
+  value: code,
+  label: `${code} ${text}`,
+}))
+
+function resourceType(
+  value: string,
+  resource?: SearchableResource,
+): PolymorphicResourceType {
+  return { value, label: capitalize(value.replace(/-/g, " ")), resource }
+}
+
+const RESOURCE_TYPES: PolymorphicResourceType[] = [
+  resourceType("license", "licenses"),
+  resourceType("machine", "machines"),
+  resourceType("user", "users"),
+  resourceType("group", "groups"),
+  resourceType("policy", "policies"),
+  resourceType("product", "products"),
+  resourceType("entitlement", "entitlements"),
+  resourceType("release", "releases"),
+  resourceType("package", "packages"),
+  resourceType("account"),
+  resourceType("artifact"),
+  resourceType("component"),
+  resourceType("environment"),
+  resourceType("key"),
+  resourceType("process"),
+  resourceType("second-factor"),
+  resourceType("token"),
+]
+
+const REQUESTOR_TYPES: PolymorphicResourceType[] = [
+  resourceType("user", "users"),
+  resourceType("license", "licenses"),
+  resourceType("product", "products"),
+  resourceType("environment"),
+]
+
+interface RequestLogFilterBarProps {
+  filters: RequestLogFilters
+  onChange: (filters: RequestLogFilters) => void
+}
+
+function asPolymorphic(
+  value: RequestLogResourceFilter | undefined,
+): { type: string; id: string } | undefined {
+  return value && typeof value === "object" ? value : undefined
+}
+
+export default function RequestLogFilterBar({
+  filters,
+  onChange,
+}: RequestLogFilterBarProps) {
+  const { isCE } = useEdition()
+
+  const filterCount = Object.entries(filters).filter(([key, value]) => {
+    if (value == null) return false
+    if (key === "date") return !!(filters.date?.start && filters.date?.end)
+    return true
+  }).length
+
+  return (
+    <Filters.FilterBar
+      disabled={isCE}
+      filterCount={filterCount}
+      onClearAll={() => onChange({})}
+      pinned={
+        <Filters.DateRangeFilter
+          label="Date"
+          icon={CalendarRange}
+          value={filters.date}
+          onChange={(date) => onChange({ ...filters, date })}
+        />
+      }
+    >
+      <Filters.EnumFilter
+        label="Method"
+        icon={ArrowLeftRight}
+        options={METHOD_OPTIONS}
+        value={filters.method}
+        onChange={(method) => onChange({ ...filters, method })}
+      />
+      <Filters.EnumFilter
+        label="Status"
+        icon={Hash}
+        options={STATUS_OPTIONS}
+        value={filters.status}
+        onChange={(status) => onChange({ ...filters, status })}
+        popoverClassName="w-60"
+        renderOption={(option) => (
+          <span className="flex min-w-0 items-baseline gap-1.5">
+            <span className="shrink-0 font-mono">{option.value}</span>
+            <span className="min-w-0 truncate text-content-normal">
+              {option.label.slice(option.value.length + 1)}
+            </span>
+          </span>
+        )}
+      />
+      <Filters.StringFilter
+        label="IP"
+        icon={Globe}
+        placeholder="e.g. 1.1.1.1"
+        value={filters.ip}
+        onChange={(ip) => onChange({ ...filters, ip })}
+      />
+      <Filters.StringFilter
+        label="URL"
+        icon={Link2}
+        placeholder="e.g. /v1/..."
+        value={filters.url}
+        onChange={(url) => onChange({ ...filters, url })}
+      />
+      <Filters.PolymorphicResourceFilter
+        label="Resource"
+        icon={MonitorCog}
+        types={RESOURCE_TYPES}
+        value={asPolymorphic(filters.resource)}
+        onChange={(resource) => onChange({ ...filters, resource })}
+      />
+      <Filters.PolymorphicResourceFilter
+        label="Requestor"
+        icon={UserRound}
+        types={REQUESTOR_TYPES}
+        value={asPolymorphic(filters.requestor)}
+        onChange={(requestor) => onChange({ ...filters, requestor })}
+      />
+    </Filters.FilterBar>
+  )
+}

--- a/src/components/request-logs/index.ts
+++ b/src/components/request-logs/index.ts
@@ -1,1 +1,2 @@
+export { default as Upgrade } from "./upgrade"
 export { default as FilterBar } from "./filter-bar"

--- a/src/components/request-logs/index.ts
+++ b/src/components/request-logs/index.ts
@@ -1,0 +1,1 @@
+export { default as FilterBar } from "./filter-bar"

--- a/src/components/request-logs/preview.tsx
+++ b/src/components/request-logs/preview.tsx
@@ -1,0 +1,43 @@
+import { Badge } from "@/components/ui/badge"
+
+import { type ZonedTimestamp } from "@/lib/timestamps"
+
+export type RequestLogPreview = {
+  relative: string
+  utc: ZonedTimestamp
+  local: ZonedTimestamp
+}
+
+export interface RequestLogPreviewHandlers {
+  onOpenPreview: (preview: RequestLogPreview, event: React.MouseEvent) => void
+  onMovePreview: (event: React.MouseEvent) => void
+  onClosePreview: () => void
+}
+
+export function RequestLogPreviewContent({
+  preview,
+}: {
+  preview: RequestLogPreview
+}) {
+  return (
+    <div className="space-y-2.5">
+      <p className="font-medium text-content-loud">{preview.relative}</p>
+      {[preview.utc, preview.local].map((timestamp) => (
+        <div key={timestamp.label} className="flex items-center gap-2">
+          <Badge
+            variant="outline"
+            className="shrink-0 bg-background-3 font-mono"
+          >
+            {timestamp.label}
+          </Badge>
+          <span className="min-w-0 flex-1 truncate text-content-muted">
+            {timestamp.date}
+          </span>
+          <span className="shrink-0 font-mono text-content-normal">
+            {timestamp.time}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/request-logs/upgrade.tsx
+++ b/src/components/request-logs/upgrade.tsx
@@ -1,0 +1,45 @@
+import { type ReactNode } from "react"
+
+import { Button } from "@/components/ui/button"
+
+import { Lock } from "lucide-react"
+
+import LockedOverlay from "@/components/locked-overlay"
+import { useCloud } from "@/hooks/use-cloud"
+
+const UPGRADE_URL = "https://keygen.sh/pricing"
+
+export default function RequestLogsUpgrade({
+  children,
+  className,
+}: {
+  children: ReactNode
+  className?: string
+}) {
+  const { isCloud } = useCloud()
+
+  const title = isCloud
+    ? "Request logs is an Ent offering"
+    : "Request logs is an EE offering"
+  const description = isCloud
+    ? "Inspect and audit every API request across your account. Upgrade to an Ent tier to unlock request logs."
+    : "Inspect and audit every API request across your account. Upgrade to Keygen EE to unlock request logs."
+
+  return (
+    <LockedOverlay
+      className={className}
+      icon={<Lock className="size-4" />}
+      title={title}
+      description={description}
+      action={
+        <Button size="sm" asChild>
+          <a href={UPGRADE_URL} target="_blank" rel="noreferrer">
+            View Pricing
+          </a>
+        </Button>
+      }
+    >
+      {children}
+    </LockedOverlay>
+  )
+}

--- a/src/components/sidebar/panel.tsx
+++ b/src/components/sidebar/panel.tsx
@@ -233,6 +233,12 @@ const VIEWS: View[] = [
         params: { accountId: keygen.config.id },
         requires: ["event-log.read"],
       },
+      {
+        to: "/$accountId/app/request-logs",
+        label: "Request Logs",
+        params: { accountId: keygen.config.id },
+        requires: ["request-log.read"],
+      },
     ]),
   },
   {

--- a/src/components/skeletons/index.ts
+++ b/src/components/skeletons/index.ts
@@ -1,3 +1,4 @@
 export { default as Table } from "./table"
 export { default as EventLogs } from "./event-logs"
+export { default as RequestLogs } from "./request-logs"
 export { default as PolicyFields } from "./policy-fields"

--- a/src/components/skeletons/request-logs.tsx
+++ b/src/components/skeletons/request-logs.tsx
@@ -1,0 +1,107 @@
+import {
+  TableHeader,
+  TableHead,
+  TableRow,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table"
+
+import { cn } from "@/lib/utils"
+
+const REQUEST_LOG_SKELETON_COLUMNS = [
+  "Timestamp",
+  "IP",
+  "Status",
+  "Method",
+  "URL",
+] as const
+
+const REQUEST_LOG_SKELETON_ROWS = [
+  ["w-44", "w-28", "w-10", "w-14", "w-64"],
+  ["w-40", "w-32", "w-10", "w-16", "w-72"],
+  ["w-44", "w-24", "w-10", "w-14", "w-56"],
+  ["w-36", "w-28", "w-10", "w-16", "w-48"],
+  ["w-44", "w-32", "w-10", "w-14", "w-64"],
+  ["w-40", "w-24", "w-10", "w-12", "w-52"],
+  ["w-44", "w-28", "w-10", "w-16", "w-72"],
+  ["w-36", "w-32", "w-10", "w-14", "w-56"],
+  ["w-44", "w-24", "w-10", "w-16", "w-60"],
+  ["w-40", "w-28", "w-10", "w-12", "w-72"],
+  ["w-44", "w-32", "w-10", "w-14", "w-44"],
+  ["w-36", "w-24", "w-10", "w-16", "w-64"],
+  ["w-44", "w-28", "w-10", "w-14", "w-56"],
+  ["w-40", "w-32", "w-10", "w-16", "w-72"],
+  ["w-36", "w-24", "w-10", "w-12", "w-48"],
+  ["w-44", "w-28", "w-10", "w-14", "w-60"],
+  ["w-40", "w-32", "w-10", "w-16", "w-52"],
+  ["w-44", "w-24", "w-10", "w-14", "w-72"],
+  ["w-36", "w-28", "w-10", "w-16", "w-56"],
+  ["w-40", "w-32", "w-10", "w-12", "w-48"],
+  ["w-44", "w-24", "w-10", "w-14", "w-72"],
+  ["w-36", "w-28", "w-10", "w-16", "w-64"],
+  ["w-44", "w-32", "w-10", "w-14", "w-56"],
+  ["w-40", "w-24", "w-10", "w-16", "w-60"],
+  ["w-36", "w-28", "w-10", "w-12", "w-48"],
+  ["w-44", "w-32", "w-10", "w-14", "w-72"],
+  ["w-40", "w-24", "w-10", "w-16", "w-52"],
+  ["w-36", "w-28", "w-10", "w-14", "w-44"],
+] as const
+
+function StaticSkeleton({ className }: { className?: string }) {
+  return <span className={className} />
+}
+
+export default function RequestLogSkeleton() {
+  return (
+    <div className="relative min-w-full px-2">
+      <table className="min-w-full border-separate border-spacing-0 text-sm">
+        <TableHeader>
+          <TableRow>
+            {REQUEST_LOG_SKELETON_COLUMNS.map((column) => (
+              <TableHead
+                key={column}
+                className="border-b border-accent bg-background text-sm select-none md:text-xs"
+              >
+                <div className="flex h-6 items-center px-1 text-xs text-content-muted">
+                  {column}
+                </div>
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {REQUEST_LOG_SKELETON_ROWS.map((row, rowIndex) => (
+            <TableRow key={rowIndex} className="pointer-events-none">
+              {row.map((width, columnIndex) => (
+                <TableCell
+                  key={columnIndex}
+                  className="border-b border-accent bg-background"
+                >
+                  {columnIndex === 4 ? (
+                    <StaticSkeleton
+                      className={cn(
+                        "block h-[14px] animate-none rounded-[3px] bg-secondary/20",
+                        width,
+                      )}
+                    />
+                  ) : columnIndex === 0 ? (
+                    <StaticSkeleton
+                      className={cn("block h-3 rounded-sm bg-accent", width)}
+                    />
+                  ) : (
+                    <StaticSkeleton
+                      className={cn(
+                        "block h-5 rounded-sm bg-content-subdued/30",
+                        width,
+                      )}
+                    />
+                  )}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </table>
+    </div>
+  )
+}

--- a/src/hooks/use-event-log-table-columns.tsx
+++ b/src/hooks/use-event-log-table-columns.tsx
@@ -4,12 +4,12 @@ import { Badge } from "@/components/ui/badge"
 
 import { type EventLog } from "@/types/event-logs"
 
+import { eventLogBadgeVariant } from "@/lib/event-logs"
 import {
-  eventLogBadgeVariant,
-  formatEventLogRelativeTime,
-  formatEventLogUtcTimestamp,
-  formatEventLogLocalTimestamp,
-} from "@/lib/event-logs"
+  formatRelativeTime,
+  formatUtcTimestamp,
+  formatLocalTimestamp,
+} from "@/lib/timestamps"
 import { createTableColumnHelper } from "@/lib/tables"
 
 import {
@@ -22,9 +22,9 @@ const column = createTableColumnHelper<EventLog>()
 
 function timestampPreview(created: string): EventLogPreview {
   return {
-    relative: formatEventLogRelativeTime(created),
-    utc: formatEventLogUtcTimestamp(created),
-    local: formatEventLogLocalTimestamp(created),
+    relative: formatRelativeTime(created),
+    utc: formatUtcTimestamp(created),
+    local: formatLocalTimestamp(created),
   }
 }
 

--- a/src/hooks/use-request-log-table-columns.tsx
+++ b/src/hooks/use-request-log-table-columns.tsx
@@ -1,0 +1,123 @@
+import { useMemo } from "react"
+
+import { Badge } from "@/components/ui/badge"
+
+import { type RequestLog } from "@/types/request-logs"
+
+import {
+  requestLogMethodBadgeVariant,
+  requestLogStatusBadgeVariant,
+} from "@/lib/request-logs"
+import {
+  formatRelativeTime,
+  formatUtcTimestamp,
+  formatLocalTimestamp,
+} from "@/lib/timestamps"
+import { createTableColumnHelper } from "@/lib/tables"
+
+import {
+  type RequestLogPreview,
+  type RequestLogPreviewHandlers,
+} from "@/components/request-logs/preview"
+
+const column = createTableColumnHelper<RequestLog>()
+
+function timestampPreview(created: string): RequestLogPreview {
+  return {
+    relative: formatRelativeTime(created),
+    utc: formatUtcTimestamp(created),
+    local: formatLocalTimestamp(created),
+  }
+}
+
+export function useRequestLogTableColumns(handlers: RequestLogPreviewHandlers) {
+  const columns = useMemo(
+    () => [
+      column.attr("created", {
+        sortingFn: "datetime",
+        header: "Timestamp",
+        cell: (info) => {
+          const created = info.getValue()
+
+          return (
+            <span
+              className="block font-mono text-xs text-content-normal"
+              onMouseEnter={(event) =>
+                handlers.onOpenPreview(timestampPreview(created), event)
+              }
+              onMouseMove={handlers.onMovePreview}
+              onMouseLeave={handlers.onClosePreview}
+            >
+              {created}
+            </span>
+          )
+        },
+      }),
+      column.attr("ip", {
+        sortingFn: "alphanumeric",
+        header: "IP",
+        cell: (info) => {
+          const ip = info.getValue()
+
+          if (!ip) return <span className="text-content-muted">--</span>
+
+          return (
+            <span className="font-mono text-xs text-content-normal">{ip}</span>
+          )
+        },
+      }),
+      column.attr("status", {
+        sortingFn: "alphanumeric",
+        header: "Status",
+        cell: (info) => {
+          const status = info.getValue()
+
+          if (!status) return <span className="text-content-muted">--</span>
+
+          return (
+            <Badge
+              variant={requestLogStatusBadgeVariant(status)}
+              className="font-mono"
+            >
+              {status}
+            </Badge>
+          )
+        },
+      }),
+      column.attr("method", {
+        sortingFn: "alphanumeric",
+        header: "Method",
+        cell: (info) => {
+          const method = info.getValue()
+
+          if (!method) return <span className="text-content-muted">--</span>
+
+          return (
+            <Badge
+              variant={requestLogMethodBadgeVariant(method)}
+              className="font-mono"
+            >
+              {method}
+            </Badge>
+          )
+        },
+      }),
+      column.attr("url", {
+        sortingFn: "alphanumeric",
+        header: "URL",
+        cell: (info) => {
+          const url = info.getValue()
+
+          if (!url) return <span className="text-content-muted">--</span>
+
+          return (
+            <span className="font-mono text-xs text-content-normal">{url}</span>
+          )
+        },
+      }),
+    ],
+    [handlers],
+  )
+
+  return columns
+}

--- a/src/keygen/index.ts
+++ b/src/keygen/index.ts
@@ -76,6 +76,9 @@ export { engines }
 import * as eventLogs from "./event-logs"
 export { eventLogs }
 
+import * as requestLogs from "./request-logs"
+export { requestLogs }
+
 import { logout } from "./logout"
 export { logout }
 

--- a/src/keygen/request-logs/get.ts
+++ b/src/keygen/request-logs/get.ts
@@ -1,0 +1,22 @@
+import config from "@/keygen/config"
+import client from "@/keygen/client"
+import { RequestLogResponse } from "@/types/request-logs"
+
+config.validate()
+
+interface GetProps {
+  id: string
+}
+
+export default async function get({
+  id,
+}: GetProps): Promise<RequestLogResponse> {
+  const result = (await client.request(
+    `/accounts/${config.id}/request-logs/${id}`,
+    {
+      method: "GET",
+    },
+  )) as RequestLogResponse
+
+  return result
+}

--- a/src/keygen/request-logs/index.ts
+++ b/src/keygen/request-logs/index.ts
@@ -1,0 +1,1 @@
+export { default as list } from "./list"

--- a/src/keygen/request-logs/index.ts
+++ b/src/keygen/request-logs/index.ts
@@ -1,1 +1,2 @@
 export { default as list } from "./list"
+export { default as get } from "./get"

--- a/src/keygen/request-logs/list.ts
+++ b/src/keygen/request-logs/list.ts
@@ -1,0 +1,77 @@
+import config from "@/keygen/config"
+import client from "@/keygen/client"
+import {
+  RequestLogListResponse,
+  type RequestLogResourceFilter,
+  type RequestLogFilters,
+} from "@/types/request-logs"
+
+config.validate()
+
+interface ListProps {
+  limit?: number
+  pageCursor?: string | null
+  pageSize?: number
+  filters?: RequestLogFilters
+}
+
+function applyPolymorphicResourceFilter(
+  params: URLSearchParams,
+  key: "resource" | "requestor",
+  value: RequestLogResourceFilter | undefined,
+) {
+  if (!value) return
+
+  if (typeof value === "string") {
+    params.set(key, value)
+    return
+  }
+
+  params.set(`${key}[type]`, value.type)
+  params.set(`${key}[id]`, value.id)
+}
+
+export default async function list({
+  limit,
+  pageCursor,
+  pageSize,
+  filters,
+}: ListProps): Promise<RequestLogListResponse> {
+  const params = new URLSearchParams()
+  if (limit != null) {
+    params.set("limit", limit.toString())
+  }
+
+  if (pageSize != null) {
+    params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
+  }
+  if (filters?.method) {
+    params.set("method", filters.method)
+  }
+  if (filters?.status) {
+    params.set("status", filters.status)
+  }
+  if (filters?.ip) {
+    params.set("ip", filters.ip)
+  }
+  if (filters?.url) {
+    params.set("url", filters.url)
+  }
+  if (filters?.date?.start && filters?.date?.end) {
+    params.set("date[start]", filters.date.start)
+    params.set("date[end]", filters.date.end)
+  }
+
+  applyPolymorphicResourceFilter(params, "resource", filters?.resource)
+  applyPolymorphicResourceFilter(params, "requestor", filters?.requestor)
+
+  const result = (await client.request(
+    `/accounts/${config.id}/request-logs?${params.toString()}`,
+    {
+      method: "GET",
+    },
+  )) as RequestLogListResponse
+
+  return result
+}

--- a/src/lib/event-logs.ts
+++ b/src/lib/event-logs.ts
@@ -1,5 +1,3 @@
-import { format, formatDistanceToNowStrict } from "date-fns"
-
 import { type DiffEntry } from "@/components/diff"
 
 const DESTRUCTIVE_EVENT_RE = [
@@ -32,85 +30,6 @@ export function eventLogBadgeVariant(
   }
 
   return "secondary"
-}
-
-export function formatEventLogRelativeTime(value: string): string {
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return value
-
-  return formatDistanceToNowStrict(date, { addSuffix: true })
-}
-
-export function formatEventLogTimestamp(value: string): string {
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return value
-
-  return format(date, "PP p")
-}
-
-export type EventLogZonedTimestamp = {
-  label: string
-  date: string
-  time: string
-}
-
-function formatEventLogZonedTimestamp(
-  value: string,
-  timeZone: string,
-  label: string,
-): EventLogZonedTimestamp {
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) {
-    return {
-      label,
-      date: value,
-      time: "",
-    }
-  }
-
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: true,
-  }).formatToParts(date)
-
-  const valueFor = (type: Intl.DateTimeFormatPartTypes) =>
-    parts.find((part) => part.type === type)?.value ?? ""
-
-  return {
-    label,
-    date: `${valueFor("month")} ${valueFor("day")}, ${valueFor("year")}`,
-    time:
-      [valueFor("hour"), valueFor("minute"), valueFor("second")].join(":") +
-      ` ${valueFor("dayPeriod")}`,
-  }
-}
-
-export function formatEventLogUtcTimestamp(
-  value: string,
-): EventLogZonedTimestamp {
-  return formatEventLogZonedTimestamp(value, "UTC", "UTC")
-}
-
-export function formatEventLogLocalTimestamp(
-  value: string,
-): EventLogZonedTimestamp {
-  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) {
-    return {
-      label: "Local",
-      date: value,
-      time: "",
-    }
-  }
-
-  return formatEventLogZonedTimestamp(value, timeZone, "Local")
 }
 
 export function visibleMetadata(

--- a/src/lib/request-logs.ts
+++ b/src/lib/request-logs.ts
@@ -1,3 +1,8 @@
+import {
+  HTTP_STATUS_CODES,
+  type RequestLogAttributes,
+} from "@/types/request-logs"
+
 export function requestLogMethodBadgeVariant(
   method: string,
 ): "secondary" | "success" | "warning" | "destructive" {
@@ -23,4 +28,52 @@ export function requestLogStatusBadgeVariant(
   if (code >= 400) return "warning"
   if (code >= 200 && code < 300) return "success"
   return "secondary"
+}
+
+export function requestLogStatusText(status: string): string | undefined {
+  return HTTP_STATUS_CODES.find((entry) => entry.code === status)?.text
+}
+
+// attempts to parse string as JSON, but falls back to original
+// string if parsing fails or if value is falsy
+function parseBody(value: string | null | undefined): unknown {
+  if (value == null || value === "") return null
+
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
+}
+
+export function formatRequestLogRequest(
+  attributes: RequestLogAttributes,
+): string {
+  return JSON.stringify(
+    {
+      method: attributes.method,
+      url: attributes.url,
+      ip: attributes.ip,
+      userAgent: attributes.userAgent,
+      headers: attributes.requestHeaders ?? {},
+      body: parseBody(attributes.requestBody),
+    },
+    null,
+    2,
+  )
+}
+
+export function formatRequestLogResponse(
+  attributes: RequestLogAttributes,
+): string {
+  return JSON.stringify(
+    {
+      status: attributes.status,
+      headers: attributes.responseHeaders ?? {},
+      body: parseBody(attributes.responseBody),
+      signature: attributes.responseSignature ?? null,
+    },
+    null,
+    2,
+  )
 }

--- a/src/lib/request-logs.ts
+++ b/src/lib/request-logs.ts
@@ -1,0 +1,26 @@
+export function requestLogMethodBadgeVariant(
+  method: string,
+): "secondary" | "success" | "warning" | "destructive" {
+  switch (method.toUpperCase()) {
+    case "POST":
+      return "success"
+    case "PUT":
+    case "PATCH":
+      return "warning"
+    case "DELETE":
+      return "destructive"
+    default:
+      return "secondary"
+  }
+}
+
+export function requestLogStatusBadgeVariant(
+  status: string,
+): "secondary" | "success" | "warning" | "destructive" {
+  const code = Number(status)
+  if (Number.isNaN(code)) return "secondary"
+  if (code >= 500) return "destructive"
+  if (code >= 400) return "warning"
+  if (code >= 200 && code < 300) return "success"
+  return "secondary"
+}

--- a/src/lib/timestamps.ts
+++ b/src/lib/timestamps.ts
@@ -1,0 +1,76 @@
+import { format, formatDistanceToNowStrict } from "date-fns"
+
+export function formatRelativeTime(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  return formatDistanceToNowStrict(date, { addSuffix: true })
+}
+
+export function formatTimestamp(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  return format(date, "PP p")
+}
+
+export type ZonedTimestamp = {
+  label: string
+  date: string
+  time: string
+}
+
+function formatZonedTimestamp(
+  value: string,
+  timeZone: string,
+  label: string,
+): ZonedTimestamp {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return {
+      label,
+      date: value,
+      time: "",
+    }
+  }
+
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  }).formatToParts(date)
+
+  const valueFor = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value ?? ""
+
+  return {
+    label,
+    date: `${valueFor("month")} ${valueFor("day")}, ${valueFor("year")}`,
+    time:
+      [valueFor("hour"), valueFor("minute"), valueFor("second")].join(":") +
+      ` ${valueFor("dayPeriod")}`,
+  }
+}
+
+export function formatUtcTimestamp(value: string): ZonedTimestamp {
+  return formatZonedTimestamp(value, "UTC", "UTC")
+}
+
+export function formatLocalTimestamp(value: string): ZonedTimestamp {
+  const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return {
+      label: "Local",
+      date: value,
+      time: "",
+    }
+  }
+
+  return formatZonedTimestamp(value, timeZone, "Local")
+}

--- a/src/pages/app/index.ts
+++ b/src/pages/app/index.ts
@@ -16,6 +16,7 @@ export { default as Arches } from "./arches"
 export { default as Channels } from "./channels"
 export { default as Engines } from "./engines"
 export { default as EventLogs } from "./event-logs"
+export { default as RequestLogs } from "./request-logs"
 
 import * as Product from "./product"
 export { Product }
@@ -67,6 +68,9 @@ export { Engine }
 
 import * as EventLog from "./event-log"
 export { EventLog }
+
+import * as RequestLog from "./request-log"
+export { RequestLog }
 
 import * as Settings from "./settings"
 export { Settings }

--- a/src/pages/app/request-log/details.tsx
+++ b/src/pages/app/request-log/details.tsx
@@ -1,0 +1,261 @@
+import { useEffect } from "react"
+import { useParams } from "@tanstack/react-router"
+import { formatDate } from "date-fns"
+
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Separator } from "@/components/ui/separator"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent } from "@/components/ui/tabs"
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbPage,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+import {
+  Sidebar,
+  SidebarHeader,
+  SidebarContent,
+  SidebarFooter,
+} from "@/components/ui/sidebar"
+
+import { Copy, Menu, SquarePen, SquarePlus } from "lucide-react"
+
+import { useGetRequestLog } from "@/queries/request-logs"
+
+import { useMobile } from "@/hooks/use-mobile"
+import { useBackNavigate } from "@/hooks/use-back-navigate"
+
+import {
+  requestLogStatusText,
+  formatRequestLogRequest,
+  formatRequestLogResponse,
+  requestLogStatusBadgeVariant,
+  requestLogMethodBadgeVariant,
+} from "@/lib/request-logs"
+import { copyToClipboard } from "@/lib/clipboard"
+
+import * as Property from "@/components/property"
+import * as Attribute from "@/components/attribute"
+import Code from "@/components/code"
+import BackButton from "@/components/back-button"
+import PageHeader from "@/components/page-header"
+import TabsSwitch from "@/components/tabs-switch"
+import TooltipBadge from "@/components/tooltip-badge"
+import ResourceLink from "@/components/resource-link"
+import CollapsibleMenu from "@/components/collapsible-menu"
+import CollapsibleCard from "@/components/collapsible-card"
+
+export default function RequestLogDetails() {
+  const { id } = useParams({ from: "/$accountId/app/request-logs/$id" })
+  const { data: requestLog, isFetching, isError } = useGetRequestLog(id)
+  const back = useBackNavigate()
+  const isMobile = useMobile()
+
+  useEffect(() => {
+    ;(async () => {
+      if (isError && !isFetching) {
+        await back()
+      }
+    })()
+  }, [isError, isFetching, back])
+
+  const environment = requestLog?.relationships.environment?.data
+  const requestor = requestLog?.relationships.requestor?.data
+  const resource = requestLog?.relationships.resource?.data
+
+  return (
+    <section className="flex h-screen w-full">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <PageHeader>
+          <Breadcrumb className="flex-1">
+            <BreadcrumbList className="text-base">
+              <BreadcrumbItem>
+                <BreadcrumbLink
+                  className="cursor-pointer"
+                  onClick={() => back()}
+                >
+                  Request Logs
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                {requestLog ? (
+                  <BreadcrumbPage className="max-w-60 truncate md:max-w-2xl">
+                    <span className="font-mono">
+                      {requestLog.attributes.method} {requestLog.attributes.url}
+                    </span>
+                  </BreadcrumbPage>
+                ) : (
+                  <Skeleton className="h-6 w-32" />
+                )}
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        </PageHeader>
+
+        {requestLog ? (
+          <ScrollArea className="min-h-0 flex-1" orientation="both">
+            <div className="px-4 py-6 md:px-10 md:py-8">
+              <BackButton className="mb-8" />
+
+              <div className="flex flex-col items-start gap-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <TooltipBadge
+                    value={requestLog.attributes.method}
+                    variant={requestLogMethodBadgeVariant(
+                      requestLog.attributes.method,
+                    )}
+                    tooltip="The HTTP method of the request."
+                    className="gap-0 px-1 font-mono text-xs hover:gap-1"
+                  />
+                  <TooltipBadge
+                    value={requestLog.attributes.status}
+                    variant={requestLogStatusBadgeVariant(
+                      requestLog.attributes.status,
+                    )}
+                    tooltip={
+                      requestLogStatusText(requestLog.attributes.status) ??
+                      "The HTTP response status code."
+                    }
+                    className="gap-0 px-1 font-mono text-xs hover:gap-1"
+                  />
+                </div>
+
+                <Button
+                  variant="clipboard"
+                  size="clipboard"
+                  onClick={() => copyToClipboard(requestLog.id)}
+                  className="w-fit"
+                >
+                  {requestLog.id}
+                  <Copy className="size-4 pt-0.5 md:size-3" />
+                </Button>
+              </div>
+
+              <div className="mt-6 space-y-6 md:mt-8">
+                <CollapsibleCard title="Request" contentClass="p-0">
+                  <Code
+                    value={formatRequestLogRequest(requestLog.attributes)}
+                  />
+                </CollapsibleCard>
+
+                <CollapsibleCard title="Response" contentClass="p-0">
+                  <Code
+                    value={formatRequestLogResponse(requestLog.attributes)}
+                  />
+                </CollapsibleCard>
+
+                <CollapsibleCard title="Relationships">
+                  <div className="grid gap-4">
+                    <Attribute.Field
+                      variant="text"
+                      label="Environment"
+                      value={
+                        <ResourceLink
+                          linkage={environment}
+                          emptyLabel="Global"
+                        />
+                      }
+                    />
+                    <Attribute.Field
+                      variant="text"
+                      label="Requestor"
+                      value={<ResourceLink linkage={requestor} />}
+                    />
+                    <Attribute.Field
+                      variant="text"
+                      label="Resource"
+                      value={<ResourceLink linkage={resource} />}
+                    />
+                  </div>
+                </CollapsibleCard>
+
+                {isMobile && (
+                  <CollapsibleCard
+                    title="Other attributes"
+                    contentClass="space-y-2"
+                  >
+                    <CollapsibleMenu title="Properties" className="space-y-2">
+                      <Attribute.Field
+                        label="Created at"
+                        value={formatDate(
+                          new Date(String(requestLog.attributes.created)),
+                          "PP",
+                        )}
+                      />
+                      <Attribute.Field
+                        label="Updated at"
+                        value={formatDate(
+                          new Date(String(requestLog.attributes.updated)),
+                          "PP",
+                        )}
+                      />
+                    </CollapsibleMenu>
+                  </CollapsibleCard>
+                )}
+              </div>
+            </div>
+          </ScrollArea>
+        ) : (
+          <div className="space-y-4 p-4 md:px-10 md:py-8">
+            <Skeleton className="h-6 w-24" />
+            <Skeleton className="h-8 w-64" />
+            <Skeleton className="h-36 w-full" />
+            <Skeleton className="h-36 w-full" />
+          </div>
+        )}
+      </div>
+
+      {!isMobile && (
+        <Tabs defaultValue="overview">
+          <Sidebar className="w-64 shrink-0" side="right">
+            <SidebarHeader className="min-h-[70px] justify-end p-0">
+              <TabsSwitch
+                options={[{ value: "overview", label: "Overview", icon: Menu }]}
+              />
+            </SidebarHeader>
+            <SidebarContent>
+              <TabsContent value="overview">
+                {requestLog ? (
+                  <>
+                    <Property.Section title="Properties" className="p-4">
+                      <Property.Field
+                        icon={SquarePlus}
+                        label="Created at"
+                        value={formatDate(
+                          new Date(String(requestLog.attributes.created)),
+                          "PP",
+                        )}
+                      />
+                      <Property.Field
+                        icon={SquarePen}
+                        label="Updated at"
+                        value={formatDate(
+                          new Date(String(requestLog.attributes.updated)),
+                          "PP",
+                        )}
+                      />
+                    </Property.Section>
+
+                    <Separator />
+                  </>
+                ) : (
+                  <div className="flex flex-col space-y-2">
+                    <Skeleton className="h-4 w-3/4" />
+                    <Skeleton className="h-4 w-1/2" />
+                    <Skeleton className="h-4 w-1/3" />
+                  </div>
+                )}
+              </TabsContent>
+            </SidebarContent>
+            <SidebarFooter className="p-4"></SidebarFooter>
+          </Sidebar>
+        </Tabs>
+      )}
+    </section>
+  )
+}

--- a/src/pages/app/request-log/index.ts
+++ b/src/pages/app/request-log/index.ts
@@ -1,0 +1,1 @@
+export { default as List } from "./list"

--- a/src/pages/app/request-log/index.ts
+++ b/src/pages/app/request-log/index.ts
@@ -1,1 +1,2 @@
 export { default as List } from "./list"
+export { default as Details } from "./details"

--- a/src/pages/app/request-log/list.tsx
+++ b/src/pages/app/request-log/list.tsx
@@ -1,0 +1,259 @@
+import { useCallback, useMemo } from "react"
+
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  TableHeader,
+  TableHead,
+  TableRow,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table"
+
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { useEdition } from "@/hooks/use-edition"
+import { useDataTable } from "@/hooks/use-data-table"
+import { useFilterSearch } from "@/hooks/use-filter-search"
+import { useCursorFollowTooltip } from "@/hooks/use-cursor-follow-tooltip"
+import { useRequestLogTableColumns } from "@/hooks/use-request-log-table-columns"
+
+import { type RequestLog } from "@/types/request-logs"
+
+import {
+  useListRequestLogs,
+  type RequestLogFilters,
+} from "@/queries/request-logs"
+
+import { cn } from "@/lib/utils"
+
+import * as RequestLogs from "@/components/request-logs"
+import {
+  type RequestLogPreview,
+  RequestLogPreviewContent,
+  type RequestLogPreviewHandlers,
+} from "@/components/request-logs/preview"
+import DataTable from "@/components/data-table"
+import PageFooter from "@/components/page-footer"
+import PageHeader from "@/components/page-header"
+import Pagination from "@/components/pagination"
+import CursorTooltip from "@/components/cursor-tooltip"
+
+const REQUEST_LOG_SKELETON_COLUMNS = [
+  "Timestamp",
+  "IP",
+  "Status",
+  "Method",
+  "URL",
+] as const
+
+const REQUEST_LOG_SKELETON_ROWS = [
+  ["w-44", "w-28", "w-10", "w-14", "w-64"],
+  ["w-40", "w-32", "w-10", "w-16", "w-72"],
+  ["w-44", "w-24", "w-10", "w-14", "w-56"],
+  ["w-36", "w-28", "w-10", "w-16", "w-48"],
+  ["w-44", "w-32", "w-10", "w-14", "w-64"],
+  ["w-40", "w-24", "w-10", "w-12", "w-52"],
+  ["w-44", "w-28", "w-10", "w-16", "w-72"],
+  ["w-36", "w-32", "w-10", "w-14", "w-56"],
+  ["w-44", "w-24", "w-10", "w-16", "w-60"],
+  ["w-40", "w-28", "w-10", "w-12", "w-72"],
+  ["w-44", "w-32", "w-10", "w-14", "w-44"],
+  ["w-36", "w-24", "w-10", "w-16", "w-64"],
+  ["w-44", "w-28", "w-10", "w-14", "w-56"],
+  ["w-40", "w-32", "w-10", "w-16", "w-72"],
+  ["w-36", "w-24", "w-10", "w-12", "w-48"],
+  ["w-44", "w-28", "w-10", "w-14", "w-60"],
+  ["w-40", "w-32", "w-10", "w-16", "w-52"],
+  ["w-44", "w-24", "w-10", "w-14", "w-72"],
+  ["w-36", "w-28", "w-10", "w-16", "w-56"],
+  ["w-40", "w-32", "w-10", "w-12", "w-48"],
+  ["w-44", "w-24", "w-10", "w-14", "w-72"],
+  ["w-36", "w-28", "w-10", "w-16", "w-64"],
+  ["w-44", "w-32", "w-10", "w-14", "w-56"],
+  ["w-40", "w-24", "w-10", "w-16", "w-60"],
+  ["w-36", "w-28", "w-10", "w-12", "w-48"],
+  ["w-44", "w-32", "w-10", "w-14", "w-72"],
+  ["w-40", "w-24", "w-10", "w-16", "w-52"],
+  ["w-36", "w-28", "w-10", "w-14", "w-44"],
+] as const
+
+function StaticSkeleton({ className }: { className?: string }) {
+  return <span className={className} />
+}
+
+function RequestLogTableSkeleton() {
+  return (
+    <div className="relative min-w-full px-2">
+      <table className="min-w-full border-separate border-spacing-0 text-sm">
+        <TableHeader>
+          <TableRow>
+            {REQUEST_LOG_SKELETON_COLUMNS.map((column) => (
+              <TableHead
+                key={column}
+                className="border-b border-accent bg-background text-sm select-none md:text-xs"
+              >
+                <div className="flex h-6 items-center px-1 text-xs text-content-muted">
+                  {column}
+                </div>
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {REQUEST_LOG_SKELETON_ROWS.map((row, rowIndex) => (
+            <TableRow key={rowIndex} className="pointer-events-none">
+              {row.map((width, columnIndex) => (
+                <TableCell
+                  key={columnIndex}
+                  className="border-b border-accent bg-background"
+                >
+                  {columnIndex === 4 ? (
+                    <StaticSkeleton
+                      className={cn(
+                        "block h-[14px] animate-none rounded-[3px] bg-secondary/20",
+                        width,
+                      )}
+                    />
+                  ) : columnIndex === 0 ? (
+                    <StaticSkeleton
+                      className={cn("block h-3 rounded-sm bg-accent", width)}
+                    />
+                  ) : (
+                    <StaticSkeleton
+                      className={cn(
+                        "block h-5 rounded-sm bg-content-subdued/30",
+                        width,
+                      )}
+                    />
+                  )}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </table>
+    </div>
+  )
+}
+
+export default function RequestLogList() {
+  const table = useDataTable()
+  const { page, pageSize, setPage } = table
+  const { isEE } = useEdition()
+
+  const [filters, setFilters] = useFilterSearch<RequestLogFilters>()
+  const { cursor, reset, goToPage } = useCursors(page, setPage)
+  const {
+    active: preview,
+    tooltipRef,
+    currentPos,
+    open: openPreview,
+    move: movePreview,
+    close: closePreview,
+    closeNow: closePreviewNow,
+  } = useCursorFollowTooltip<RequestLogPreview>()
+
+  const previewHandlers = useMemo<RequestLogPreviewHandlers>(
+    () => ({
+      onOpenPreview: openPreview,
+      onMovePreview: movePreview,
+      onClosePreview: closePreview,
+    }),
+    [openPreview, movePreview, closePreview],
+  )
+
+  const handleFiltersChange = useCallback(
+    (next: RequestLogFilters) => {
+      closePreviewNow()
+      setFilters(next)
+      reset()
+    },
+    [closePreviewNow, setFilters, reset],
+  )
+
+  const columns = useRequestLogTableColumns(previewHandlers)
+
+  const {
+    data: requestLogs,
+    links,
+    isLoading,
+    isFetching,
+  } = useListRequestLogs(
+    {
+      cursor,
+      pageSize,
+      filters,
+    },
+    { enabled: isEE },
+  )
+
+  const nextCursor = cursorFromLink(links?.next)
+  const loading = isLoading || isFetching
+
+  const handlePageChange = useCallback(
+    (nextPage: number) => {
+      closePreviewNow()
+      goToPage(nextPage, nextCursor)
+    },
+    [closePreviewNow, goToPage, nextCursor],
+  )
+
+  const requestLogList = (
+    <ScrollArea className="h-full overflow-auto">
+      <DataTable<RequestLog>
+        data={requestLogs}
+        table={table}
+        columns={columns}
+        isLoading={loading}
+      />
+    </ScrollArea>
+  )
+
+  const content = (
+    <>
+      <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
+        <RequestLogs.FilterBar
+          filters={filters}
+          onChange={handleFiltersChange}
+        />
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {isEE ? (
+          requestLogList
+        ) : (
+          <RequestLogs.Upgrade className="h-full">
+            <ScrollArea className="h-full overflow-auto">
+              <RequestLogTableSkeleton />
+            </ScrollArea>
+          </RequestLogs.Upgrade>
+        )}
+      </div>
+
+      <PageFooter>
+        <Pagination
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={handlePageChange}
+          isLoading={loading}
+        />
+      </PageFooter>
+    </>
+  )
+
+  return (
+    <section className="flex h-screen flex-col">
+      <PageHeader title="Request Logs" />
+
+      {content}
+
+      <CursorTooltip
+        open={!!preview}
+        tooltipRef={tooltipRef}
+        currentPos={currentPos}
+        className="w-80"
+      >
+        {preview && <RequestLogPreviewContent preview={preview} />}
+      </CursorTooltip>
+    </section>
+  )
+}

--- a/src/pages/app/request-log/list.tsx
+++ b/src/pages/app/request-log/list.tsx
@@ -1,13 +1,6 @@
 import { useCallback, useMemo } from "react"
 
 import { ScrollArea } from "@/components/ui/scroll-area"
-import {
-  TableHeader,
-  TableHead,
-  TableRow,
-  TableBody,
-  TableCell,
-} from "@/components/ui/table"
 
 import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useEdition } from "@/hooks/use-edition"
@@ -23,9 +16,8 @@ import {
   type RequestLogFilters,
 } from "@/queries/request-logs"
 
-import { cn } from "@/lib/utils"
-
 import * as RequestLogs from "@/components/request-logs"
+import * as Skeletons from "@/components/skeletons"
 import {
   type RequestLogPreview,
   RequestLogPreviewContent,
@@ -36,104 +28,6 @@ import PageFooter from "@/components/page-footer"
 import PageHeader from "@/components/page-header"
 import Pagination from "@/components/pagination"
 import CursorTooltip from "@/components/cursor-tooltip"
-
-const REQUEST_LOG_SKELETON_COLUMNS = [
-  "Timestamp",
-  "IP",
-  "Status",
-  "Method",
-  "URL",
-] as const
-
-const REQUEST_LOG_SKELETON_ROWS = [
-  ["w-44", "w-28", "w-10", "w-14", "w-64"],
-  ["w-40", "w-32", "w-10", "w-16", "w-72"],
-  ["w-44", "w-24", "w-10", "w-14", "w-56"],
-  ["w-36", "w-28", "w-10", "w-16", "w-48"],
-  ["w-44", "w-32", "w-10", "w-14", "w-64"],
-  ["w-40", "w-24", "w-10", "w-12", "w-52"],
-  ["w-44", "w-28", "w-10", "w-16", "w-72"],
-  ["w-36", "w-32", "w-10", "w-14", "w-56"],
-  ["w-44", "w-24", "w-10", "w-16", "w-60"],
-  ["w-40", "w-28", "w-10", "w-12", "w-72"],
-  ["w-44", "w-32", "w-10", "w-14", "w-44"],
-  ["w-36", "w-24", "w-10", "w-16", "w-64"],
-  ["w-44", "w-28", "w-10", "w-14", "w-56"],
-  ["w-40", "w-32", "w-10", "w-16", "w-72"],
-  ["w-36", "w-24", "w-10", "w-12", "w-48"],
-  ["w-44", "w-28", "w-10", "w-14", "w-60"],
-  ["w-40", "w-32", "w-10", "w-16", "w-52"],
-  ["w-44", "w-24", "w-10", "w-14", "w-72"],
-  ["w-36", "w-28", "w-10", "w-16", "w-56"],
-  ["w-40", "w-32", "w-10", "w-12", "w-48"],
-  ["w-44", "w-24", "w-10", "w-14", "w-72"],
-  ["w-36", "w-28", "w-10", "w-16", "w-64"],
-  ["w-44", "w-32", "w-10", "w-14", "w-56"],
-  ["w-40", "w-24", "w-10", "w-16", "w-60"],
-  ["w-36", "w-28", "w-10", "w-12", "w-48"],
-  ["w-44", "w-32", "w-10", "w-14", "w-72"],
-  ["w-40", "w-24", "w-10", "w-16", "w-52"],
-  ["w-36", "w-28", "w-10", "w-14", "w-44"],
-] as const
-
-function StaticSkeleton({ className }: { className?: string }) {
-  return <span className={className} />
-}
-
-function RequestLogTableSkeleton() {
-  return (
-    <div className="relative min-w-full px-2">
-      <table className="min-w-full border-separate border-spacing-0 text-sm">
-        <TableHeader>
-          <TableRow>
-            {REQUEST_LOG_SKELETON_COLUMNS.map((column) => (
-              <TableHead
-                key={column}
-                className="border-b border-accent bg-background text-sm select-none md:text-xs"
-              >
-                <div className="flex h-6 items-center px-1 text-xs text-content-muted">
-                  {column}
-                </div>
-              </TableHead>
-            ))}
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {REQUEST_LOG_SKELETON_ROWS.map((row, rowIndex) => (
-            <TableRow key={rowIndex} className="pointer-events-none">
-              {row.map((width, columnIndex) => (
-                <TableCell
-                  key={columnIndex}
-                  className="border-b border-accent bg-background"
-                >
-                  {columnIndex === 4 ? (
-                    <StaticSkeleton
-                      className={cn(
-                        "block h-[14px] animate-none rounded-[3px] bg-secondary/20",
-                        width,
-                      )}
-                    />
-                  ) : columnIndex === 0 ? (
-                    <StaticSkeleton
-                      className={cn("block h-3 rounded-sm bg-accent", width)}
-                    />
-                  ) : (
-                    <StaticSkeleton
-                      className={cn(
-                        "block h-5 rounded-sm bg-content-subdued/30",
-                        width,
-                      )}
-                    />
-                  )}
-                </TableCell>
-              ))}
-            </TableRow>
-          ))}
-        </TableBody>
-      </table>
-    </div>
-  )
-}
 
 export default function RequestLogList() {
   const table = useDataTable()
@@ -223,7 +117,7 @@ export default function RequestLogList() {
         ) : (
           <RequestLogs.Upgrade className="h-full">
             <ScrollArea className="h-full overflow-auto">
-              <RequestLogTableSkeleton />
+              <Skeletons.RequestLogs />
             </ScrollArea>
           </RequestLogs.Upgrade>
         )}

--- a/src/pages/app/request-log/list.tsx
+++ b/src/pages/app/request-log/list.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from "react"
+import { useNavigate } from "@tanstack/react-router"
 
 import { ScrollArea } from "@/components/ui/scroll-area"
 
@@ -16,6 +17,7 @@ import {
   type RequestLogFilters,
 } from "@/queries/request-logs"
 
+import * as keygen from "@/keygen"
 import * as RequestLogs from "@/components/request-logs"
 import * as Skeletons from "@/components/skeletons"
 import {
@@ -32,6 +34,7 @@ import CursorTooltip from "@/components/cursor-tooltip"
 export default function RequestLogList() {
   const table = useDataTable()
   const { page, pageSize, setPage } = table
+  const navigate = useNavigate()
   const { isEE } = useEdition()
 
   const [filters, setFilters] = useFilterSearch<RequestLogFilters>()
@@ -98,6 +101,12 @@ export default function RequestLogList() {
         table={table}
         columns={columns}
         isLoading={loading}
+        onRowClick={(requestLog) =>
+          navigate({
+            to: "/$accountId/app/request-logs/$id",
+            params: { accountId: keygen.config.id, id: requestLog.id },
+          })
+        }
       />
     </ScrollArea>
   )

--- a/src/pages/app/request-logs.tsx
+++ b/src/pages/app/request-logs.tsx
@@ -1,0 +1,5 @@
+import * as Page from "@/pages"
+
+export default function RequestLogs() {
+  return <Page.App.RequestLog.List />
+}

--- a/src/pages/app/request-logs.tsx
+++ b/src/pages/app/request-logs.tsx
@@ -1,5 +1,26 @@
+import { Outlet, useParams } from "@tanstack/react-router"
+
+import { RequestLogView } from "@/types/request-logs"
+
+import * as Motion from "@/components/motion"
 import * as Page from "@/pages"
 
 export default function RequestLogs() {
-  return <Page.App.RequestLog.List />
+  const { id } = useParams({ strict: false })
+
+  const view = id ? RequestLogView.Details : RequestLogView.List
+
+  const direction: 1 | -1 = view === RequestLogView.Details ? 1 : -1
+
+  const key = view === RequestLogView.List ? "list" : `details-${id}`
+
+  return (
+    <Motion.Slide direction={direction}>
+      {view === RequestLogView.List ? (
+        <Page.App.RequestLog.List key={key} />
+      ) : (
+        <Outlet key={key} />
+      )}
+    </Motion.Slide>
+  )
 }

--- a/src/queries/request-logs.ts
+++ b/src/queries/request-logs.ts
@@ -1,0 +1,49 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { useEnvironment } from "@/hooks/use-environment"
+
+import { APIError } from "@/types/api"
+import { type RequestLogFilters } from "@/types/request-logs"
+
+import * as keygen from "@/keygen"
+
+export type { RequestLogFilters }
+
+export function useListRequestLogs(
+  params?: {
+    cursor?: string | null
+    pageSize?: number
+    filters?: RequestLogFilters
+  },
+  options?: { enabled?: boolean },
+) {
+  const { code } = useEnvironment()
+
+  const query = useQuery({
+    queryKey: ["request-logs", { environment: code, ...params }],
+    queryFn: async () => {
+      const response = await keygen.requestLogs.list(
+        params
+          ? {
+              pageCursor: params.cursor,
+              pageSize: params.pageSize,
+              filters: params.filters,
+            }
+          : {},
+      )
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response
+    },
+    enabled: options?.enabled,
+  })
+
+  return {
+    ...query,
+    data: query.data?.data ?? [],
+    links: query.data?.links,
+  }
+}

--- a/src/queries/request-logs.ts
+++ b/src/queries/request-logs.ts
@@ -9,6 +9,24 @@ import * as keygen from "@/keygen"
 
 export type { RequestLogFilters }
 
+export function useGetRequestLog(requestLogId: string) {
+  const { code } = useEnvironment()
+
+  return useQuery({
+    queryKey: ["request-logs", requestLogId, { environment: code }],
+    queryFn: async () => {
+      const response = await keygen.requestLogs.get({ id: requestLogId })
+
+      if (!response.data) {
+        throw new Error("Request log not found")
+      }
+
+      return response.data
+    },
+    enabled: !!requestLogId,
+  })
+}
+
 export function useListRequestLogs(
   params?: {
     cursor?: string | null

--- a/src/routes/$accountId/app.request-logs.$id.tsx
+++ b/src/routes/$accountId/app.request-logs.$id.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import * as Page from "@/pages/index"
+
+export const Route = createFileRoute("/$accountId/app/request-logs/$id")({
+  component: () => <Page.App.RequestLog.Details />,
+})

--- a/src/routes/$accountId/app.request-logs.tsx
+++ b/src/routes/$accountId/app.request-logs.tsx
@@ -1,0 +1,60 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { type RequestLogFilters } from "@/queries/request-logs"
+import { type RequestLogResourceFilter } from "@/types/request-logs"
+
+import { requirePermission } from "@/lib/permissions"
+
+import * as Page from "@/pages/index"
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function parseResourceFilter(
+  value: unknown,
+): RequestLogResourceFilter | undefined {
+  if (typeof value === "string") return value
+  if (
+    isRecord(value) &&
+    typeof value.type === "string" &&
+    typeof value.id === "string"
+  ) {
+    return { type: value.type, id: value.id }
+  }
+  return undefined
+}
+
+function validateSearch(search: Record<string, unknown>): RequestLogFilters {
+  const filters: RequestLogFilters = {}
+
+  if (typeof search.method === "string") filters.method = search.method
+  if (typeof search.status === "string") filters.status = search.status
+  if (typeof search.ip === "string") filters.ip = search.ip
+  if (typeof search.url === "string") filters.url = search.url
+
+  const resource = parseResourceFilter(search.resource)
+  if (resource) filters.resource = resource
+
+  const requestor = parseResourceFilter(search.requestor)
+  if (requestor) filters.requestor = requestor
+
+  if (isRecord(search.date)) {
+    filters.date = {}
+    if (typeof search.date.start === "string") {
+      filters.date.start = search.date.start
+    }
+    if (typeof search.date.end === "string") {
+      filters.date.end = search.date.end
+    }
+  }
+
+  return filters
+}
+
+export const Route = createFileRoute("/$accountId/app/request-logs")({
+  component: () => <Page.App.RequestLogs />,
+  validateSearch,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "request-log.read"),
+})

--- a/src/types/request-logs.ts
+++ b/src/types/request-logs.ts
@@ -1,0 +1,131 @@
+import { APIResponse, Resource, Relationship, Linkage } from "@/types/api"
+
+export type RequestLogAttributes = {
+  url: string
+  method: string
+  status: string
+  ip: string | null
+  userAgent: string | null
+  requestHeaders?: Record<string, unknown> | null
+  requestBody?: string | null
+  responseSignature?: string | null
+  responseHeaders?: Record<string, unknown> | null
+  responseBody?: string | null
+  created: string
+  updated: string
+}
+
+export type RequestLogRelationships = {
+  account: Relationship<Linkage<"accounts">>
+  environment: Relationship<Linkage<"environments"> | null>
+  requestor: Relationship<Linkage | null>
+  resource: Relationship<Linkage | null>
+}
+
+export type RequestLog = Resource<
+  "request-logs",
+  RequestLogAttributes,
+  RequestLogRelationships
+>
+
+export type RequestLogListResponse = APIResponse<RequestLog[]>
+
+export type RequestLogResourceFilter =
+  | string
+  | {
+      type: string
+      id: string
+    }
+
+export type RequestLogFilters = {
+  method?: string
+  status?: string
+  ip?: string
+  url?: string
+  requestor?: RequestLogResourceFilter
+  resource?: RequestLogResourceFilter
+  date?: {
+    start?: string
+    end?: string
+  }
+}
+
+export const HTTP_METHODS = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+] as const
+
+export const HTTP_STATUS_CODES = [
+  { code: "100", text: "Continue" },
+  { code: "101", text: "Switching Protocols" },
+  { code: "102", text: "Processing" },
+  { code: "103", text: "Early Hints" },
+
+  { code: "200", text: "OK" },
+  { code: "201", text: "Created" },
+  { code: "202", text: "Accepted" },
+  { code: "203", text: "Non-Authoritative Information" },
+  { code: "204", text: "No Content" },
+  { code: "205", text: "Reset Content" },
+  { code: "206", text: "Partial Content" },
+  { code: "207", text: "Multi-Status" },
+  { code: "208", text: "Already Reported" },
+  { code: "226", text: "IM Used" },
+
+  { code: "300", text: "Multiple Choices" },
+  { code: "301", text: "Moved Permanently" },
+  { code: "302", text: "Found" },
+  { code: "303", text: "See Other" },
+  { code: "304", text: "Not Modified" },
+  { code: "305", text: "Use Proxy" },
+  { code: "306", text: "Unused" },
+  { code: "307", text: "Temporary Redirect" },
+  { code: "308", text: "Permanent Redirect" },
+
+  { code: "400", text: "Bad Request" },
+  { code: "401", text: "Unauthorized" },
+  { code: "402", text: "Payment Required" },
+  { code: "403", text: "Forbidden" },
+  { code: "404", text: "Not Found" },
+  { code: "405", text: "Method Not Allowed" },
+  { code: "406", text: "Not Acceptable" },
+  { code: "407", text: "Proxy Authentication Required" },
+  { code: "408", text: "Request Timeout" },
+  { code: "409", text: "Conflict" },
+  { code: "410", text: "Gone" },
+  { code: "411", text: "Length Required" },
+  { code: "412", text: "Precondition Failed" },
+  { code: "413", text: "Content Too Large" },
+  { code: "414", text: "URI Too Long" },
+  { code: "415", text: "Unsupported Media Type" },
+  { code: "416", text: "Range Not Satisfiable" },
+  { code: "417", text: "Expectation Failed" },
+  { code: "418", text: "I'm a Teapot" },
+  { code: "421", text: "Misdirected Request" },
+  { code: "422", text: "Unprocessable Content" },
+  { code: "423", text: "Locked" },
+  { code: "424", text: "Failed Dependency" },
+  { code: "425", text: "Too Early" },
+  { code: "426", text: "Upgrade Required" },
+  { code: "428", text: "Precondition Required" },
+  { code: "429", text: "Too Many Requests" },
+  { code: "431", text: "Request Header Fields Too Large" },
+  { code: "451", text: "Unavailable For Legal Reasons" },
+
+  { code: "500", text: "Internal Server Error" },
+  { code: "501", text: "Not Implemented" },
+  { code: "502", text: "Bad Gateway" },
+  { code: "503", text: "Service Unavailable" },
+  { code: "504", text: "Gateway Timeout" },
+  { code: "505", text: "HTTP Version Not Supported" },
+  { code: "506", text: "Variant Also Negotiates" },
+  { code: "507", text: "Insufficient Storage" },
+  { code: "508", text: "Loop Detected" },
+  { code: "510", text: "Not Extended" },
+  { code: "511", text: "Network Authentication Required" },
+] as const

--- a/src/types/request-logs.ts
+++ b/src/types/request-logs.ts
@@ -1,5 +1,10 @@
 import { APIResponse, Resource, Relationship, Linkage } from "@/types/api"
 
+export enum RequestLogView {
+  List = "list",
+  Details = "details",
+}
+
 export type RequestLogAttributes = {
   url: string
   method: string
@@ -28,6 +33,7 @@ export type RequestLog = Resource<
   RequestLogRelationships
 >
 
+export type RequestLogResponse = APIResponse<RequestLog>
 export type RequestLogListResponse = APIResponse<RequestLog[]>
 
 export type RequestLogResourceFilter =


### PR DESCRIPTION
Closes #193. Adds list plus filter bar and details views for request logs, and added support to the Events feed to link to request logs.

<img width="700" src="https://github.com/user-attachments/assets/1671bea7-0847-4f63-905d-b9e727555762" />
<img width="700" src="https://github.com/user-attachments/assets/1daeb0ef-02ef-483a-bada-406f3ad69edb" />


---

Selecting `View request logs` in an Events feed takes the user to a request logs list view pre-filtered by that resource:
<img width="700" src="https://github.com/user-attachments/assets/b9af29d0-cb94-48c2-b59f-f73fab93dad7" />
<img width="700" src="https://github.com/user-attachments/assets/5de05d6b-3453-4068-a0d6-0a1ae0744c7b" />

---

<img width="700"  src="https://github.com/user-attachments/assets/2bc0acf2-e067-4587-898e-9459e468bfd7" />


