### PR TITLE
Update older pages to align with newer patterns

### DIFF
--- a/src/components/entitlements/advanced-dialog.tsx
+++ b/src/components/entitlements/advanced-dialog.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent } from "@/components/ui/tabs"
+import {
+  Dialog,
+  DialogHeader,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+
+import { Text, CurlyBraces } from "lucide-react"
+
+import { useGetEntitlement } from "@/queries/entitlements"
+
+import * as Entitlements from "@/components/entitlements"
+import Metadata from "@/components/metadata"
+import TabsSwitch from "@/components/tabs-switch"
+import InspectResource from "@/components/inspect-resource"
+import CollapsibleCard from "@/components/collapsible-card"
+
+interface AdvancedDialogProps {
+  id: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export default function AdvancedDialog({
+  id,
+  open,
+  onOpenChange,
+}: AdvancedDialogProps) {
+  const {
+    data: entitlement,
+    isLoading: entitlementLoading,
+    isFetching: entitlementFetching,
+    isError: entitlementError,
+  } = useGetEntitlement(id)
+
+  const [tab, setTab] = useState<"attributes" | "inspect">("attributes")
+  const hasError = entitlementError && !entitlementFetching
+
+  return (
+    <Dialog open={open && !hasError} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[calc(100dvh-2rem)] w-full flex-col overflow-hidden p-0 md:min-w-4xl">
+        <DialogHeader className="flex items-start border-b border-accent p-4 pt-3">
+          <DialogTitle className="text-base">Advanced</DialogTitle>
+          <DialogDescription className="sr-only">Advanced</DialogDescription>
+        </DialogHeader>
+        <div className="flex min-h-0 flex-1 flex-col">
+          {!entitlement || entitlementLoading ? (
+            <div className="space-y-4 p-4">
+              <div className="flex items-center gap-4">
+                <Skeleton className="h-8 w-48" />
+                <Skeleton className="h-8 w-32" />
+              </div>
+
+              <div className="space-y-4">
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            </div>
+          ) : (
+            <Tabs
+              value={tab}
+              onValueChange={(value) => setTab(value as typeof tab)}
+              className="flex min-h-0 min-w-0 flex-1 flex-col gap-0"
+            >
+              <TabsSwitch
+                className="pt-8 pb-0"
+                options={[
+                  {
+                    value: "attributes",
+                    label: "Other attributes",
+                    icon: Text,
+                  },
+                  {
+                    value: "inspect",
+                    label: "Inspect entitlement",
+                    icon: CurlyBraces,
+                  },
+                ]}
+              />
+              <TabsContent
+                value="attributes"
+                className="flex min-h-0 min-w-0 flex-1 flex-col"
+              >
+                <ScrollArea className="min-h-0 w-full min-w-0">
+                  <div className="flex min-w-0 flex-col gap-2 p-2">
+                    <Entitlements.AllAttributes entitlement={entitlement} />
+
+                    <CollapsibleCard title="Metadata" contentClass="p-0">
+                      <Metadata resource={entitlement} className="p-2" />
+                    </CollapsibleCard>
+                  </div>
+                </ScrollArea>
+              </TabsContent>
+
+              <TabsContent
+                value="inspect"
+                className="flex min-h-0 min-w-0 flex-1 p-0"
+              >
+                <InspectResource resource={entitlement} />
+              </TabsContent>
+            </Tabs>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/entitlements/all-attributes.tsx
+++ b/src/components/entitlements/all-attributes.tsx
@@ -1,0 +1,31 @@
+import { humanize } from "@/lib/utils"
+import { entitlementAttributeTypeSchema } from "@/lib/entitlements"
+
+import { Entitlement } from "@/types/entitlements"
+
+import AttributeGroup from "@/components/entitlements/attribute-group"
+
+type Key = keyof typeof entitlementAttributeTypeSchema
+
+interface AllAttributesProps {
+  entitlement: Entitlement
+  className?: string
+}
+
+export default function AllAttributes({
+  entitlement,
+  className,
+}: AllAttributesProps): React.ReactElement {
+  const keys = (Object.keys(entitlementAttributeTypeSchema) as Key[]).sort(
+    (a, b) => humanize(a).localeCompare(humanize(b)),
+  )
+
+  return (
+    <AttributeGroup
+      entitlement={entitlement}
+      title="Attributes"
+      keys={keys}
+      className={className}
+    />
+  )
+}

--- a/src/components/entitlements/attribute-group.tsx
+++ b/src/components/entitlements/attribute-group.tsx
@@ -1,0 +1,64 @@
+import { humanize } from "@/lib/utils"
+import { entitlementAttributeTypeSchema } from "@/lib/entitlements"
+import {
+  Entitlement,
+  EntitlementAttributeDescriptions,
+} from "@/types/entitlements"
+import * as Attribute from "@/components/attribute"
+import CollapsibleCard from "@/components/collapsible-card"
+
+type Key = keyof typeof entitlementAttributeTypeSchema
+
+type AttributeGroupProps = {
+  entitlement: Entitlement
+  title: string
+  keys: readonly Key[]
+  when?: (entitlement: Entitlement) => boolean
+  className?: string
+}
+
+export default function AttributeGroup({
+  entitlement,
+  title,
+  keys,
+  when,
+  className,
+}: AttributeGroupProps): React.ReactElement | null {
+  if (when && !when(entitlement)) return null
+  if (keys.length === 0) return null
+
+  const middle = Math.ceil(keys.length / 2)
+  const left = keys.slice(0, middle)
+  const right = keys.slice(middle)
+
+  const row = (k: Key) => (
+    <Attribute.Field
+      key={k}
+      label={humanize(k)}
+      variant="none"
+      value={
+        <Attribute.Value
+          type={entitlementAttributeTypeSchema[k]}
+          value={entitlement.attributes[k]}
+          tooltip={
+            (
+              EntitlementAttributeDescriptions as Record<
+                Key,
+                string | undefined
+              >
+            )[k]
+          }
+        />
+      }
+    />
+  )
+
+  return (
+    <CollapsibleCard title={title} contentClass={className}>
+      <div className="md:grid md:grid-cols-2 md:gap-x-6 md:divide-x md:divide-dashed">
+        <div className="space-y-4 md:pr-3">{left.map(row)}</div>
+        <div className="mt-4 space-y-4 md:mt-0 md:pl-3">{right.map(row)}</div>
+      </div>
+    </CollapsibleCard>
+  )
+}

--- a/src/components/entitlements/index.ts
+++ b/src/components/entitlements/index.ts
@@ -1,2 +1,6 @@
+export { default as AdvancedDialog } from "./advanced-dialog"
+export { default as AttributeGroup } from "./attribute-group"
+export { default as AllAttributes } from "./all-attributes"
+
 import * as Form from "./form"
 export { Form }

--- a/src/components/environments/view/details.tsx
+++ b/src/components/environments/view/details.tsx
@@ -1,27 +1,29 @@
-import { copyToClipboard } from "@/lib/clipboard"
+import { useState, type ReactNode } from "react"
 
 import { Button } from "@/components/ui/button"
-import {
-  AlertDialog,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-  AlertDialogDescription,
-} from "@/components/ui/alert-dialog"
 import { Separator } from "@/components/ui/separator"
-import { Badge } from "@/components/ui/badge"
 
 import { Copy, Globe, GlobeLock } from "lucide-react"
 
-import { Environment, IsolationStrategy } from "@/types/environments"
+import {
+  Environment,
+  IsolationStrategy,
+  IsolationStrategyLabels,
+  IsolationStrategyDescriptions,
+  EnvironmentAttributeDescriptions,
+} from "@/types/environments"
 
-import CollapsibleCard from "@/components/collapsible-card"
-import CollapsibleMenu from "@/components/collapsible-menu"
+import { copyToClipboard } from "@/lib/clipboard"
+
 import * as Attribute from "@/components/attribute"
-import * as Loading from "@/components/loading"
+import TooltipBadge from "@/components/tooltip-badge"
+import CollapsibleCard from "@/components/collapsible-card"
+import ConfirmationModal from "@/components/confirmation-modal"
+
+const IsolationStrategyIcons: Record<IsolationStrategy, ReactNode> = {
+  [IsolationStrategy.Isolated]: <GlobeLock className="size-3" />,
+  [IsolationStrategy.Shared]: <Globe className="size-3" />,
+}
 
 interface EnvironmentDetailsProps {
   environment: Environment
@@ -36,24 +38,31 @@ export default function EnvironmentDetails({
   onEditEnvironment,
   onDeleteEnvironment,
 }: EnvironmentDetailsProps) {
+  const [deleteOpen, setDeleteOpen] = useState(false)
+
   return (
     <>
       <div className="flex flex-col justify-between p-4 md:flex-row">
         <div className="flex flex-col space-y-2">
-          <h2 className="text-sm">
-            {environment.attributes.isolationStrategy ===
-            IsolationStrategy.Isolated ? (
-              <Badge variant="secondary">
-                <GlobeLock className="inline size-4" />
-                Isolated
-              </Badge>
-            ) : (
-              <Badge variant="secondary">
-                <Globe className="inline size-4" />
-                Shared
-              </Badge>
-            )}
-          </h2>
+          <div>
+            <TooltipBadge
+              variant="secondary"
+              icon={
+                IsolationStrategyIcons[environment.attributes.isolationStrategy]
+              }
+              value={
+                IsolationStrategyLabels[
+                  environment.attributes.isolationStrategy
+                ]
+              }
+              tooltip={
+                IsolationStrategyDescriptions[
+                  environment.attributes.isolationStrategy
+                ]
+              }
+              className="px-1 text-xs"
+            />
+          </div>
           <div className="flex items-center gap-2">
             <h1 className="font-owners-wide text-2xl font-medium">
               {environment.attributes.name}
@@ -76,59 +85,37 @@ export default function EnvironmentDetails({
           <Button variant="outline" onClick={onEditEnvironment}>
             Edit
           </Button>
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button variant="outline">Delete</Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>
-                  Delete environment {environment.attributes.name}?
-                </AlertDialogTitle>
-                <AlertDialogDescription>
-                  This will remove the environment and queue all resources for
-                  removal.
-                  <br />
-                  This action cannot be undone.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel asChild>
-                  <Button variant="outline" disabled={loading}>
-                    Cancel
-                  </Button>
-                </AlertDialogCancel>
-                <Button
-                  variant="destructive"
-                  disabled={loading}
-                  onClick={onDeleteEnvironment}
-                >
-                  {loading ? (
-                    <Loading.Dots className="bg-background" />
-                  ) : (
-                    "Delete"
-                  )}
-                </Button>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+          <Button variant="outline" onClick={() => setDeleteOpen(true)}>
+            Delete
+          </Button>
         </div>
       </div>
 
       <div className="m-4 mt-0">
-        <CollapsibleCard title="Environment attributes">
-          <CollapsibleMenu
-            title="Environment details"
-            className="flex flex-col space-y-4 md:flex-row md:space-y-0"
-          >
+        <CollapsibleCard title="Attributes">
+          <div className="flex flex-col space-y-4 md:flex-row md:space-y-0">
             <div className="flex-1 space-y-4">
               <Attribute.Field
+                variant="none"
                 label="Code"
-                value={environment.attributes.code}
+                value={
+                  <Attribute.Value
+                    type="raw"
+                    value={environment.attributes.code}
+                    tooltip={EnvironmentAttributeDescriptions.code}
+                  />
+                }
               />
               <Attribute.Field
+                variant="none"
                 label="Isolation Strategy"
-                value={environment.attributes.isolationStrategy}
+                value={
+                  <Attribute.Value
+                    type="enum"
+                    value={environment.attributes.isolationStrategy}
+                    tooltip={EnvironmentAttributeDescriptions.isolationStrategy}
+                  />
+                }
               />
             </div>
             <div className="mx-4 hidden md:block">
@@ -136,13 +123,43 @@ export default function EnvironmentDetails({
             </div>
             <div className="flex-1 space-y-4">
               <Attribute.Field
+                variant="none"
                 label="Created"
-                value={environment.attributes.created}
+                value={
+                  <Attribute.Value
+                    type="date"
+                    value={environment.attributes.created}
+                    tooltip="When the environment was created."
+                  />
+                }
+              />
+              <Attribute.Field
+                variant="none"
+                label="Updated"
+                value={
+                  <Attribute.Value
+                    type="date"
+                    value={environment.attributes.updated}
+                    tooltip="When the environment was last updated."
+                  />
+                }
               />
             </div>
-          </CollapsibleMenu>
+          </div>
         </CollapsibleCard>
       </div>
+
+      <ConfirmationModal
+        title={`Delete ${environment.attributes.name}`}
+        description="This will remove the environment and queue all resources for removal. This action cannot be undone."
+        open={deleteOpen}
+        disabled={loading}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={onDeleteEnvironment}
+        label="Delete"
+        variant="destructive"
+        confirmText={environment.attributes.name || "delete environment"}
+      />
     </>
   )
 }

--- a/src/components/products/advanced-dialog.tsx
+++ b/src/components/products/advanced-dialog.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent } from "@/components/ui/tabs"
+import {
+  Dialog,
+  DialogHeader,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+
+import { Text, CurlyBraces } from "lucide-react"
+
+import { useGetProduct } from "@/queries/products"
+
+import * as Products from "@/components/products"
+import Metadata from "@/components/metadata"
+import TabsSwitch from "@/components/tabs-switch"
+import InspectResource from "@/components/inspect-resource"
+import CollapsibleCard from "@/components/collapsible-card"
+
+interface AdvancedDialogProps {
+  id: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export default function AdvancedDialog({
+  id,
+  open,
+  onOpenChange,
+}: AdvancedDialogProps) {
+  const {
+    data: product,
+    isLoading: productLoading,
+    isFetching: productFetching,
+    isError: productError,
+  } = useGetProduct(id)
+
+  const [tab, setTab] = useState<"attributes" | "inspect">("attributes")
+  const hasError = productError && !productFetching
+
+  return (
+    <Dialog open={open && !hasError} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[calc(100dvh-2rem)] w-full flex-col overflow-hidden p-0 md:min-w-4xl">
+        <DialogHeader className="flex items-start border-b border-accent p-4 pt-3">
+          <DialogTitle className="text-base">Advanced</DialogTitle>
+          <DialogDescription className="sr-only">Advanced</DialogDescription>
+        </DialogHeader>
+        <div className="flex min-h-0 flex-1 flex-col">
+          {!product || productLoading ? (
+            <div className="space-y-4 p-4">
+              <div className="flex items-center gap-4">
+                <Skeleton className="h-8 w-48" />
+                <Skeleton className="h-8 w-32" />
+              </div>
+
+              <div className="space-y-4">
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            </div>
+          ) : (
+            <Tabs
+              value={tab}
+              onValueChange={(value) => setTab(value as typeof tab)}
+              className="flex min-h-0 min-w-0 flex-1 flex-col gap-0"
+            >
+              <TabsSwitch
+                className="pt-8 pb-0"
+                options={[
+                  {
+                    value: "attributes",
+                    label: "Other attributes",
+                    icon: Text,
+                  },
+                  {
+                    value: "inspect",
+                    label: "Inspect product",
+                    icon: CurlyBraces,
+                  },
+                ]}
+              />
+              <TabsContent
+                value="attributes"
+                className="flex min-h-0 min-w-0 flex-1 flex-col"
+              >
+                <ScrollArea className="min-h-0 w-full min-w-0">
+                  <div className="flex min-w-0 flex-col gap-2 p-2">
+                    <Products.AllAttributes product={product} />
+
+                    <CollapsibleCard title="Metadata" contentClass="p-0">
+                      <Metadata resource={product} className="p-2" />
+                    </CollapsibleCard>
+                  </div>
+                </ScrollArea>
+              </TabsContent>
+
+              <TabsContent
+                value="inspect"
+                className="flex min-h-0 min-w-0 flex-1 p-0"
+              >
+                <InspectResource resource={product} />
+              </TabsContent>
+            </Tabs>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/products/all-attributes.tsx
+++ b/src/components/products/all-attributes.tsx
@@ -1,0 +1,31 @@
+import { humanize } from "@/lib/utils"
+import { productAttributeTypeSchema } from "@/lib/products"
+
+import { Product } from "@/types/products"
+
+import AttributeGroup from "@/components/products/attribute-group"
+
+type Key = keyof typeof productAttributeTypeSchema
+
+interface AllAttributesProps {
+  product: Product
+  className?: string
+}
+
+export default function AllAttributes({
+  product,
+  className,
+}: AllAttributesProps): React.ReactElement {
+  const keys = (Object.keys(productAttributeTypeSchema) as Key[]).sort((a, b) =>
+    humanize(a).localeCompare(humanize(b)),
+  )
+
+  return (
+    <AttributeGroup
+      product={product}
+      title="Attributes"
+      keys={keys}
+      className={className}
+    />
+  )
+}

--- a/src/components/products/attribute-group.tsx
+++ b/src/components/products/attribute-group.tsx
@@ -1,0 +1,56 @@
+import { humanize } from "@/lib/utils"
+import { productAttributeTypeSchema } from "@/lib/products"
+import { Product, ProductAttributeDescriptions } from "@/types/products"
+import * as Attribute from "@/components/attribute"
+import CollapsibleCard from "@/components/collapsible-card"
+
+type Key = keyof typeof productAttributeTypeSchema
+
+type AttributeGroupProps = {
+  product: Product
+  title: string
+  keys: readonly Key[]
+  when?: (product: Product) => boolean
+  className?: string
+}
+
+export default function AttributeGroup({
+  product,
+  title,
+  keys,
+  when,
+  className,
+}: AttributeGroupProps): React.ReactElement | null {
+  if (when && !when(product)) return null
+  if (keys.length === 0) return null
+
+  const middle = Math.ceil(keys.length / 2)
+  const left = keys.slice(0, middle)
+  const right = keys.slice(middle)
+
+  const row = (k: Key) => (
+    <Attribute.Field
+      key={k}
+      label={humanize(k)}
+      variant="none"
+      value={
+        <Attribute.Value
+          type={productAttributeTypeSchema[k]}
+          value={product.attributes[k]}
+          tooltip={
+            (ProductAttributeDescriptions as Record<Key, string | undefined>)[k]
+          }
+        />
+      }
+    />
+  )
+
+  return (
+    <CollapsibleCard title={title} contentClass={className}>
+      <div className="md:grid md:grid-cols-2 md:gap-x-6 md:divide-x md:divide-dashed">
+        <div className="space-y-4 md:pr-3">{left.map(row)}</div>
+        <div className="mt-4 space-y-4 md:mt-0 md:pl-3">{right.map(row)}</div>
+      </div>
+    </CollapsibleCard>
+  )
+}

--- a/src/components/products/index.ts
+++ b/src/components/products/index.ts
@@ -1,2 +1,6 @@
+export { default as AdvancedDialog } from "./advanced-dialog"
+export { default as AttributeGroup } from "./attribute-group"
+export { default as AllAttributes } from "./all-attributes"
+
 import * as Form from "./form"
 export { Form }

--- a/src/lib/entitlements.ts
+++ b/src/lib/entitlements.ts
@@ -6,6 +6,16 @@ import { settleMutations } from "@/queries/utils"
 
 import { toast } from "@/lib/toast"
 
+import { AttributeType } from "@/components/attribute/value"
+
+export const entitlementAttributeTypeSchema: Record<
+  keyof Omit<Entitlement["attributes"], "metadata" | "created" | "updated">,
+  AttributeType
+> = {
+  name: "string",
+  code: "raw",
+}
+
 type EntitlementValues = {
   attach?: string[]
   create?: { name: string; code: string; metadata?: Record<string, unknown> }[]

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1,0 +1,16 @@
+import { AttributeType } from "@/components/attribute/value"
+
+import { Product } from "@/types/products"
+
+export const productAttributeTypeSchema: Record<
+  keyof Omit<
+    Product["attributes"],
+    "metadata" | "created" | "updated" | "platforms" | "permissions"
+  >,
+  AttributeType
+> = {
+  name: "string",
+  code: "raw",
+  distributionStrategy: "enum",
+  url: "raw",
+}

--- a/src/pages/app/entitlement/details.tsx
+++ b/src/pages/app/entitlement/details.tsx
@@ -3,10 +3,10 @@ import { useParams } from "@tanstack/react-router"
 import { formatDate } from "date-fns"
 
 import { Button } from "@/components/ui/button"
-import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Tabs, TabsContent } from "@/components/ui/tabs"
+import { Separator } from "@/components/ui/separator"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent } from "@/components/ui/tabs"
 import {
   Breadcrumb,
   BreadcrumbList,
@@ -37,26 +37,28 @@ import {
   EllipsisVertical,
 } from "lucide-react"
 
-import { useGetEntitlement, useRemoveEntitlement } from "@/queries/entitlements"
+import { EntitlementAttributeDescriptions } from "@/types/entitlements"
+
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useGetEntitlement, useRemoveEntitlement } from "@/queries/entitlements"
 
 import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
 
 import * as Property from "@/components/property"
+import * as EventLogs from "@/components/event-logs"
 import * as Attribute from "@/components/attribute"
 import * as Entitlements from "@/components/entitlements"
-import * as EventLogs from "@/components/event-logs"
 import Can from "@/components/can"
 import Metadata from "@/components/metadata"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
 import BackButton from "@/components/back-button"
-import ConfirmationModal from "@/components/confirmation-modal"
 import ResourceLink from "@/components/resource-link"
 import CollapsibleCard from "@/components/collapsible-card"
+import ConfirmationModal from "@/components/confirmation-modal"
 
 export default function EntitlementDetails() {
   const { id } = useParams({
@@ -215,9 +217,15 @@ export default function EntitlementDetails() {
               <div className="mt-6 space-y-6 md:mt-8">
                 <CollapsibleCard title="Attributes">
                   <Attribute.Field
-                    variant="outline"
+                    variant="none"
                     label="Code"
-                    value={entitlement.attributes.code}
+                    value={
+                      <Attribute.Value
+                        type="raw"
+                        value={entitlement.attributes.code}
+                        tooltip={EntitlementAttributeDescriptions.code}
+                      />
+                    }
                   />
                 </CollapsibleCard>
 

--- a/src/pages/app/entitlement/details.tsx
+++ b/src/pages/app/entitlement/details.tsx
@@ -31,6 +31,7 @@ import {
 import {
   Menu,
   GitFork,
+  Logs,
   Copy,
   SquarePlus,
   SquarePen,
@@ -80,6 +81,7 @@ export default function EntitlementDetails() {
   const [open, setOpen] = useState({
     edit: false,
     delete: false,
+    attributes: false,
   })
 
   useEffect(() => {
@@ -247,6 +249,17 @@ export default function EntitlementDetails() {
                 <CollapsibleCard title="Metadata" contentClass="p-0">
                   <Metadata resource={entitlement} />
                 </CollapsibleCard>
+
+                {isMobile && (
+                  <Button
+                    variant="outline"
+                    onClick={() => toggleOpen("attributes", true)}
+                    className="w-full text-content-muted"
+                  >
+                    <Logs className="mt-0.5 size-4 text-content-normal" />
+                    View All Attributes
+                  </Button>
+                )}
               </div>
             </div>
           </ScrollArea>
@@ -322,7 +335,16 @@ export default function EntitlementDetails() {
                 />
               </TabsContent>
             </SidebarContent>
-            <SidebarFooter className="p-4"></SidebarFooter>
+            <SidebarFooter className="p-4">
+              <Button
+                variant="outline"
+                onClick={() => toggleOpen("attributes", true)}
+                className="w-full text-content-muted"
+              >
+                <Logs className="mt-0.5 size-4 text-content-normal" />
+                View All Attributes
+              </Button>
+            </SidebarFooter>
           </Sidebar>
         </Tabs>
       )}
@@ -343,6 +365,14 @@ export default function EntitlementDetails() {
         variant="destructive"
         confirmText={entitlement?.attributes.name || "delete entitlement"}
       />
+
+      {entitlement && (
+        <Entitlements.AdvancedDialog
+          id={entitlement.id}
+          open={open.attributes}
+          onOpenChange={() => toggleOpen("attributes", false)}
+        />
+      )}
     </section>
   )
 }

--- a/src/pages/app/product/details.tsx
+++ b/src/pages/app/product/details.tsx
@@ -1,12 +1,13 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, type ReactNode } from "react"
 import { useParams } from "@tanstack/react-router"
+import { formatDate } from "date-fns"
 
-import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { Separator } from "@/components/ui/separator"
+import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Tabs, TabsContent } from "@/components/ui/tabs"
+import { Separator } from "@/components/ui/separator"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent } from "@/components/ui/tabs"
 import {
   Breadcrumb,
   BreadcrumbList,
@@ -30,22 +31,27 @@ import {
 
 import {
   Menu,
-  GitFork,
   Copy,
   Lock,
-  Unlock,
   Award,
-  SquarePlus,
+  Unlock,
+  GitFork,
   SquarePen,
+  SquarePlus,
   EllipsisVertical,
 } from "lucide-react"
 
-import { DistributionStrategy } from "@/types/products"
+import {
+  DistributionStrategy,
+  DistributionStrategyLabels,
+  ProductAttributeDescriptions,
+  DistributionStrategyDescriptions,
+} from "@/types/products"
 
-import { useGetProduct, useRemoveProduct } from "@/queries/products"
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useGetProduct, useRemoveProduct } from "@/queries/products"
 
 import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
@@ -62,9 +68,16 @@ import TabsSwitch from "@/components/tabs-switch"
 import BackButton from "@/components/back-button"
 import GoToButton from "@/components/go-to-button"
 import ResourceLink from "@/components/resource-link"
-import ConfirmationModal from "@/components/confirmation-modal"
+import TooltipBadge from "@/components/tooltip-badge"
 import CollapsibleCard from "@/components/collapsible-card"
 import CollapsibleMenu from "@/components/collapsible-menu"
+import ConfirmationModal from "@/components/confirmation-modal"
+
+const DistributionStrategyIcons: Record<DistributionStrategy, ReactNode> = {
+  [DistributionStrategy.Licensed]: <Award className="size-3" />,
+  [DistributionStrategy.Open]: <Unlock className="size-3" />,
+  [DistributionStrategy.Closed]: <Lock className="size-3" />,
+}
 
 export default function ProductDetails() {
   const { id } = useParams({ from: "/$accountId/app/products/$id" })
@@ -195,24 +208,25 @@ export default function ProductDetails() {
             <div className="px-4 py-6 md:px-10 md:py-8">
               <BackButton className="mb-8" />
               <div className="mb-2">
-                {product.attributes.distributionStrategy ===
-                DistributionStrategy.Licensed ? (
-                  <Badge variant="secondary">
-                    <Award className="inline size-4" />
-                    Licensed
-                  </Badge>
-                ) : product.attributes.distributionStrategy ===
-                  DistributionStrategy.Closed ? (
-                  <Badge variant="secondary">
-                    <Lock className="inline size-4" />
-                    Closed
-                  </Badge>
-                ) : (
-                  <Badge variant="secondary">
-                    <Unlock className="inline size-4" />
-                    Open
-                  </Badge>
-                )}
+                <TooltipBadge
+                  variant="secondary"
+                  icon={
+                    DistributionStrategyIcons[
+                      product.attributes.distributionStrategy
+                    ]
+                  }
+                  value={
+                    DistributionStrategyLabels[
+                      product.attributes.distributionStrategy
+                    ]
+                  }
+                  tooltip={
+                    DistributionStrategyDescriptions[
+                      product.attributes.distributionStrategy
+                    ]
+                  }
+                  className="px-1 text-xs"
+                />
               </div>
               <div className="flex flex-col gap-3 md:flex-row md:items-center">
                 <h1 className="font-owners-wide text-2xl font-medium">
@@ -234,30 +248,46 @@ export default function ProductDetails() {
                   <div className="flex flex-col space-y-4 md:flex-row md:space-y-0">
                     <div className="flex-1 space-y-4">
                       <Attribute.Field
-                        variant="outline"
+                        variant="none"
                         label="Code"
-                        value={product.attributes.code}
+                        value={
+                          <Attribute.Value
+                            type="raw"
+                            value={product.attributes.code}
+                            tooltip={ProductAttributeDescriptions.code}
+                          />
+                        }
                       />
                       <Attribute.Field
-                        variant="text"
+                        variant="none"
                         label="URL"
-                        value={product.attributes.url || "--"}
+                        value={
+                          <Attribute.Value
+                            type="raw"
+                            value={product.attributes.url}
+                            emptyLabel="Not set"
+                            tooltip="The product's website or homepage URL."
+                          />
+                        }
                       />
                     </div>
                     <div className="mx-4 hidden md:block">
                       <Separator orientation="vertical" dashed={true} />
                     </div>
                     <div className="flex-1 space-y-4">
-                      <div className="flex items-center gap-2">
-                        <Attribute.Field
-                          label="Distribution Strategy"
-                          value={product.attributes.distributionStrategy}
-                          tooltip={`The distribution strategy for releases.
-                                    Licensed = only licensed users.
-                                    Open = anybody, no license required.
-                                    Closed = only admins.`}
-                        />
-                      </div>
+                      <Attribute.Field
+                        variant="none"
+                        label="Distribution Strategy"
+                        value={
+                          <Attribute.Value
+                            type="enum"
+                            value={product.attributes.distributionStrategy}
+                            tooltip={
+                              ProductAttributeDescriptions.distributionStrategy
+                            }
+                          />
+                        }
+                      />
                       <Attribute.Array
                         label="Platforms"
                         array={product.attributes.platforms || []}
@@ -361,16 +391,18 @@ export default function ProductDetails() {
                         <Property.Field
                           icon={SquarePlus}
                           label="Created at"
-                          value={new Date(
-                            product.attributes.created,
-                          ).toLocaleDateString()}
+                          value={formatDate(
+                            new Date(String(product.attributes.created)),
+                            "PP",
+                          )}
                         />
                         <Property.Field
                           icon={SquarePen}
                           label="Updated at"
-                          value={new Date(
-                            product.attributes.updated,
-                          ).toLocaleDateString()}
+                          value={formatDate(
+                            new Date(String(product.attributes.updated)),
+                            "PP",
+                          )}
                         />
                       </>
                     ) : (
@@ -431,16 +463,18 @@ export default function ProductDetails() {
                       <Property.Field
                         icon={SquarePlus}
                         label="Created at"
-                        value={new Date(
-                          product.attributes.created,
-                        ).toLocaleDateString()}
+                        value={formatDate(
+                          new Date(String(product.attributes.created)),
+                          "PP",
+                        )}
                       />
                       <Property.Field
                         icon={SquarePen}
                         label="Updated at"
-                        value={new Date(
-                          product.attributes.updated,
-                        ).toLocaleDateString()}
+                        value={formatDate(
+                          new Date(String(product.attributes.updated)),
+                          "PP",
+                        )}
                       />
                     </Property.Section>
                   </>

--- a/src/pages/app/product/details.tsx
+++ b/src/pages/app/product/details.tsx
@@ -31,6 +31,7 @@ import {
 
 import {
   Menu,
+  Logs,
   Copy,
   Lock,
   Award,
@@ -91,6 +92,7 @@ export default function ProductDetails() {
   const [open, setOpen] = useState({
     edit: false,
     delete: false,
+    attributes: false,
   })
 
   useEffect(() => {
@@ -423,6 +425,17 @@ export default function ProductDetails() {
                     />
                   </CollapsibleCard>
                 )}
+
+                {isMobile && (
+                  <Button
+                    variant="outline"
+                    onClick={() => toggleOpen("attributes", true)}
+                    className="w-full text-content-muted"
+                  >
+                    <Logs className="mt-0.5 size-4 text-content-normal" />
+                    View All Attributes
+                  </Button>
+                )}
               </div>
             </div>
           </ScrollArea>
@@ -497,7 +510,16 @@ export default function ProductDetails() {
                 />
               </TabsContent>
             </SidebarContent>
-            <SidebarFooter></SidebarFooter>
+            <SidebarFooter className="p-4">
+              <Button
+                variant="outline"
+                onClick={() => toggleOpen("attributes", true)}
+                className="w-full text-content-muted"
+              >
+                <Logs className="mt-0.5 size-4 text-content-normal" />
+                View All Attributes
+              </Button>
+            </SidebarFooter>
           </Sidebar>
         </Tabs>
       )}
@@ -518,6 +540,14 @@ export default function ProductDetails() {
         variant="destructive"
         confirmText={product?.attributes.name || "delete product"}
       />
+
+      {product && (
+        <Products.AdvancedDialog
+          id={product.id}
+          open={open.attributes}
+          onOpenChange={() => toggleOpen("attributes", false)}
+        />
+      )}
     </section>
   )
 }

--- a/src/types/environments.ts
+++ b/src/types/environments.ts
@@ -74,3 +74,10 @@ export const IsolationStrategyDescriptions: Readonly<
   [IsolationStrategy.Shared]:
     "The environment will be shared with the global environment. Resources in the global environment will be available as read-only resources.",
 } as const
+
+export const IsolationStrategyLabels: Readonly<
+  Record<IsolationStrategy, string>
+> = {
+  [IsolationStrategy.Isolated]: "Isolated",
+  [IsolationStrategy.Shared]: "Shared",
+} as const

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -92,6 +92,14 @@ export const DistributionStrategyDescriptions: Readonly<
     "Only admins can access releases. Download links must be generated server-side. API authentication is required.",
 } as const
 
+export const DistributionStrategyLabels: Readonly<
+  Record<DistributionStrategy, string>
+> = {
+  [DistributionStrategy.Licensed]: "Licensed",
+  [DistributionStrategy.Open]: "Open",
+  [DistributionStrategy.Closed]: "Closed",
+} as const
+
 export const ProductPermissions = [
   "account.read",
   "arch.read",


### PR DESCRIPTION
Closes #200.

Environments, products and entitlements now have hoverable badges and attributes like other details pages:
<img width="700" src="https://github.com/user-attachments/assets/24ae4517-ac3e-4327-9eba-f4b04bb3f4f1" />
<img width="700" src="https://github.com/user-attachments/assets/2c79bb31-44b5-452b-ab46-3f61cc5900cf" />

Products and entitlements now have advanced dialogs like other details pages:
<img width="700" src="https://github.com/user-attachments/assets/99dc1cec-c685-4be0-a42e-e680a5fa36f1" />
