### PR TITLE
Fix mobile sidebar open/close state

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { VariantProps, cva } from "class-variance-authority"
 
-import { useMobile } from "@/hooks/use-mobile"
+import { useMobile, isMobileViewport } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -60,9 +60,9 @@ function SidebarProvider({
   const isMobile = useMobile()
   const [openMobile, setOpenMobile] = React.useState(false)
 
-  // This is the internal state of the sidebar.
-  // We use openProp and setOpenProp for control from outside the component.
-  const [_open, _setOpen] = React.useState(defaultOpen)
+  const [_open, _setOpen] = React.useState(() =>
+    isMobileViewport() ? false : defaultOpen,
+  )
   const open = openProp ?? _open
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -1,12 +1,21 @@
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 960
+const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`
+
+// mobile check that can be used outside of React components
+export function isMobileViewport(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    window.matchMedia(MOBILE_MEDIA_QUERY).matches
+  )
+}
 
 export function useMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const [isMobile, setIsMobile] = React.useState<boolean>(isMobileViewport)
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = window.matchMedia(MOBILE_MEDIA_QUERY)
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     }
@@ -15,5 +24,5 @@ export function useMobile() {
     return () => mql.removeEventListener("change", onChange)
   }, [])
 
-  return !!isMobile
+  return isMobile
 }

--- a/src/layouts/app-layout.tsx
+++ b/src/layouts/app-layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react"
-import { Outlet, useNavigate } from "@tanstack/react-router"
+import { Outlet, useNavigate, useRouter } from "@tanstack/react-router"
 
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { useSidebar, SidebarProvider } from "@/components/ui/sidebar"
@@ -53,11 +53,18 @@ export default function AppLayout() {
 }
 
 function AppLayoutContent() {
-  const { open } = useSidebar()
+  const { open, setOpen } = useSidebar()
   const isMobile = useMobile()
+  const router = useRouter()
+
+  // close sidebar on mobile whenever navigation resolves
+  useEffect(() => {
+    if (!isMobile) return
+    return router.subscribe("onResolved", () => setOpen(false))
+  }, [isMobile, router, setOpen])
 
   return (
-    <div className="flex h-screen w-screen overflow-hidden">
+    <div className="relative flex h-screen w-screen overflow-hidden">
       <Sidebar.Panel />
       <main
         className={cn(
@@ -67,6 +74,14 @@ function AppLayoutContent() {
       >
         <Outlet />
       </main>
+      {isMobile && open && (
+        <button
+          type="button"
+          aria-label="Close sidebar"
+          onClick={() => setOpen(false)}
+          className="absolute inset-0 z-40 cursor-default"
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Closes #31, closes #216.

For mobile, sidebar now closes:
* on initial page load
* whenever switching routes
* by tapping outside of the sidebar container