### PR TITLE
Fix singleplayer auth being able to access account route

### DIFF
--- a/src/components/auth/form/login.tsx
+++ b/src/components/auth/form/login.tsx
@@ -234,7 +234,7 @@ function EmailStep({
             noValidate
             className="my-3 w-full space-y-7"
           >
-            <BackButton onClick={onBack} />
+            {!keygen.config.hasFixedAccount && <BackButton onClick={onBack} />}
             <Forms.Section.Header variant="auth" className="mb-1">
               Sign in to your account
             </Forms.Section.Header>

--- a/src/routes/auth.tsx
+++ b/src/routes/auth.tsx
@@ -1,7 +1,18 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, redirect } from "@tanstack/react-router"
 
 import * as Layout from "@/layouts/index"
+import * as keygen from "@/keygen"
 
 export const Route = createFileRoute("/auth")({
+  beforeLoad: () => {
+    if (keygen.config.hasFixedAccount) {
+      redirect({
+        to: "/$accountId/auth/login",
+        params: { accountId: keygen.config.id },
+        replace: true,
+        throw: true,
+      })
+    }
+  },
   component: () => <Layout.Auth />,
 })


### PR DESCRIPTION
Singleplayer users could navigate via the `Go back` button in the `/login` page, which would take them to the account form (bare auth path), and they could get stuck there. Also, adds redirect from the account form to the login form if they land on that page for any other reason.