### PR TITLE
Fix env switching causing logout for cookie-based sessions

### DIFF
--- a/src/keygen/client.ts
+++ b/src/keygen/client.ts
@@ -57,13 +57,16 @@ export class Client {
     } = {},
   ): Promise<APIResponse<T>> {
     const authToken = options.root ? this.rootToken : this.activeToken
+
+    const isEnvironmentScoped = !options.root && this.environmentToken != null
+    const useBearer =
+      authToken != null && (!config.isCloud || isEnvironmentScoped)
+
     const defaultHeaders = {
       Accept: "application/vnd.api+json",
       "Content-Type": "application/vnd.api+json",
       "Keygen-Version": config.version,
-      ...(authToken && !config.isCloud
-        ? { Authorization: `Bearer ${authToken}` }
-        : {}),
+      ...(useBearer ? { Authorization: `Bearer ${authToken}` } : {}),
       ...(options.root || !this.environment
         ? {}
         : { "Keygen-Environment": this.environment }),


### PR DESCRIPTION
Closes #224. Env-scoped requests were falling back to the global session cookie, causing a `401` and subsequent logout. Now sends the environment token as a bearer for env-scoped requests in cookie-based sessions.