### PR TITLE
Fix sidebar nav links missing account id

### DIFF
--- a/src/components/sidebar/panel.tsx
+++ b/src/components/sidebar/panel.tsx
@@ -301,11 +301,12 @@ const VIEWS: View[] = [
 
 function useActiveView(): View {
   const matchRoute = useMatchRoute()
+  const accountId = keygen.config.id
 
   for (const view of VIEWS) {
     if (
       view.routes.some((o) =>
-        matchRoute({ to: o.to, params: o.params, fuzzy: true }),
+        matchRoute({ to: o.to, params: { accountId }, fuzzy: true }),
       )
     ) {
       return view
@@ -338,6 +339,7 @@ export default function SidebarPanel(): React.ReactElement {
   const activeView = useActiveView()
   const visibleViews = useVisibleViews()
   const { can } = usePermissions()
+  const accountId = keygen.config.id
   const [selectedView, setSelectedView] = useState(activeView)
   const { open, setOpen } = useSidebar()
   const [paletteOpen, setPaletteOpen] = useState(false)
@@ -535,6 +537,7 @@ export default function SidebarPanel(): React.ReactElement {
                       <SidebarMenuButton asChild>
                         <Link
                           {...route}
+                          params={{ accountId }}
                           activeProps={{
                             className: "bg-background-2 text-content-loud",
                           }}


### PR DESCRIPTION
Fixes a regression from c1d60063 / #233, which moved config.id from URL-derived state to router-derived state, but the sidebar nav initializes at module load before the router runs `beforeLoad`, so as a result config.id was still an empty string. Attempting to nav would go to e.g. `/app/products` instead of a proper URL like `portal.keygen.sh/$accountId/app/products`