### PR TITLE
Add API tokens UI and API integration

### DIFF
--- a/src/components/filter-bar/array-filter.tsx
+++ b/src/components/filter-bar/array-filter.tsx
@@ -187,7 +187,7 @@ export default function ArrayFilter({
           >
             <ScrollArea
               className={cn(
-                visibleOptions.length > MAX_VISIBLE_OPTIONS && "h-64",
+                visibleOptions.length > MAX_VISIBLE_OPTIONS && "max-h-64",
               )}
             >
               <div className="flex flex-col gap-0.5">

--- a/src/components/resource-link.tsx
+++ b/src/components/resource-link.tsx
@@ -30,6 +30,7 @@ import { getLicenseLabel } from "@/lib/licenses"
 import { getMachineLabel } from "@/lib/machines"
 import { getPackageLabel } from "@/lib/packages"
 import { getReleaseLabel } from "@/lib/releases"
+import { truncator } from "@/lib/truncate"
 
 import * as keygen from "@/keygen"
 import GoToButton from "@/components/go-to-button"
@@ -49,12 +50,15 @@ const NAVIGABLE_TYPES = new Set([
   "artifacts",
 ])
 
+const truncateLabel = truncator("end", { maxLength: 24 })
+
 interface ResourceLinkViewProps {
   linkage: Linkage
   label?: string | null
   isLoading?: boolean
   isError?: boolean
   buttonClassName?: string
+  truncate?: boolean
 }
 
 function ResourceLinkView({
@@ -63,11 +67,13 @@ function ResourceLinkView({
   isLoading,
   isError,
   buttonClassName,
+  truncate = false,
 }: ResourceLinkViewProps): ReactElement {
   if (isError) return <Badge variant="destructive">ERROR</Badge>
   if (isLoading) return <Skeleton className="h-5 w-32 rounded-sm" />
 
-  const text = label || linkage.id
+  const resolved = label || linkage.id
+  const text = truncate ? truncateLabel(resolved) : resolved
 
   if (!NAVIGABLE_TYPES.has(linkage.type)) {
     return <span className="text-content-normal">{text}</span>
@@ -86,6 +92,7 @@ function ResourceLinkView({
 interface ResolvedLinkProps {
   linkage: Linkage
   buttonClassName?: string
+  truncate?: boolean
 }
 
 function makeResourceLink<T>(
@@ -99,6 +106,7 @@ function makeResourceLink<T>(
   return function ResolvedLink({
     linkage,
     buttonClassName,
+    truncate,
   }: ResolvedLinkProps): ReactElement {
     const { data, isLoading, isError } = useGet(linkage.id)
 
@@ -109,6 +117,7 @@ function makeResourceLink<T>(
         isLoading={isLoading}
         isError={isError}
         buttonClassName={buttonClassName}
+        truncate={truncate}
       />
     )
   }
@@ -156,12 +165,14 @@ export interface ResourceLinkProps {
   linkage?: Linkage | null
   emptyLabel?: string
   buttonClassName?: string
+  truncate?: boolean
 }
 
 export default function ResourceLink({
   linkage,
   emptyLabel = "None",
   buttonClassName,
+  truncate,
 }: ResourceLinkProps): ReactElement {
   if (!linkage) {
     return <span className="text-content-subdued">{emptyLabel}</span>
@@ -170,10 +181,20 @@ export default function ResourceLink({
   const ResolvedLink = RESOURCE_LINKS[linkage.type]
 
   if (ResolvedLink) {
-    return <ResolvedLink linkage={linkage} buttonClassName={buttonClassName} />
+    return (
+      <ResolvedLink
+        linkage={linkage}
+        buttonClassName={buttonClassName}
+        truncate={truncate}
+      />
+    )
   }
 
   return (
-    <ResourceLinkView linkage={linkage} buttonClassName={buttonClassName} />
+    <ResourceLinkView
+      linkage={linkage}
+      buttonClassName={buttonClassName}
+      truncate={truncate}
+    />
   )
 }

--- a/src/components/resource-link.tsx
+++ b/src/components/resource-link.tsx
@@ -1,7 +1,11 @@
 import { type ReactElement } from "react"
 
-import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip"
 
 import { type Linkage } from "@/types/api"
 
@@ -69,11 +73,31 @@ function ResourceLinkView({
   buttonClassName,
   truncate = false,
 }: ResourceLinkViewProps): ReactElement {
-  if (isError) return <Badge variant="destructive">ERROR</Badge>
   if (isLoading) return <Skeleton className="h-5 w-32 rounded-sm" />
 
   const resolved = label || linkage.id
   const text = truncate ? truncateLabel(resolved) : resolved
+
+  // a resource we can't resolve, e.g. a user/bearer that
+  // lives outside the active environment's scope
+  if (isError) {
+    return (
+      <Tooltip>
+        <TooltipTrigger className="cursor-pointer">
+          <GoToButton
+            path={`/$accountId/app/${linkage.type}/$id`}
+            params={{ accountId: keygen.config.id, id: linkage.id }}
+            label={text}
+            disabled
+          />
+        </TooltipTrigger>
+        <TooltipContent className="max-w-64 bg-background-4 text-pretty text-content-muted">
+          This resource could not be loaded. It may not be accessible from this
+          environment, or you may not have permission.
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
 
   if (!NAVIGABLE_TYPES.has(linkage.type)) {
     return <span className="text-content-normal">{text}</span>

--- a/src/components/sidebar/panel.tsx
+++ b/src/components/sidebar/panel.tsx
@@ -235,7 +235,14 @@ const VIEWS: View[] = [
     id: ViewId.Access,
     label: "Access",
     icon: KeyRound,
-    routes: [],
+    routes: linkOptions([
+      {
+        to: "/$accountId/app/tokens",
+        label: "Tokens",
+        params: { accountId: keygen.config.id },
+        requires: ["token.read"],
+      },
+    ]),
   },
   {
     id: ViewId.Security,

--- a/src/components/sidebar/panel.tsx
+++ b/src/components/sidebar/panel.tsx
@@ -46,7 +46,6 @@ import {
   Webhook,
   Package,
   Settings,
-  KeyRound,
 } from "lucide-react"
 
 import * as keygen from "@/keygen"
@@ -232,9 +231,9 @@ const VIEWS: View[] = [
     ]),
   },
   {
-    id: ViewId.Access,
-    label: "Access",
-    icon: KeyRound,
+    id: ViewId.Security,
+    label: "Security",
+    icon: Shield,
     routes: linkOptions([
       {
         to: "/$accountId/app/tokens",
@@ -242,13 +241,6 @@ const VIEWS: View[] = [
         params: { accountId: keygen.config.id },
         requires: ["token.read"],
       },
-    ]),
-  },
-  {
-    id: ViewId.Security,
-    label: "Security",
-    icon: Shield,
-    routes: linkOptions([
       {
         to: "/$accountId/app/event-logs",
         label: "Event Logs",

--- a/src/components/tokens/all-attributes.tsx
+++ b/src/components/tokens/all-attributes.tsx
@@ -1,0 +1,30 @@
+import { humanize } from "@/lib/utils"
+import { tokenAttributeTypeSchema } from "@/lib/tokens"
+import { Token } from "@/types/tokens"
+
+import AttributeGroup from "@/components/tokens/attribute-group"
+
+type Key = keyof typeof tokenAttributeTypeSchema
+
+interface AllAttributesProps {
+  token: Token
+  className?: string
+}
+
+export default function AllAttributes({
+  token,
+  className,
+}: AllAttributesProps): React.ReactElement {
+  const keys = (Object.keys(tokenAttributeTypeSchema) as Key[])
+    .filter((key) => token.attributes[key] !== undefined)
+    .sort((a, b) => humanize(a).localeCompare(humanize(b)))
+
+  return (
+    <AttributeGroup
+      token={token}
+      title="Attributes"
+      keys={keys}
+      className={className}
+    />
+  )
+}

--- a/src/components/tokens/attribute-group.tsx
+++ b/src/components/tokens/attribute-group.tsx
@@ -1,0 +1,56 @@
+import { humanize } from "@/lib/utils"
+import { tokenAttributeTypeSchema } from "@/lib/tokens"
+import { Token, TokenAttributeDescriptions } from "@/types/tokens"
+import * as Attribute from "@/components/attribute"
+import CollapsibleCard from "@/components/collapsible-card"
+
+type Key = keyof typeof tokenAttributeTypeSchema
+
+type AttributeGroupProps = {
+  token: Token
+  title: string
+  keys: readonly Key[]
+  when?: (token: Token) => boolean
+  className?: string
+}
+
+export default function AttributeGroup({
+  token,
+  title,
+  keys,
+  when,
+  className,
+}: AttributeGroupProps): React.ReactElement | null {
+  if (when && !when(token)) return null
+  if (keys.length === 0) return null
+
+  const middle = Math.ceil(keys.length / 2)
+  const left = keys.slice(0, middle)
+  const right = keys.slice(middle)
+
+  const row = (k: Key) => (
+    <Attribute.Field
+      key={k}
+      label={humanize(k)}
+      variant="none"
+      value={
+        <Attribute.Value
+          type={tokenAttributeTypeSchema[k]}
+          value={token.attributes[k] ?? null}
+          tooltip={
+            (TokenAttributeDescriptions as Record<Key, string | undefined>)[k]
+          }
+        />
+      }
+    />
+  )
+
+  return (
+    <CollapsibleCard title={title} contentClass={className}>
+      <div className="md:grid md:grid-cols-2 md:gap-x-6 md:divide-x md:divide-dashed">
+        <div className="space-y-4 md:pr-3">{left.map(row)}</div>
+        <div className="mt-4 space-y-4 md:mt-0 md:pl-3">{right.map(row)}</div>
+      </div>
+    </CollapsibleCard>
+  )
+}

--- a/src/components/tokens/dialog/advanced.tsx
+++ b/src/components/tokens/dialog/advanced.tsx
@@ -1,0 +1,98 @@
+import { useState } from "react"
+
+import { Skeleton } from "@/components/ui/skeleton"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent } from "@/components/ui/tabs"
+import {
+  Dialog,
+  DialogHeader,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+
+import { Text, CurlyBraces } from "lucide-react"
+
+import { useGetToken } from "@/queries/tokens"
+
+import AllAttributes from "../all-attributes"
+import TabsSwitch from "@/components/tabs-switch"
+import InspectResource from "@/components/inspect-resource"
+
+interface AdvancedDialogProps {
+  id: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export default function AdvancedDialog({
+  id,
+  open,
+  onOpenChange,
+}: AdvancedDialogProps) {
+  const { data: token, isLoading, isFetching, isError } = useGetToken(id)
+
+  const [tab, setTab] = useState<"attributes" | "inspect">("attributes")
+  const hasError = isError && !isFetching
+
+  return (
+    <Dialog open={open && !hasError} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-[calc(100dvh-2rem)] w-full flex-col overflow-hidden p-0 md:min-w-4xl">
+        <DialogHeader className="flex items-start border-b border-accent p-4 pt-3">
+          <DialogTitle className="text-base">Advanced</DialogTitle>
+          <DialogDescription className="sr-only">Advanced</DialogDescription>
+        </DialogHeader>
+        <div className="flex min-h-0 flex-1 flex-col">
+          {!token || isLoading ? (
+            <div className="space-y-4 p-4">
+              <div className="flex items-center gap-4">
+                <Skeleton className="h-8 w-48" />
+                <Skeleton className="h-8 w-32" />
+              </div>
+              <div className="space-y-4">
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            </div>
+          ) : (
+            <Tabs
+              value={tab}
+              onValueChange={(value) => setTab(value as typeof tab)}
+              className="flex min-h-0 min-w-0 flex-1 flex-col gap-0"
+            >
+              <TabsSwitch
+                className="pt-8 pb-0"
+                options={[
+                  { value: "attributes", label: "Attributes", icon: Text },
+                  {
+                    value: "inspect",
+                    label: "Inspect token",
+                    icon: CurlyBraces,
+                  },
+                ]}
+              />
+              <TabsContent
+                value="attributes"
+                className="flex min-h-0 min-w-0 flex-1 flex-col"
+              >
+                <ScrollArea className="min-h-0 w-full min-w-0">
+                  <div className="flex min-w-0 flex-col gap-2 p-2">
+                    <AllAttributes token={token} />
+                  </div>
+                </ScrollArea>
+              </TabsContent>
+
+              <TabsContent
+                value="inspect"
+                className="flex min-h-0 min-w-0 flex-1 p-0"
+              >
+                <InspectResource resource={token} />
+              </TabsContent>
+            </Tabs>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/tokens/dialog/index.ts
+++ b/src/components/tokens/dialog/index.ts
@@ -1,0 +1,3 @@
+export { default as Secret } from "./secret"
+export { default as Internal } from "./internal"
+export { default as Advanced } from "./advanced"

--- a/src/components/tokens/dialog/internal.tsx
+++ b/src/components/tokens/dialog/internal.tsx
@@ -1,3 +1,5 @@
+import { useState, useCallback } from "react"
+
 import { ScrollArea } from "@/components/ui/scroll-area"
 import {
   Dialog,
@@ -7,18 +9,19 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog"
 
-import { useListTokens } from "@/queries/tokens"
-
 import { useDataTable } from "@/hooks/use-data-table"
 import { useCursors, cursorFromLink } from "@/hooks/use-cursors"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 import { useTokenTableColumns } from "@/hooks/use-token-table-columns"
 
-import { Token } from "@/types/tokens"
+import { useListTokens } from "@/queries/tokens"
+
+import { Token, type TokenFilters, InternalTokenRoles } from "@/types/tokens"
 
 import DataTable from "@/components/data-table"
 import Pagination from "@/components/pagination"
 import PageFooter from "@/components/page-footer"
+import TokenFilterBar from "../filter-bar"
 
 interface InternalTokensDialogProps {
   open: boolean
@@ -31,21 +34,30 @@ export default function InternalTokensDialog({
 }: InternalTokensDialogProps) {
   const table = useDataTable()
   const { page, setPage } = table
-  const { cursor, goToPage } = useCursors(page, setPage)
+  const { cursor, reset, goToPage } = useCursors(page, setPage)
+  const columns = useTokenTableColumns()
+  const navigateToResource = useResourceNavigate()
+
+  const [filters, setFilters] = useState<TokenFilters>({
+    bearerRoles: [...InternalTokenRoles],
+  })
 
   const {
     data: tokens,
     links,
     isLoading,
-  } = useListTokens({
-    cursor,
-    pageSize: 15, // Ignore hook value since we're in a dialog
-  })
+  } = useListTokens({ cursor, pageSize: 15, filters }, { enabled: open })
 
-  const columns = useTokenTableColumns()
-  const navigateToResource = useResourceNavigate()
+  const handleFiltersChange = useCallback(
+    (next: TokenFilters) => {
+      setFilters(next)
+      reset()
+    },
+    [reset],
+  )
 
   const handleNavigate = async (token: Token) => {
+    onOpenChange(false)
     await navigateToResource(token)
   }
 
@@ -62,6 +74,10 @@ export default function InternalTokensDialog({
             Internal access tokens
           </DialogTitle>
         </DialogHeader>
+
+        <div className="border-b border-accent p-2">
+          <TokenFilterBar filters={filters} onChange={handleFiltersChange} />
+        </div>
 
         <ScrollArea className="min-h-0 flex-1">
           <DataTable<Token>

--- a/src/components/tokens/dialog/internal.tsx
+++ b/src/components/tokens/dialog/internal.tsx
@@ -1,0 +1,87 @@
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  Dialog,
+  DialogHeader,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+
+import { useListTokens } from "@/queries/tokens"
+
+import { useDataTable } from "@/hooks/use-data-table"
+import { useCursors, cursorFromLink } from "@/hooks/use-cursors"
+import { useResourceNavigate } from "@/hooks/use-resource-navigate"
+import { useTokenTableColumns } from "@/hooks/use-token-table-columns"
+
+import { Token } from "@/types/tokens"
+
+import DataTable from "@/components/data-table"
+import Pagination from "@/components/pagination"
+import PageFooter from "@/components/page-footer"
+
+interface InternalTokensDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export default function InternalTokensDialog({
+  open,
+  onOpenChange,
+}: InternalTokensDialogProps) {
+  const table = useDataTable()
+  const { page, setPage } = table
+  const { cursor, goToPage } = useCursors(page, setPage)
+
+  const {
+    data: tokens,
+    links,
+    isLoading,
+  } = useListTokens({
+    cursor,
+    pageSize: 15, // Ignore hook value since we're in a dialog
+  })
+
+  const columns = useTokenTableColumns()
+  const navigateToResource = useResourceNavigate()
+
+  const handleNavigate = async (token: Token) => {
+    await navigateToResource(token)
+  }
+
+  const nextCursor = cursorFromLink(links?.next)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex h-screen min-w-screen flex-col overflow-hidden rounded-none p-0 md:h-[calc(100dvh-16rem)] md:max-w-4xl md:min-w-auto md:rounded-md">
+        <DialogHeader className="h-fit border-b border-accent p-2">
+          <DialogDescription className="flex h-5 items-center space-x-1 text-xs">
+            Viewing all internal access tokens
+          </DialogDescription>
+          <DialogTitle className="text-start text-sm">
+            Internal access tokens
+          </DialogTitle>
+        </DialogHeader>
+
+        <ScrollArea className="min-h-0 flex-1">
+          <DataTable<Token>
+            data={tokens}
+            table={table}
+            columns={columns}
+            isLoading={isLoading}
+            onRowClick={handleNavigate}
+          />
+        </ScrollArea>
+
+        <PageFooter>
+          <Pagination
+            page={page}
+            hasNext={!!nextCursor}
+            onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
+            isLoading={isLoading}
+          />
+        </PageFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/tokens/dialog/secret.tsx
+++ b/src/components/tokens/dialog/secret.tsx
@@ -1,0 +1,43 @@
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+} from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+
+import ClipboardValue from "@/components/clipboard-value"
+
+interface TokenSecretDialogProps {
+  secret: string | null
+  onClose: () => void
+}
+
+export default function TokenSecretDialog({
+  secret,
+  onClose,
+}: TokenSecretDialogProps) {
+  return (
+    <AlertDialog open={!!secret} onOpenChange={(open) => !open && onClose()}>
+      <AlertDialogContent className="p-0">
+        <AlertDialogHeader className="px-6 pt-6 text-start">
+          <AlertDialogTitle className="text-base">
+            Save your token
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            This is the only time we'll show this token. Copy it and store it
+            somewhere safe — you won't be able to retrieve it again.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="px-6 py-4">
+          {secret && <ClipboardValue value={secret} />}
+        </div>
+        <AlertDialogFooter className="gap-4 border-t border-accent p-4">
+          <Button onClick={onClose}>Done</Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/components/tokens/filter-bar.tsx
+++ b/src/components/tokens/filter-bar.tsx
@@ -1,0 +1,59 @@
+import { KeyRound } from "lucide-react"
+
+import * as Filters from "@/components/filter-bar"
+
+import config from "@/keygen/config"
+
+import { TokenBearerType, type TokenFilters } from "@/types/tokens"
+
+const BEARER_TYPES: ReadonlyArray<{
+  value: TokenBearerType
+  label: string
+  resource?: "users" | "licenses" | "products"
+}> = [
+  { value: TokenBearerType.User, label: "User", resource: "users" },
+  { value: TokenBearerType.License, label: "License", resource: "licenses" },
+  { value: TokenBearerType.Product, label: "Product", resource: "products" },
+  ...(config.isCE
+    ? []
+    : [{ value: TokenBearerType.Environment, label: "Environment" }]),
+]
+
+interface TokenFilterBarProps {
+  filters: TokenFilters
+  onChange: (filters: TokenFilters) => void
+}
+
+export default function TokenFilterBar({
+  filters,
+  onChange,
+}: TokenFilterBarProps) {
+  const filterCount = filters.bearerId ? 1 : 0
+
+  const value =
+    filters.bearerType && filters.bearerId
+      ? { type: filters.bearerType, id: filters.bearerId }
+      : undefined
+
+  return (
+    <Filters.FilterBar
+      filterCount={filterCount}
+      onClearAll={() => onChange({})}
+    >
+      <Filters.PolymorphicResourceFilter
+        label="Bearer"
+        icon={KeyRound}
+        placeholder="Bearer ID"
+        types={BEARER_TYPES}
+        value={value}
+        onChange={(next) =>
+          onChange(
+            next
+              ? { bearerType: next.type as TokenBearerType, bearerId: next.id }
+              : {},
+          )
+        }
+      />
+    </Filters.FilterBar>
+  )
+}

--- a/src/components/tokens/filter-bar.tsx
+++ b/src/components/tokens/filter-bar.tsx
@@ -2,8 +2,6 @@ import { KeyRound, Shield } from "lucide-react"
 
 import * as Filters from "@/components/filter-bar"
 
-import config from "@/keygen/config"
-
 import {
   TokenBearerType,
   TokenRole,
@@ -15,14 +13,11 @@ import {
 const BEARER_TYPES: ReadonlyArray<{
   value: TokenBearerType
   label: string
-  resource?: "users" | "licenses" | "products"
+  resource: "users" | "licenses" | "products"
 }> = [
   { value: TokenBearerType.User, label: "User", resource: "users" },
   { value: TokenBearerType.License, label: "License", resource: "licenses" },
   { value: TokenBearerType.Product, label: "Product", resource: "products" },
-  ...(config.isCE
-    ? []
-    : [{ value: TokenBearerType.Environment, label: "Environment" }]),
 ]
 
 const ROLE_OPTIONS = AllTokenRoles.map((role) => ({
@@ -57,7 +52,6 @@ export default function TokenFilterBar({
       <Filters.PolymorphicResourceFilter
         label="Bearer"
         icon={KeyRound}
-        placeholder="Bearer ID"
         types={BEARER_TYPES}
         value={bearerValue}
         onChange={(next) =>

--- a/src/components/tokens/filter-bar.tsx
+++ b/src/components/tokens/filter-bar.tsx
@@ -1,10 +1,16 @@
-import { KeyRound } from "lucide-react"
+import { KeyRound, Shield } from "lucide-react"
 
 import * as Filters from "@/components/filter-bar"
 
 import config from "@/keygen/config"
 
-import { TokenBearerType, type TokenFilters } from "@/types/tokens"
+import {
+  TokenBearerType,
+  TokenRole,
+  TokenRoleLabels,
+  AllTokenRoles,
+  type TokenFilters,
+} from "@/types/tokens"
 
 const BEARER_TYPES: ReadonlyArray<{
   value: TokenBearerType
@@ -19,6 +25,11 @@ const BEARER_TYPES: ReadonlyArray<{
     : [{ value: TokenBearerType.Environment, label: "Environment" }]),
 ]
 
+const ROLE_OPTIONS = AllTokenRoles.map((role) => ({
+  value: role,
+  label: TokenRoleLabels[role],
+}))
+
 interface TokenFilterBarProps {
   filters: TokenFilters
   onChange: (filters: TokenFilters) => void
@@ -28,9 +39,12 @@ export default function TokenFilterBar({
   filters,
   onChange,
 }: TokenFilterBarProps) {
-  const filterCount = filters.bearerId ? 1 : 0
+  const roles = filters.bearerRoles ?? [...AllTokenRoles]
+  const allRolesSelected = roles.length === AllTokenRoles.length
 
-  const value =
+  const filterCount = (filters.bearerId ? 1 : 0) + (allRolesSelected ? 0 : 1)
+
+  const bearerValue =
     filters.bearerType && filters.bearerId
       ? { type: filters.bearerType, id: filters.bearerId }
       : undefined
@@ -38,20 +52,34 @@ export default function TokenFilterBar({
   return (
     <Filters.FilterBar
       filterCount={filterCount}
-      onClearAll={() => onChange({})}
+      onClearAll={() => onChange({ bearerRoles: [...AllTokenRoles] })}
     >
       <Filters.PolymorphicResourceFilter
         label="Bearer"
         icon={KeyRound}
         placeholder="Bearer ID"
         types={BEARER_TYPES}
-        value={value}
+        value={bearerValue}
         onChange={(next) =>
-          onChange(
-            next
-              ? { bearerType: next.type as TokenBearerType, bearerId: next.id }
-              : {},
-          )
+          onChange({
+            ...filters,
+            bearerType: next?.type as TokenBearerType | undefined,
+            bearerId: next?.id,
+          })
+        }
+      />
+      <Filters.ArrayFilter
+        label="Role"
+        icon={Shield}
+        options={ROLE_OPTIONS}
+        value={allRolesSelected ? undefined : roles}
+        onChange={(next) =>
+          onChange({
+            ...filters,
+            bearerRoles: (next as TokenRole[] | undefined) ?? [
+              ...AllTokenRoles,
+            ],
+          })
         }
       />
     </Filters.FilterBar>

--- a/src/components/tokens/filter-bar.tsx
+++ b/src/components/tokens/filter-bar.tsx
@@ -13,11 +13,14 @@ import {
 const BEARER_TYPES: ReadonlyArray<{
   value: TokenBearerType
   label: string
-  resource: "users" | "licenses" | "products"
+  resource?: "users" | "licenses" | "products"
 }> = [
   { value: TokenBearerType.User, label: "User", resource: "users" },
   { value: TokenBearerType.License, label: "License", resource: "licenses" },
   { value: TokenBearerType.Product, label: "Product", resource: "products" },
+  // environments aren't a searchable resource, so this falls
+  // back to the polymorphic filter's raw id input
+  { value: TokenBearerType.Environment, label: "Environment" },
 ]
 
 const ROLE_OPTIONS = AllTokenRoles.map((role) => ({
@@ -52,6 +55,7 @@ export default function TokenFilterBar({
       <Filters.PolymorphicResourceFilter
         label="Bearer"
         icon={KeyRound}
+        placeholder="Environment ID"
         types={BEARER_TYPES}
         value={bearerValue}
         onChange={(next) =>

--- a/src/components/tokens/form/create.tsx
+++ b/src/components/tokens/form/create.tsx
@@ -1,0 +1,143 @@
+import { useState, type ReactNode } from "react"
+import { useForm, useWatch } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+
+import { ShieldCheck, User, KeyRound, Box, Layers } from "lucide-react"
+
+import * as Schemas from "@/schemas"
+import { TokenBearerKind, TokenBearerKindLabels } from "@/types/tokens"
+
+import { useCreateToken } from "@/queries/tokens"
+
+import { toast } from "@/lib/toast"
+
+import * as Forms from "@/components/forms"
+import * as Tokens from "@/components/tokens"
+import { BadgeGroup, BadgeGroupItem } from "@/components/badge-group"
+
+const BEARER_KIND_BADGE_ICONS: Record<TokenBearerKind, ReactNode> = {
+  [TokenBearerKind.Admin]: <ShieldCheck />,
+  [TokenBearerKind.User]: <User />,
+  [TokenBearerKind.License]: <KeyRound />,
+  [TokenBearerKind.Product]: <Box />,
+  [TokenBearerKind.Environment]: <Layers />,
+}
+
+const ATTRIBUTE_FIELDS = [
+  "name",
+  "expiry",
+  "maxActivations",
+  "maxDeactivations",
+  "permissions",
+  "bearerId",
+]
+
+interface CreateTokenFormProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  fixedBearerKind?: TokenBearerKind
+}
+
+export default function CreateTokenForm({
+  open,
+  onOpenChange,
+  fixedBearerKind,
+}: CreateTokenFormProps) {
+  const [secret, setSecret] = useState<string | null>(null)
+  const createToken = useCreateToken()
+
+  const defaultValues: Schemas.Tokens.CreateFormValues = {
+    bearerKind: fixedBearerKind ?? TokenBearerKind.Admin,
+    bearerId: null,
+    name: "",
+    expiry: null,
+    maxActivations: null,
+    maxDeactivations: null,
+    permissions: null,
+  }
+
+  const form = useForm<
+    Schemas.Tokens.CreateFormValues,
+    unknown,
+    Schemas.Tokens.CreateValues
+  >({
+    resolver: zodResolver(Schemas.Tokens.CreateSchema),
+    mode: "onChange",
+    defaultValues,
+  })
+
+  const bearerKind = useWatch({ control: form.control, name: "bearerKind" })
+
+  const handleSubmit = async (values: Schemas.Tokens.CreateValues) => {
+    const token = await createToken.mutateAsync(values)
+
+    toast({ message: "Token created", variant: "success" })
+    form.reset(defaultValues)
+    setSecret(token.attributes.token ?? null)
+  }
+
+  return (
+    <>
+      <Forms.Provider form={form}>
+        <Forms.Container.Dialog open={open} onOpenChange={onOpenChange}>
+          <Forms.Layout.Wizard
+            onSubmit={handleSubmit}
+            isPending={createToken.isPending}
+            submitLabel="Create Token"
+            description={
+              <BadgeGroup prefix="Creating a new" suffix="token">
+                <BadgeGroupItem>
+                  {BEARER_KIND_BADGE_ICONS[bearerKind]}
+                  {TokenBearerKindLabels[bearerKind]}
+                </BadgeGroupItem>
+              </BadgeGroup>
+            }
+            errorMessage="Failed to create token"
+          >
+            {fixedBearerKind == null && (
+              <Forms.Section.Step crumb="Bearer type" fields={["bearerKind"]}>
+                <Tokens.Form.Fields include={["bearerKind"]} />
+              </Forms.Section.Step>
+            )}
+
+            <Forms.Section.Step crumb="Attributes" fields={ATTRIBUTE_FIELDS}>
+              <Forms.Field.Title>
+                <Tokens.Form.Fields
+                  include={["name"]}
+                  titleVariant
+                  autoFocus="name"
+                />
+              </Forms.Field.Title>
+
+              <Forms.Section.Card title="Attributes">
+                <Forms.Section.Columns>
+                  <Forms.Section.Column>
+                    <Tokens.Form.Fields
+                      include={
+                        bearerKind === TokenBearerKind.License
+                          ? ["bearerId", "expiry"]
+                          : ["bearerId"]
+                      }
+                    />
+                  </Forms.Section.Column>
+                  <Forms.Section.Column>
+                    <Tokens.Form.Fields
+                      include={
+                        bearerKind === TokenBearerKind.License
+                          ? ["maxActivations", "maxDeactivations"]
+                          : ["expiry"]
+                      }
+                    />
+                  </Forms.Section.Column>
+                </Forms.Section.Columns>
+                <Tokens.Form.Fields include={["permissions"]} />
+              </Forms.Section.Card>
+            </Forms.Section.Step>
+          </Forms.Layout.Wizard>
+        </Forms.Container.Dialog>
+      </Forms.Provider>
+
+      <Tokens.Dialog.Secret secret={secret} onClose={() => setSecret(null)} />
+    </>
+  )
+}

--- a/src/components/tokens/form/fields.tsx
+++ b/src/components/tokens/form/fields.tsx
@@ -1,0 +1,590 @@
+import { useState, type ReactNode } from "react"
+import { useFormContext, useWatch } from "react-hook-form"
+import { format, parseISO } from "date-fns"
+
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  FormField,
+  FormItem,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form"
+
+import {
+  X,
+  Box,
+  User,
+  Layers,
+  KeyRound,
+  ShieldCheck,
+  CalendarIcon,
+} from "lucide-react"
+
+import * as keygen from "@/keygen"
+
+import { cn } from "@/lib/utils"
+import { getUserLabel } from "@/lib/users"
+
+import { useListLicenses } from "@/queries/licenses"
+import { useListProducts } from "@/queries/products"
+import { useListEnvironments } from "@/queries/environments"
+import { useGetCurrentUser, useListUsers } from "@/queries/users"
+
+import * as Schemas from "@/schemas"
+import { Permissions, UserRole } from "@/types/users"
+import {
+  TokenBearerKind,
+  TokenBearerKindLabels,
+  TokenFormFieldDescriptions,
+  TokenBearerKindDescriptions,
+} from "@/types/tokens"
+import { type FieldVariant } from "@/components/forms/field"
+
+import * as Forms from "@/components/forms"
+import * as Search from "@/components/search"
+import * as Calendars from "@/components/calendars"
+import MultiSelect from "@/components/multi-select"
+import { CardSelector, CardOption } from "@/components/card-selector"
+
+const BEARER_KIND_ICONS: Record<TokenBearerKind, ReactNode> = {
+  [TokenBearerKind.Admin]: (
+    <ShieldCheck className="size-6 text-content-subdued md:size-5" />
+  ),
+  [TokenBearerKind.User]: (
+    <User className="size-6 text-content-subdued md:size-5" />
+  ),
+  [TokenBearerKind.License]: (
+    <KeyRound className="size-6 text-content-subdued md:size-5" />
+  ),
+  [TokenBearerKind.Product]: (
+    <Box className="size-6 text-content-subdued md:size-5" />
+  ),
+  [TokenBearerKind.Environment]: (
+    <Layers className="size-6 text-content-subdued md:size-5" />
+  ),
+}
+
+const BEARER_KINDS: TokenBearerKind[] = [
+  TokenBearerKind.Admin,
+  TokenBearerKind.User,
+  TokenBearerKind.License,
+  TokenBearerKind.Product,
+  ...(keygen.config.isCE ? [] : [TokenBearerKind.Environment]),
+]
+
+const BEARER_KIND_OPTIONS: CardOption<TokenBearerKind>[] = BEARER_KINDS.map(
+  (kind) => ({
+    value: kind,
+    label: TokenBearerKindLabels[kind],
+    icon: BEARER_KIND_ICONS[kind],
+    tooltip: TokenBearerKindDescriptions[kind],
+  }),
+)
+
+const DEFAULT_FIELDS: Schemas.Tokens.FieldNames[] = [
+  "bearerKind",
+  "name",
+  "expiry",
+  "maxActivations",
+  "maxDeactivations",
+  "permissions",
+  "bearerId",
+]
+
+interface TokensFormFieldsProps {
+  include?: Schemas.Tokens.FieldNames[]
+  fieldVariant?: FieldVariant
+  titleVariant?: boolean
+  autoFocus?: Schemas.Tokens.FieldNames
+}
+
+export default function TokensFormFields({
+  include,
+  fieldVariant = "stacking",
+  titleVariant,
+  autoFocus,
+}: TokensFormFieldsProps) {
+  const fields = include ?? DEFAULT_FIELDS
+
+  return (
+    <>
+      {fields.map((field) => {
+        switch (field) {
+          case "bearerKind":
+            return <BearerKindField key="bearerKind" />
+          case "bearerId":
+            return <BearerField key="bearerId" fieldVariant={fieldVariant} />
+          case "name":
+            return (
+              <NameField
+                key="name"
+                autoFocus={autoFocus === "name"}
+                titleVariant={titleVariant}
+                fieldVariant={fieldVariant}
+              />
+            )
+          case "expiry":
+            return <ExpiryField key="expiry" fieldVariant={fieldVariant} />
+          case "maxActivations":
+            return (
+              <MaxActivationsField
+                key="maxActivations"
+                fieldVariant={fieldVariant}
+              />
+            )
+          case "maxDeactivations":
+            return (
+              <MaxDeactivationsField
+                key="maxDeactivations"
+                fieldVariant={fieldVariant}
+              />
+            )
+          case "permissions":
+            return !keygen.config.isCE ? (
+              <PermissionsField key="permissions" fieldVariant={fieldVariant} />
+            ) : null
+          default:
+            return null
+        }
+      })}
+    </>
+  )
+}
+
+function BearerKindField() {
+  const form = useFormContext<Schemas.Tokens.BaseValues>()
+
+  return (
+    <Forms.Field.CardSelector title="Bearer type">
+      <FormField
+        control={form.control}
+        name="bearerKind"
+        render={({ field }) => (
+          <FormItem>
+            <CardSelector
+              options={BEARER_KIND_OPTIONS}
+              value={field.value}
+              onChange={(value) => {
+                field.onChange(value)
+                form.setValue("bearerId", null)
+              }}
+              columns={3}
+            />
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </Forms.Field.CardSelector>
+  )
+}
+
+function BearerField({ fieldVariant }: { fieldVariant?: FieldVariant }) {
+  const form = useFormContext<Schemas.Tokens.BaseValues>()
+  const kind = useWatch({ control: form.control, name: "bearerKind" })
+
+  if (kind == null) return null
+  if (kind === TokenBearerKind.Admin) {
+    return <AdminBearerField fieldVariant={fieldVariant} />
+  }
+
+  return (
+    <FormField
+      control={form.control}
+      name="bearerId"
+      render={({ field, fieldState }) => (
+        <FormItem>
+          <Forms.Field.Header
+            label={TokenBearerKindLabels[kind]}
+            variant={fieldVariant}
+            tooltip={TokenFormFieldDescriptions.bearer}
+          >
+            {kind === TokenBearerKind.User && (
+              <UserBearerSelect
+                value={field.value}
+                onChange={field.onChange}
+                invalid={!!fieldState.error}
+              />
+            )}
+            {kind === TokenBearerKind.License && (
+              <LicenseBearerSelect
+                value={field.value}
+                onChange={field.onChange}
+                invalid={!!fieldState.error}
+              />
+            )}
+            {kind === TokenBearerKind.Product && (
+              <ProductBearerSelect
+                value={field.value}
+                onChange={field.onChange}
+                invalid={!!fieldState.error}
+              />
+            )}
+            {kind === TokenBearerKind.Environment && (
+              <EnvironmentBearerSelect
+                value={field.value}
+                onChange={field.onChange}
+              />
+            )}
+          </Forms.Field.Header>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+function AdminBearerField({ fieldVariant }: { fieldVariant?: FieldVariant }) {
+  const { data: me } = useGetCurrentUser()
+
+  return (
+    <FormItem>
+      <Forms.Field.Header
+        label={TokenBearerKindLabels[TokenBearerKind.Admin]}
+        variant={fieldVariant}
+        tooltip={TokenFormFieldDescriptions.bearer}
+      >
+        <Input
+          disabled
+          readOnly
+          value={me ? getUserLabel(me) : ""}
+          disabledTooltip="Cannot be changed. Admin tokens can only be created under the current bearer."
+        />
+      </Forms.Field.Header>
+    </FormItem>
+  )
+}
+
+interface BearerSelectProps {
+  value?: string | null
+  onChange: (value: string | null) => void
+  invalid?: boolean
+}
+
+function UserBearerSelect({ value, onChange, invalid }: BearerSelectProps) {
+  const { data: users = [] } = useListUsers({
+    cursor: "",
+    pageSize: 20,
+    filters: { roles: [UserRole.User] },
+  })
+
+  return (
+    <Search.Select
+      resource="users"
+      options={users}
+      value={value}
+      onChange={onChange}
+      invalid={invalid}
+    />
+  )
+}
+
+function LicenseBearerSelect({ value, onChange, invalid }: BearerSelectProps) {
+  const { data: licenses = [] } = useListLicenses({ cursor: "", pageSize: 20 })
+
+  return (
+    <Search.Select
+      resource="licenses"
+      options={licenses}
+      value={value}
+      onChange={onChange}
+      invalid={invalid}
+    />
+  )
+}
+
+function ProductBearerSelect({ value, onChange, invalid }: BearerSelectProps) {
+  const { data: products = [] } = useListProducts({ cursor: "", pageSize: 20 })
+
+  return (
+    <Search.Select
+      resource="products"
+      options={products}
+      value={value}
+      onChange={onChange}
+      invalid={invalid}
+    />
+  )
+}
+
+function EnvironmentBearerSelect({ value, onChange }: BearerSelectProps) {
+  const { data: environments = [] } = useListEnvironments({
+    cursor: "",
+    pageSize: 50,
+  })
+
+  return (
+    <Select value={value ?? ""} onValueChange={onChange}>
+      <SelectTrigger className="w-full">
+        <SelectValue placeholder="Select an environment" />
+      </SelectTrigger>
+      <SelectContent>
+        {environments.map((environment) => (
+          <SelectItem key={environment.id} value={environment.id}>
+            {environment.attributes.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function NameField({
+  autoFocus,
+  titleVariant,
+  fieldVariant,
+}: {
+  autoFocus?: boolean
+  titleVariant?: boolean
+  fieldVariant?: FieldVariant
+}) {
+  const form = useFormContext<Schemas.Tokens.BaseValues>()
+
+  return (
+    <FormField
+      control={form.control}
+      name="name"
+      render={({ field }) => (
+        <FormItem>
+          {titleVariant ? (
+            <FormControl>
+              <Input
+                {...field}
+                value={field.value ?? ""}
+                variant="title"
+                placeholder="Enter a token name..."
+                className="border-none text-xl placeholder:text-content-subdued! md:text-2xl"
+                autoFocus={autoFocus}
+                autoComplete="off"
+                onChange={(e) => field.onChange(e.target.value || null)}
+              />
+            </FormControl>
+          ) : (
+            <Forms.Field.Header
+              label="Name"
+              variant={fieldVariant}
+              optional
+              tooltip={TokenFormFieldDescriptions.name}
+            >
+              <FormControl>
+                <Input
+                  {...field}
+                  value={field.value ?? ""}
+                  placeholder="e.g. CI server, Production..."
+                  autoFocus={autoFocus}
+                  onChange={(e) => field.onChange(e.target.value || null)}
+                />
+              </FormControl>
+            </Forms.Field.Header>
+          )}
+          <FormMessage className={titleVariant ? "ml-2" : undefined} />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+function ExpiryField({ fieldVariant }: { fieldVariant?: FieldVariant }) {
+  const form = useFormContext<Schemas.Tokens.BaseValues>()
+  const [open, setOpen] = useState(false)
+
+  return (
+    <FormField
+      control={form.control}
+      name="expiry"
+      render={({ field }) => {
+        const selectedDate = field.value ? parseISO(field.value) : undefined
+
+        return (
+          <FormItem>
+            <Forms.Field.Header
+              label="Expiry date"
+              variant={fieldVariant}
+              optional
+              tooltip={TokenFormFieldDescriptions.expiry}
+            >
+              <FormControl>
+                <Popover open={open} onOpenChange={setOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="outline"
+                      className={cn(
+                        "w-full justify-start text-left font-normal",
+                        !field.value && "text-muted-foreground",
+                      )}
+                    >
+                      <CalendarIcon className="mr-2 size-4 text-content-normal" />
+                      {selectedDate ? (
+                        format(selectedDate, "PPP")
+                      ) : (
+                        <span>Select date</span>
+                      )}
+                      {field.value && (
+                        <span
+                          role="button"
+                          tabIndex={0}
+                          className="ml-auto flex size-6 items-center justify-center rounded-sm opacity-50 hover:opacity-100"
+                          onClick={(e) => {
+                            e.preventDefault()
+                            e.stopPropagation()
+                            field.onChange(null)
+                          }}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault()
+                              e.stopPropagation()
+                              field.onChange(null)
+                            }
+                          }}
+                        >
+                          <X className="size-3.5" />
+                        </span>
+                      )}
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent align="start" className="w-auto p-0">
+                    <Calendars.DatePicker
+                      selected={selectedDate}
+                      onApply={(date) => {
+                        field.onChange(date ? date.toISOString() : null)
+                        setOpen(false)
+                      }}
+                      onCancel={() => setOpen(false)}
+                    />
+                  </PopoverContent>
+                </Popover>
+              </FormControl>
+            </Forms.Field.Header>
+            <FormMessage />
+          </FormItem>
+        )
+      }}
+    />
+  )
+}
+
+function MaxActivationsField({
+  fieldVariant,
+}: {
+  fieldVariant?: FieldVariant
+}) {
+  const form = useFormContext<Schemas.Tokens.BaseValues>()
+
+  return (
+    <FormField
+      control={form.control}
+      name="maxActivations"
+      render={({ field }) => (
+        <FormItem>
+          <Forms.Field.Header
+            label="Max activations"
+            variant={fieldVariant}
+            optional
+            tooltip={TokenFormFieldDescriptions.maxActivations}
+          >
+            <FormControl>
+              <Input
+                type="number"
+                min={0}
+                value={field.value ?? ""}
+                placeholder="Unlimited"
+                onChange={(e) =>
+                  field.onChange(
+                    e.target.value ? parseInt(e.target.value) : null,
+                  )
+                }
+              />
+            </FormControl>
+          </Forms.Field.Header>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+function MaxDeactivationsField({
+  fieldVariant,
+}: {
+  fieldVariant?: FieldVariant
+}) {
+  const form = useFormContext<Schemas.Tokens.BaseValues>()
+
+  return (
+    <FormField
+      control={form.control}
+      name="maxDeactivations"
+      render={({ field }) => (
+        <FormItem>
+          <Forms.Field.Header
+            label="Max deactivations"
+            variant={fieldVariant}
+            optional
+            tooltip={TokenFormFieldDescriptions.maxDeactivations}
+          >
+            <FormControl>
+              <Input
+                type="number"
+                min={0}
+                value={field.value ?? ""}
+                placeholder="Unlimited"
+                onChange={(e) =>
+                  field.onChange(
+                    e.target.value ? parseInt(e.target.value) : null,
+                  )
+                }
+              />
+            </FormControl>
+          </Forms.Field.Header>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
+function PermissionsField({ fieldVariant }: { fieldVariant?: FieldVariant }) {
+  const form = useFormContext<Schemas.Tokens.BaseValues>()
+
+  return (
+    <FormField
+      control={form.control}
+      name="permissions"
+      render={({ field }) => (
+        <FormItem>
+          <Forms.Field.Header
+            label="Permissions"
+            variant={fieldVariant}
+            optional
+            tooltip={TokenFormFieldDescriptions.permissions}
+          >
+            <MultiSelect
+              value={field.value}
+              onChange={field.onChange}
+              options={Permissions.map((permission) => ({
+                label: permission,
+                value: permission,
+              }))}
+              includeNone
+              includeWildcard
+              placeholder="Leave blank to inherit the bearer's permissions"
+            />
+          </Forms.Field.Header>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}

--- a/src/components/tokens/form/fields.tsx
+++ b/src/components/tokens/form/fields.tsx
@@ -124,9 +124,9 @@ export default function TokensFormFields({
       {fields.map((field) => {
         switch (field) {
           case "bearerKind":
-            return <BearerKindField key="bearerKind" />
+            return <BearerTypeField key="bearerKind" />
           case "bearerId":
-            return <BearerField key="bearerId" fieldVariant={fieldVariant} />
+            return <BearerIdField key="bearerId" fieldVariant={fieldVariant} />
           case "name":
             return (
               <NameField
@@ -164,7 +164,7 @@ export default function TokensFormFields({
   )
 }
 
-function BearerKindField() {
+function BearerTypeField() {
   const form = useFormContext<Schemas.Tokens.BaseValues>()
 
   return (
@@ -191,7 +191,7 @@ function BearerKindField() {
   )
 }
 
-function BearerField({ fieldVariant }: { fieldVariant?: FieldVariant }) {
+function BearerIdField({ fieldVariant }: { fieldVariant?: FieldVariant }) {
   const form = useFormContext<Schemas.Tokens.BaseValues>()
   const kind = useWatch({ control: form.control, name: "bearerKind" })
 

--- a/src/components/tokens/form/index.ts
+++ b/src/components/tokens/form/index.ts
@@ -1,0 +1,2 @@
+export { default as Create } from "./create"
+export { default as Fields } from "./fields"

--- a/src/components/tokens/index.ts
+++ b/src/components/tokens/index.ts
@@ -1,0 +1,12 @@
+import * as Form from "./form"
+export { Form }
+
+import * as View from "./view"
+export { View }
+
+import * as Dialog from "./dialog"
+export { Dialog }
+
+export { default as FilterBar } from "./filter-bar"
+export { default as AllAttributes } from "./all-attributes"
+export { default as AttributeGroup } from "./attribute-group"

--- a/src/components/tokens/view/index.ts
+++ b/src/components/tokens/view/index.ts
@@ -1,0 +1,1 @@
+export { default as Internal } from "./internal"

--- a/src/components/tokens/view/internal.tsx
+++ b/src/components/tokens/view/internal.tsx
@@ -1,0 +1,141 @@
+import { useMemo, useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { ScrollArea } from "@/components/ui/scroll-area"
+
+import { useResourceNavigate } from "@/hooks/use-resource-navigate"
+
+import { useListTokens } from "@/queries/tokens"
+
+import { Token, TokenKindLabels, InternalTokenKinds } from "@/types/tokens"
+
+import * as Tokens from "@/components/tokens"
+import Can from "@/components/can"
+import ClipboardButton from "@/components/clipboard-button"
+
+const PREVIEW_COUNT = 10
+
+export default function InternalTokensPage() {
+  const navigateToResource = useResourceNavigate()
+
+  // FIXME(cazden) query by type when API supports it
+  const { data: tokens, isLoading } = useListTokens({ pageSize: 100 })
+
+  // manually filter for now
+  const internalTokens = useMemo(
+    () =>
+      tokens.filter((token) =>
+        InternalTokenKinds.includes(token.attributes.kind),
+      ),
+    [tokens],
+  )
+
+  const [createOpen, setCreateOpen] = useState(false)
+  const [viewAllOpen, setViewAllOpen] = useState(false)
+
+  const handleNavigate = async (token: Token) => {
+    setViewAllOpen(false)
+    await navigateToResource(token)
+  }
+
+  const preview = internalTokens.slice(0, PREVIEW_COUNT)
+  const remaining = internalTokens.length - preview.length
+
+  return (
+    <div className="overflow-hidden rounded bg-background-1">
+      <Can permission="token.generate">
+        <div className="flex items-center justify-end border-b border-accent p-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setCreateOpen(true)}
+            className="border-none bg-background-2"
+          >
+            New Token
+          </Button>
+        </div>
+      </Can>
+
+      <div className="flex flex-col">
+        {isLoading ? (
+          <div className="space-y-3 p-4">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        ) : internalTokens.length === 0 ? (
+          <span className="p-4 text-sm text-content-subdued">
+            No internal access tokens yet. Create one to start integrating with
+            the Keygen API.
+          </span>
+        ) : (
+          <>
+            <ScrollArea className="h-80">
+              {preview.map((token) => (
+                <TokenRow
+                  key={token.id}
+                  token={token}
+                  onNavigate={handleNavigate}
+                />
+              ))}
+            </ScrollArea>
+            {remaining > 0 && (
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => setViewAllOpen(true)}
+                className="h-12 rounded-t-none border-t border-accent text-sm text-primary transition-colors hover:bg-background-2"
+              >
+                View all tokens
+              </Button>
+            )}
+          </>
+        )}
+      </div>
+
+      <Tokens.Form.Create open={createOpen} onOpenChange={setCreateOpen} />
+
+      <Tokens.Dialog.Internal
+        open={viewAllOpen}
+        onOpenChange={setViewAllOpen}
+      />
+    </div>
+  )
+}
+
+interface TokenRowProps {
+  token: Token
+  onNavigate: (token: Token) => void
+}
+
+function TokenRow({ token, onNavigate }: TokenRowProps) {
+  return (
+    <div
+      onClick={() => onNavigate(token)}
+      className="flex cursor-pointer items-center gap-3 border-b border-accent p-3 transition-colors last:border-b-0 hover:bg-background-2"
+    >
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm text-content-loud">
+            {token.attributes.name || (
+              <span className="flex items-center font-normal text-content-disabled">
+                {"(name not set)"}
+              </span>
+            )}
+          </span>
+          <Badge variant="secondary" className="px-1 text-xs">
+            {TokenKindLabels[token.attributes.kind] ?? token.attributes.kind}
+          </Badge>
+        </div>
+        <span className="text-xs text-content-subdued">
+          {token.attributes.expiry
+            ? `Expires ${new Date(token.attributes.expiry).toLocaleDateString()}`
+            : "Never expires"}
+        </span>
+      </div>
+
+      <ClipboardButton value={token.id} className="w-fit text-sm" />
+    </div>
+  )
+}

--- a/src/components/tokens/view/internal.tsx
+++ b/src/components/tokens/view/internal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -9,7 +9,7 @@ import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import { useListTokens } from "@/queries/tokens"
 
-import { Token, TokenKindLabels, InternalTokenKinds } from "@/types/tokens"
+import { Token, TokenKindLabels, InternalTokenRoles } from "@/types/tokens"
 
 import * as Tokens from "@/components/tokens"
 import Can from "@/components/can"
@@ -20,17 +20,10 @@ const PREVIEW_COUNT = 10
 export default function InternalTokensPage() {
   const navigateToResource = useResourceNavigate()
 
-  // FIXME(cazden) query by type when API supports it
-  const { data: tokens, isLoading } = useListTokens({ pageSize: 100 })
-
-  // manually filter for now
-  const internalTokens = useMemo(
-    () =>
-      tokens.filter((token) =>
-        InternalTokenKinds.includes(token.attributes.kind),
-      ),
-    [tokens],
-  )
+  const { data: internalTokens, isLoading } = useListTokens({
+    pageSize: 100,
+    filters: { bearerRoles: [...InternalTokenRoles] },
+  })
 
   const [createOpen, setCreateOpen] = useState(false)
   const [viewAllOpen, setViewAllOpen] = useState(false)

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -81,7 +81,10 @@ function Input({
       return (
         <Tooltip>
           <TooltipTrigger asChild>
-            <span tabIndex={0} className="block">
+            <span
+              tabIndex={0}
+              className="block rounded-md transition-colors hover:bg-background-1"
+            >
               {element}
             </span>
           </TooltipTrigger>

--- a/src/hooks/use-token-table-columns.tsx
+++ b/src/hooks/use-token-table-columns.tsx
@@ -1,0 +1,65 @@
+import { useMemo } from "react"
+
+import { Badge } from "@/components/ui/badge"
+
+import { Token, TokenKindLabels } from "@/types/tokens"
+
+import { createTableColumnHelper } from "@/lib/tables"
+
+import ResourceLink from "@/components/resource-link"
+import ClipboardButton from "@/components/clipboard-button"
+
+const column = createTableColumnHelper<Token>()
+
+export function useTokenTableColumns() {
+  return useMemo(
+    () => [
+      column.id({
+        header: "ID",
+        cell: (info) => <ClipboardButton value={info.getValue()} />,
+      }),
+      column.attr("kind", {
+        header: "Type",
+        cell: (info) => {
+          const kind = info.getValue()
+          return (
+            <Badge variant="secondary">{TokenKindLabels[kind] ?? kind}</Badge>
+          )
+        },
+      }),
+      column.attr("name", {
+        header: "Name",
+        cell: (info) =>
+          info.getValue() || <span className="text-content-muted">--</span>,
+      }),
+      column.rel("bearer", {
+        header: "Bearer",
+        enableSorting: false,
+        cell: (info) => <ResourceLink linkage={info.getValue()?.data} />,
+      }),
+      column.attr("expiry", {
+        sortingFn: "datetime",
+        header: "Expiry",
+        cell: (info) => {
+          const value = info.getValue()
+          return value ? (
+            new Date(value).toLocaleDateString()
+          ) : (
+            <span className="text-content-subdued">Never</span>
+          )
+        },
+      }),
+      column.attr("created", {
+        sortingFn: "datetime",
+        header: "Created",
+        cell: (info) => new Date(info.getValue()).toLocaleDateString(),
+      }),
+      column.attr("updated", {
+        sortingFn: "datetime",
+        header: "Updated",
+        cell: (info) => new Date(info.getValue()).toLocaleDateString(),
+      }),
+    ],
+    [],
+  )
+}

--- a/src/hooks/use-token-table-columns.tsx
+++ b/src/hooks/use-token-table-columns.tsx
@@ -35,7 +35,9 @@ export function useTokenTableColumns() {
       column.rel("bearer", {
         header: "Bearer",
         enableSorting: false,
-        cell: (info) => <ResourceLink linkage={info.getValue()?.data} />,
+        cell: (info) => (
+          <ResourceLink linkage={info.getValue()?.data} truncate />
+        ),
       }),
       column.attr("expiry", {
         sortingFn: "datetime",

--- a/src/keygen/client.ts
+++ b/src/keygen/client.ts
@@ -63,9 +63,21 @@ export class Client {
       root?: boolean
       signal?: AbortSignal
       prefix?: string
+      environment?: string | null
+      environmentToken?: string | null
     } = {},
   ): Promise<APIResponse<T>> {
-    const authToken = options.root ? this.rootToken : this.activeToken
+    // override to target an environment other than the active one
+    // e.g. creating an environment token from the global context
+    const envHeader =
+      options.environment !== undefined ? options.environment : this.environment
+
+    const authToken = options.root
+      ? this.rootToken
+      : options.environmentToken !== undefined
+        ? options.environmentToken
+        : this.activeToken
+
     const defaultHeaders = {
       Accept: "application/vnd.api+json",
       "Content-Type": "application/vnd.api+json",
@@ -73,9 +85,9 @@ export class Client {
       ...(config.isTokenAuthenticated && authToken
         ? { Authorization: `Bearer ${authToken}` }
         : {}),
-      ...(options.root || !this.environment
+      ...(options.root || !envHeader
         ? {}
-        : { "Keygen-Environment": this.environment }),
+        : { "Keygen-Environment": envHeader }),
     }
 
     const headers = {
@@ -83,8 +95,11 @@ export class Client {
       ...options.headers,
     }
 
-    const { root, prefix, ...fetchOptions } = options
+    const { root, prefix, environment, environmentToken, ...fetchOptions } =
+      options
     void root
+    void environment
+    void environmentToken
 
     const response = await fetch(`${this.host}/${prefix ?? "v1"}${endpoint}`, {
       ...fetchOptions,

--- a/src/keygen/tokens/create-for-bearer.ts
+++ b/src/keygen/tokens/create-for-bearer.ts
@@ -1,0 +1,54 @@
+import config from "@/keygen/config"
+import client from "@/keygen/client"
+
+import * as Schemas from "@/schemas"
+import { compact } from "@/lib/compact"
+
+import { TokenResponse, TokenBearerKind } from "@/types/tokens"
+
+config.validate()
+
+interface CreateForBearerProps {
+  values: Schemas.Tokens.CreateValues
+  bearerType: string
+  environment?: string | null
+  environmentToken?: string | null
+}
+
+export default async function createForBearer({
+  values,
+  bearerType,
+  environment,
+  environmentToken,
+}: CreateForBearerProps): Promise<TokenResponse> {
+  const isLicense = values.bearerKind === TokenBearerKind.License
+
+  const body = {
+    data: {
+      type: "tokens",
+      attributes: compact({
+        name: values.name || undefined,
+        expiry: isLicense ? values.expiry : undefined,
+        maxActivations: isLicense ? values.maxActivations : undefined,
+        maxDeactivations: isLicense ? values.maxDeactivations : undefined,
+        permissions:
+          !config.isCE && values.permissions?.length
+            ? values.permissions
+            : undefined,
+      }),
+    },
+  }
+
+  const result = (await client.request(
+    `/accounts/${config.id}/${bearerType}/${values.bearerId}/tokens`,
+    {
+      method: "POST",
+      body: JSON.stringify(body),
+      ...(environment != null
+        ? { environment, environmentToken }
+        : { root: true }),
+    },
+  )) as TokenResponse
+
+  return result
+}

--- a/src/keygen/tokens/create-for-bearer.ts
+++ b/src/keygen/tokens/create-for-bearer.ts
@@ -28,7 +28,7 @@ export default async function createForBearer({
       type: "tokens",
       attributes: compact({
         name: values.name || undefined,
-        expiry: isLicense ? values.expiry : undefined,
+        expiry: values.expiry,
         maxActivations: isLicense ? values.maxActivations : undefined,
         maxDeactivations: isLicense ? values.maxDeactivations : undefined,
         permissions:

--- a/src/keygen/tokens/create.ts
+++ b/src/keygen/tokens/create.ts
@@ -27,7 +27,7 @@ export default async function create({
         ? {
             attributes: compact({
               name: values.name || undefined,
-              expiry: isLicense ? values.expiry : undefined,
+              expiry: values.expiry,
               maxActivations: isLicense ? values.maxActivations : undefined,
               maxDeactivations: isLicense ? values.maxDeactivations : undefined,
               permissions:

--- a/src/keygen/tokens/create.ts
+++ b/src/keygen/tokens/create.ts
@@ -1,15 +1,45 @@
 import config from "@/keygen/config"
 import client from "@/keygen/client"
-import { TokenResponse, CreateTokenPayload } from "@/types/tokens"
+
+import { Linkage } from "@/types/api"
+import { TokenResponse, TokenBearerKind } from "@/types/tokens"
+
+import * as Schemas from "@/schemas"
+import { compact } from "@/lib/compact"
 
 config.validate()
 
+interface CreateProps {
+  values?: Schemas.Tokens.CreateValues
+  relationships?: { environment?: { data: Linkage<"environments"> } }
+}
+
 export default async function create({
+  values,
   relationships,
-}: {
-  relationships: CreateTokenPayload
-}): Promise<TokenResponse> {
-  const body = { data: { type: "tokens", relationships } }
+}: CreateProps): Promise<TokenResponse> {
+  const isLicense = values?.bearerKind === TokenBearerKind.License
+
+  const body = {
+    data: {
+      type: "tokens",
+      ...(values != null
+        ? {
+            attributes: compact({
+              name: values.name || undefined,
+              expiry: isLicense ? values.expiry : undefined,
+              maxActivations: isLicense ? values.maxActivations : undefined,
+              maxDeactivations: isLicense ? values.maxDeactivations : undefined,
+              permissions:
+                !config.isCE && values.permissions?.length
+                  ? values.permissions
+                  : undefined,
+            }),
+          }
+        : {}),
+      ...(relationships != null ? { relationships } : {}),
+    },
+  }
 
   const result = (await client.request(`/accounts/${config.id}/tokens`, {
     method: "POST",

--- a/src/keygen/tokens/get.ts
+++ b/src/keygen/tokens/get.ts
@@ -1,0 +1,17 @@
+import config from "@/keygen/config"
+import client from "@/keygen/client"
+import { TokenResponse } from "@/types/tokens"
+
+config.validate()
+
+interface GetProps {
+  id: string
+}
+
+export default async function get({ id }: GetProps): Promise<TokenResponse> {
+  const result = (await client.request(`/accounts/${config.id}/tokens/${id}`, {
+    method: "GET",
+  })) as TokenResponse
+
+  return result
+}

--- a/src/keygen/tokens/index.ts
+++ b/src/keygen/tokens/index.ts
@@ -1,2 +1,6 @@
-export { default as create } from "./create"
+export { default as get } from "./get"
+export { default as list } from "./list"
 export { default as revoke } from "./revoke"
+export { default as create } from "./create"
+export { default as createForBearer } from "./create-for-bearer"
+export { default as regenerate } from "./regenerate"

--- a/src/keygen/tokens/list.ts
+++ b/src/keygen/tokens/list.ts
@@ -25,12 +25,16 @@ export default async function list({
     params.set("page[size]", pageSize.toString())
     params.set("page[cursor]", pageCursor ?? "")
   }
-  // TODO(cazden) add filter by type when API supports it
   if (filters?.bearerType) {
     params.set("bearer[type]", filters.bearerType)
   }
   if (filters?.bearerId) {
     params.set("bearer[id]", filters.bearerId)
+  }
+  if (filters?.bearerRoles?.length) {
+    for (const role of filters.bearerRoles) {
+      params.append("bearer[role][]", role)
+    }
   }
   if (filters?.environment) {
     params.set("environment", filters.environment)

--- a/src/keygen/tokens/list.ts
+++ b/src/keygen/tokens/list.ts
@@ -1,0 +1,47 @@
+import config from "@/keygen/config"
+import client from "@/keygen/client"
+import { TokensListResponse, type TokenFilters } from "@/types/tokens"
+
+config.validate()
+
+interface ListProps {
+  limit?: number
+  pageCursor?: string | null
+  pageSize?: number
+  filters?: TokenFilters
+}
+
+export default async function list({
+  limit,
+  pageCursor,
+  pageSize,
+  filters,
+}: ListProps): Promise<TokensListResponse> {
+  const params = new URLSearchParams()
+  if (limit != null) {
+    params.set("limit", limit.toString())
+  }
+  if (pageSize != null) {
+    params.set("page[size]", pageSize.toString())
+    params.set("page[cursor]", pageCursor ?? "")
+  }
+  // TODO(cazden) add filter by type when API supports it
+  if (filters?.bearerType) {
+    params.set("bearer[type]", filters.bearerType)
+  }
+  if (filters?.bearerId) {
+    params.set("bearer[id]", filters.bearerId)
+  }
+  if (filters?.environment) {
+    params.set("environment", filters.environment)
+  }
+
+  const result = (await client.request(
+    `/accounts/${config.id}/tokens?${params.toString()}`,
+    {
+      method: "GET",
+    },
+  )) as TokensListResponse
+
+  return result
+}

--- a/src/keygen/tokens/regenerate.ts
+++ b/src/keygen/tokens/regenerate.ts
@@ -13,7 +13,6 @@ export default async function regenerate({
 }: RegenerateProps): Promise<TokenResponse> {
   const result = (await client.request(`/accounts/${config.id}/tokens/${id}`, {
     method: "PUT",
-    root: true,
   })) as TokenResponse
 
   return result

--- a/src/keygen/tokens/regenerate.ts
+++ b/src/keygen/tokens/regenerate.ts
@@ -1,0 +1,20 @@
+import config from "@/keygen/config"
+import client from "@/keygen/client"
+import { TokenResponse } from "@/types/tokens"
+
+config.validate()
+
+interface RegenerateProps {
+  id: string
+}
+
+export default async function regenerate({
+  id,
+}: RegenerateProps): Promise<TokenResponse> {
+  const result = (await client.request(`/accounts/${config.id}/tokens/${id}`, {
+    method: "PUT",
+    root: true,
+  })) as TokenResponse
+
+  return result
+}

--- a/src/keygen/users/get.ts
+++ b/src/keygen/users/get.ts
@@ -11,6 +11,7 @@ interface GetProps {
 export default async function get({ id }: GetProps): Promise<UserResponse> {
   const result = (await client.request(`/accounts/${config.id}/users/${id}`, {
     method: "GET",
+    root: client.currentUser === id,
   })) as UserResponse
 
   return result

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -1,0 +1,37 @@
+import * as keygen from "@/keygen"
+
+import { Token, TokenAttributes } from "@/types/tokens"
+
+import { AttributeType } from "@/components/attribute/value"
+
+export const tokenAttributeTypeSchema: Record<
+  keyof Omit<TokenAttributes, "created" | "updated" | "permissions" | "token">,
+  AttributeType
+> = {
+  kind: "raw",
+  name: "raw",
+  expiry: "date",
+  activations: "number",
+  maxActivations: "number",
+  deactivations: "number",
+  maxDeactivations: "number",
+}
+
+const BASE =
+  "This permanently revokes the token. Any integration using it will immediately lose access. This cannot be undone."
+
+export function revokeTokenDescription(
+  token: Token | null | undefined,
+): string {
+  if (!token) return BASE
+
+  if (token.id === keygen.client.currentTokenId) {
+    return `${BASE} You're currently authenticated with this token, so revoking it will sign you out and require you to re-authenticate.`
+  }
+
+  if (token.attributes.kind === "admin-token") {
+    return `${BASE} Admin tokens can authenticate your portal session, so revoking this token may sign you out and require you to re-authenticate.`
+  }
+
+  return BASE
+}

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -17,21 +17,21 @@ export const tokenAttributeTypeSchema: Record<
   maxDeactivations: "number",
 }
 
-const BASE =
+const BASE_REVOCATION_DESCRIPTION =
   "This permanently revokes the token. Any integration using it will immediately lose access. This cannot be undone."
 
 export function revokeTokenDescription(
   token: Token | null | undefined,
 ): string {
-  if (!token) return BASE
+  if (!token) return BASE_REVOCATION_DESCRIPTION
 
   if (token.id === keygen.client.currentTokenId) {
-    return `${BASE} You're currently authenticated with this token, so revoking it will sign you out and require you to re-authenticate.`
+    return `${BASE_REVOCATION_DESCRIPTION} You're currently authenticated with this token, so revoking it will sign you out and require you to re-authenticate.`
   }
 
   if (token.attributes.kind === "admin-token") {
-    return `${BASE} Admin tokens can authenticate your portal session, so revoking this token may sign you out and require you to re-authenticate.`
+    return `${BASE_REVOCATION_DESCRIPTION} Admin tokens can authenticate your Portal session, so revoking this token may sign you out and require you to re-authenticate.`
   }
 
-  return BASE
+  return BASE_REVOCATION_DESCRIPTION
 }

--- a/src/pages/app/index.ts
+++ b/src/pages/app/index.ts
@@ -19,6 +19,7 @@ export { default as EventLogs } from "./event-logs"
 export { default as RequestLogs } from "./request-logs"
 export { default as WebhookEndpoints } from "./webhook-endpoints"
 export { default as WebhookEvents } from "./webhook-events"
+export { default as Tokens } from "./tokens"
 
 import * as Product from "./product"
 export { Product }
@@ -79,6 +80,9 @@ export { WebhookEndpoint }
 
 import * as WebhookEvent from "./webhook-event"
 export { WebhookEvent }
+
+import * as Token from "./token"
+export { Token }
 
 import * as Settings from "./settings"
 export { Settings }

--- a/src/pages/app/settings/developers.tsx
+++ b/src/pages/app/settings/developers.tsx
@@ -37,7 +37,7 @@ export default function DevelopersPage() {
           <div className="grid w-full max-w-5xl grid-cols-1 gap-x-16 gap-y-8 md:grid-cols-[1fr_2fr]">
             <div className="flex flex-col space-y-2">
               <h2 className="font-owners-wide text-lg text-content-loud">
-                Internal access tokens
+                Internal Access Tokens
               </h2>
               <p className="font-owners-text text-sm text-content-muted">
                 Tokens for authenticating your own integrations with the Keygen

--- a/src/pages/app/settings/developers.tsx
+++ b/src/pages/app/settings/developers.tsx
@@ -54,7 +54,7 @@ export default function DevelopersPage() {
                 Configure API version and account protection.
               </p>
             </div>
-            <div className="overflow-hidden rounded bg-background-1 p-4">
+            <div className="overflow-hidden rounded bg-background-1">
               {accountLoading ? (
                 <div className="space-y-4">
                   <Skeleton className="h-12 w-full" />

--- a/src/pages/app/settings/developers.tsx
+++ b/src/pages/app/settings/developers.tsx
@@ -16,6 +16,7 @@ import {
 import * as Motion from "@/components/motion"
 import * as Account from "@/components/account"
 import * as Attribute from "@/components/attribute"
+import * as Tokens from "@/components/tokens"
 import Can from "@/components/can"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
@@ -34,6 +35,17 @@ export default function DevelopersPage() {
       <ScrollArea className="min-h-0 flex-1 overflow-y-auto">
         <div className="flex flex-col px-4 py-4 md:px-10 md:py-8">
           <div className="grid w-full max-w-5xl grid-cols-1 gap-x-16 gap-y-8 md:grid-cols-[1fr_2fr]">
+            <div className="flex flex-col space-y-2">
+              <h2 className="font-owners-wide text-lg text-content-loud">
+                Internal access tokens
+              </h2>
+              <p className="font-owners-text text-sm text-content-muted">
+                Tokens for authenticating your own integrations with the Keygen
+                API.
+              </p>
+            </div>
+            <Tokens.View.Internal />
+
             <div className="flex flex-col space-y-2">
               <h2 className="font-owners-wide text-lg text-content-loud">
                 Developer Settings

--- a/src/pages/app/token/details.tsx
+++ b/src/pages/app/token/details.tsx
@@ -1,0 +1,530 @@
+import { useState, useEffect } from "react"
+import { useParams } from "@tanstack/react-router"
+import { formatDate } from "date-fns"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Separator } from "@/components/ui/separator"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent } from "@/components/ui/tabs"
+import {
+  Sidebar,
+  SidebarHeader,
+  SidebarContent,
+  SidebarFooter,
+} from "@/components/ui/sidebar"
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbPage,
+  BreadcrumbLink,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+
+import {
+  Copy,
+  Menu,
+  Logs,
+  GitFork,
+  SquarePen,
+  SquarePlus,
+  TriangleAlert,
+} from "lucide-react"
+
+import { useMobile } from "@/hooks/use-mobile"
+import { useSidebarTab } from "@/hooks/use-sidebar-tab"
+import { useBackNavigate } from "@/hooks/use-back-navigate"
+import {
+  useGetToken,
+  useRevokeToken,
+  useRegenerateToken,
+} from "@/queries/tokens"
+
+import {
+  TokenKindLabels,
+  TokenKindDescriptions,
+  TokenAttributeDescriptions,
+} from "@/types/tokens"
+
+import { toast } from "@/lib/toast"
+import { copyToClipboard } from "@/lib/clipboard"
+import { revokeTokenDescription } from "@/lib/tokens"
+
+import * as Property from "@/components/property"
+import * as Attribute from "@/components/attribute"
+import * as EventLogs from "@/components/event-logs"
+import * as Tokens from "@/components/tokens"
+import Can from "@/components/can"
+import PageHeader from "@/components/page-header"
+import BackButton from "@/components/back-button"
+import TabsSwitch from "@/components/tabs-switch"
+import TooltipBadge from "@/components/tooltip-badge"
+import ResourceLink from "@/components/resource-link"
+import CollapsibleCard from "@/components/collapsible-card"
+import CollapsibleMenu from "@/components/collapsible-menu"
+import ConfirmationModal from "@/components/confirmation-modal"
+
+export default function TokenDetails() {
+  const { id } = useParams({ from: "/$accountId/app/tokens/$id" })
+  const { data: token, isLoading, isFetching, isError } = useGetToken(id)
+  const revokeToken = useRevokeToken()
+  const regenerateToken = useRegenerateToken()
+
+  const back = useBackNavigate()
+  const isMobile = useMobile()
+  const [tab, setTab] = useSidebarTab()
+
+  const [open, setOpen] = useState({
+    revoke: false,
+    regenerate: false,
+    attributes: false,
+  })
+  const [secret, setSecret] = useState<string | null>(null)
+
+  useEffect(() => {
+    ;(async () => {
+      if (isError && !isFetching) {
+        await back()
+      }
+    })()
+  }, [isError, isFetching, back])
+
+  const handleRevoke = () => {
+    revokeToken.mutate(
+      { id },
+      {
+        onSuccess: async () => {
+          toast({ message: "Token revoked", variant: "success" })
+          await back()
+        },
+        onError: () => {
+          toast({ message: "Failed to revoke token", variant: "error" })
+        },
+      },
+    )
+  }
+
+  const handleRegenerate = () => {
+    regenerateToken.mutate(
+      { id },
+      {
+        onSuccess: (regenerated) => {
+          toast({ message: "Token regenerated", variant: "success" })
+          setOpen((prev) => ({ ...prev, regenerate: false }))
+          setSecret(regenerated.attributes.token ?? null)
+        },
+        onError: () => {
+          toast({ message: "Failed to regenerate token", variant: "error" })
+        },
+      },
+    )
+  }
+
+  const properties = token ? (
+    <>
+      <Property.Field
+        icon={SquarePlus}
+        label="Created at"
+        value={formatDate(new Date(String(token.attributes.created)), "PP")}
+      />
+      <Property.Field
+        icon={SquarePen}
+        label="Updated at"
+        value={formatDate(new Date(String(token.attributes.updated)), "PP")}
+      />
+    </>
+  ) : (
+    <div className="flex flex-col space-y-2">
+      <Skeleton className="h-4 w-3/4" />
+      <Skeleton className="h-4 w-1/2" />
+    </div>
+  )
+
+  return (
+    <section className="flex h-screen w-full">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <PageHeader>
+          <Breadcrumb className="flex-1">
+            <BreadcrumbList className="text-base">
+              <BreadcrumbItem>
+                <BreadcrumbLink
+                  className="cursor-pointer"
+                  onClick={() => back()}
+                >
+                  Tokens
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator />
+              <BreadcrumbItem>
+                {token ? (
+                  <BreadcrumbPage>
+                    {token.attributes.name || token.id}
+                  </BreadcrumbPage>
+                ) : (
+                  <Skeleton className="h-6 w-32" />
+                )}
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+
+          <div className="flex items-center gap-2">
+            <Can permission="token.regenerate">
+              <Button
+                variant="outline"
+                disabled={isLoading}
+                onClick={() =>
+                  setOpen((prev) => ({ ...prev, regenerate: true }))
+                }
+              >
+                Regenerate
+              </Button>
+            </Can>
+            <Can permission="token.revoke">
+              <Button
+                variant="outline"
+                disabled={isLoading}
+                onClick={() => setOpen((prev) => ({ ...prev, revoke: true }))}
+              >
+                Revoke
+              </Button>
+            </Can>
+          </div>
+        </PageHeader>
+
+        {token ? (
+          <ScrollArea className="min-h-0 flex-1 overflow-y-auto">
+            <div className="px-4 py-6 md:px-10 md:py-8">
+              <BackButton className="mb-8" />
+
+              {token.attributes.kind === "admin-token" && (
+                <div className="mb-6 flex items-start gap-2 rounded-md bg-warning/20 p-3 text-sm text-pretty text-warning">
+                  <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+                  <p className="flex flex-col text-xs">
+                    <strong>
+                      Admin tokens should be used sparingly for API
+                      integrations.
+                    </strong>
+                    <span className="text-pretty">
+                      Admin tokens are automatically revoked when the admin's
+                      password is changed, when its second factors are changed,
+                      or when the admin's role or permissions are changed. As
+                      such, we <strong>DO NOT</strong> recommend using admin
+                      tokens for API integrations. Doing so could cause your API
+                      integration to break unexpectedly.
+                    </span>
+                  </p>
+                </div>
+              )}
+
+              <div className="mb-2">
+                <TooltipBadge
+                  variant="secondary"
+                  value={TokenKindLabels[token.attributes.kind]}
+                  tooltip={TokenKindDescriptions[token.attributes.kind]}
+                  className="px-1 text-xs"
+                />
+              </div>
+              <div className="flex flex-col gap-3 md:flex-row md:items-center">
+                <h1 className="font-owners-wide text-2xl font-medium">
+                  {token.attributes.name || (
+                    <span className="flex items-center text-lg font-normal text-content-disabled">
+                      {"(name not set)"}
+                    </span>
+                  )}
+                </h1>
+                <Button
+                  variant="clipboard"
+                  size="clipboard"
+                  onClick={() => copyToClipboard(token.id)}
+                  className="w-fit pb-0.5"
+                >
+                  {token.id}
+                  <Copy className="size-4 pt-0.5 md:size-3" />
+                </Button>
+              </div>
+
+              <div className="mt-6 space-y-6 md:mt-8">
+                <CollapsibleCard title="Attributes">
+                  <div className="flex flex-col space-y-4 md:flex-row md:space-y-0">
+                    <div className="flex-1 space-y-4">
+                      <Attribute.Field
+                        variant="none"
+                        label="Subtype"
+                        value={
+                          <Attribute.Value
+                            type="raw"
+                            value={token.attributes.kind}
+                            tooltip="The kind of token, derived from its bearer (e.g. admin-token, user-token)."
+                          />
+                        }
+                      />
+                      {token.attributes.activations != null && (
+                        <>
+                          <Attribute.Field
+                            variant="none"
+                            label="Activations"
+                            value={
+                              <Attribute.Value
+                                type="raw"
+                                value={String(token.attributes.activations)}
+                                tooltip={TokenAttributeDescriptions.activations}
+                              />
+                            }
+                          />
+                          <Attribute.Field
+                            variant="none"
+                            label="Deactivations"
+                            value={
+                              <Attribute.Value
+                                type="raw"
+                                value={String(
+                                  token.attributes.deactivations ?? 0,
+                                )}
+                                tooltip={
+                                  TokenAttributeDescriptions.deactivations
+                                }
+                              />
+                            }
+                          />
+                        </>
+                      )}
+                    </div>
+                    <div className="mx-4 hidden md:block">
+                      <Separator orientation="vertical" dashed={true} />
+                    </div>
+                    <div className="flex-1 space-y-4">
+                      <Attribute.Field
+                        variant="none"
+                        label="Expiry"
+                        value={
+                          <Attribute.Value
+                            type="raw"
+                            value={
+                              token.attributes.expiry
+                                ? formatDate(
+                                    new Date(token.attributes.expiry),
+                                    "PP",
+                                  )
+                                : null
+                            }
+                            emptyLabel="Never"
+                            tooltip={TokenAttributeDescriptions.expiry}
+                          />
+                        }
+                      />
+                      {token.attributes.activations != null && (
+                        <>
+                          <Attribute.Field
+                            variant="none"
+                            label="Max activations"
+                            value={
+                              <Attribute.Value
+                                type="raw"
+                                value={
+                                  token.attributes.maxActivations != null
+                                    ? String(token.attributes.maxActivations)
+                                    : null
+                                }
+                                emptyLabel="Unlimited"
+                                tooltip={
+                                  TokenAttributeDescriptions.maxActivations
+                                }
+                              />
+                            }
+                          />
+                          <Attribute.Field
+                            variant="none"
+                            label="Max deactivations"
+                            value={
+                              <Attribute.Value
+                                type="raw"
+                                value={
+                                  token.attributes.maxDeactivations != null
+                                    ? String(token.attributes.maxDeactivations)
+                                    : null
+                                }
+                                emptyLabel="Unlimited"
+                                tooltip={
+                                  TokenAttributeDescriptions.maxDeactivations
+                                }
+                              />
+                            }
+                          />
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  <CollapsibleMenu title="Permissions" defaultOpen={false}>
+                    {token.attributes.permissions != null &&
+                    token.attributes.permissions.length > 0 ? (
+                      <div className="flex max-w-full flex-wrap gap-2">
+                        {token.attributes.permissions.map(
+                          (permission, index) => (
+                            <Badge
+                              key={index}
+                              className="text-sm text-content-muted"
+                            >
+                              {permission}
+                            </Badge>
+                          ),
+                        )}
+                      </div>
+                    ) : (
+                      <p className="text-sm text-content-muted">
+                        No permissions defined.
+                      </p>
+                    )}
+                  </CollapsibleMenu>
+                </CollapsibleCard>
+
+                <CollapsibleCard title="Relationships">
+                  <div className="grid gap-4">
+                    <Attribute.Field
+                      variant="text"
+                      label="Bearer"
+                      value={
+                        <ResourceLink
+                          linkage={token.relationships.bearer?.data}
+                        />
+                      }
+                    />
+                    <Attribute.Field
+                      variant="text"
+                      label="Environment"
+                      value={
+                        <ResourceLink
+                          linkage={token.relationships.environment?.data}
+                          emptyLabel="Global"
+                        />
+                      }
+                    />
+                  </div>
+                </CollapsibleCard>
+
+                {isMobile && (
+                  <CollapsibleCard title="Properties" contentClass="space-y-2">
+                    {properties}
+                  </CollapsibleCard>
+                )}
+
+                {isMobile && (
+                  <CollapsibleCard title="Events">
+                    <EventLogs.Feed
+                      compact
+                      filters={{ resource: { type: "token", id } }}
+                    />
+                  </CollapsibleCard>
+                )}
+
+                {isMobile && (
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      setOpen((prev) => ({ ...prev, attributes: true }))
+                    }
+                    className="w-full text-content-muted"
+                  >
+                    <Logs className="mt-0.5 size-4 text-content-normal" />
+                    View All Attributes
+                  </Button>
+                )}
+              </div>
+            </div>
+          </ScrollArea>
+        ) : (
+          <div className="space-y-4 p-4 md:px-10 md:py-8">
+            <Skeleton className="h-6 w-24" />
+            <div className="mb-8 flex items-center gap-4">
+              <Skeleton className="h-8 w-48" />
+              <Skeleton className="h-8 w-32" />
+            </div>
+            <div className="space-y-4">
+              <Skeleton className="h-10 w-full" />
+              <Skeleton className="h-10 w-full" />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {!isMobile && (
+        <Tabs value={tab} onValueChange={setTab}>
+          <Sidebar className="w-64 shrink-0" side="right">
+            <SidebarHeader className="min-h-[70px] justify-end p-0">
+              <TabsSwitch
+                options={[
+                  { value: "overview", label: "Overview", icon: Menu },
+                  { value: "events", label: "Events", icon: GitFork },
+                ]}
+              />
+            </SidebarHeader>
+            <SidebarContent>
+              <TabsContent value="overview" className="space-y-4 p-4">
+                <Property.Section title="Properties">
+                  {properties}
+                </Property.Section>
+              </TabsContent>
+
+              <TabsContent
+                value="events"
+                className="flex min-h-0 flex-1 flex-col p-0"
+              >
+                <EventLogs.Feed
+                  compact
+                  filters={{ resource: { type: "token", id } }}
+                />
+              </TabsContent>
+            </SidebarContent>
+            <SidebarFooter className="p-4">
+              <Button
+                variant="outline"
+                onClick={() =>
+                  setOpen((prev) => ({ ...prev, attributes: true }))
+                }
+                className="w-full text-content-muted"
+              >
+                <Logs className="mt-0.5 size-4 text-content-normal" />
+                View All Attributes
+              </Button>
+            </SidebarFooter>
+          </Sidebar>
+        </Tabs>
+      )}
+
+      <ConfirmationModal
+        open={open.revoke}
+        title="Revoke token"
+        description={revokeTokenDescription(token)}
+        label="Revoke"
+        variant="destructive"
+        disabled={revokeToken.isPending}
+        onClose={() => setOpen((prev) => ({ ...prev, revoke: false }))}
+        onConfirm={handleRevoke}
+      />
+
+      <ConfirmationModal
+        open={open.regenerate}
+        title="Regenerate token"
+        description="This generates a new token value and immediately invalidates the current one. Any integration using the current value will stop working until it's updated."
+        label="Regenerate"
+        variant="destructive"
+        disabled={regenerateToken.isPending}
+        onClose={() => setOpen((prev) => ({ ...prev, regenerate: false }))}
+        onConfirm={handleRegenerate}
+      />
+
+      <Tokens.Dialog.Secret secret={secret} onClose={() => setSecret(null)} />
+
+      {token && (
+        <Tokens.Dialog.Advanced
+          id={token.id}
+          open={open.attributes}
+          onOpenChange={(value) =>
+            setOpen((prev) => ({ ...prev, attributes: value }))
+          }
+        />
+      )}
+    </section>
+  )
+}

--- a/src/pages/app/token/index.ts
+++ b/src/pages/app/token/index.ts
@@ -1,0 +1,2 @@
+export { default as List } from "./list"
+export { default as Details } from "./details"

--- a/src/pages/app/token/list.tsx
+++ b/src/pages/app/token/list.tsx
@@ -1,0 +1,89 @@
+import { useState, useCallback } from "react"
+
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+
+import { useDataTable } from "@/hooks/use-data-table"
+import { useFilterSearch } from "@/hooks/use-filter-search"
+import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { useResourceNavigate } from "@/hooks/use-resource-navigate"
+import { useTokenTableColumns } from "@/hooks/use-token-table-columns"
+
+import { Token, type TokenFilters } from "@/types/tokens"
+
+import { useListTokens } from "@/queries/tokens"
+
+import * as Tokens from "@/components/tokens"
+import Can from "@/components/can"
+import DataTable from "@/components/data-table"
+import Pagination from "@/components/pagination"
+import PageHeader from "@/components/page-header"
+import PageFooter from "@/components/page-footer"
+
+export default function TokensList() {
+  const table = useDataTable()
+  const { page, pageSize, setPage } = table
+  const columns = useTokenTableColumns()
+  const navigateToResource = useResourceNavigate()
+
+  const [filters, setFilters] = useFilterSearch<TokenFilters>()
+  const { cursor, reset, goToPage } = useCursors(page, setPage)
+
+  const [createOpen, setCreateOpen] = useState(false)
+
+  const {
+    data: tokens,
+    links,
+    isLoading,
+  } = useListTokens({ cursor, pageSize, filters })
+
+  const handleFiltersChange = useCallback(
+    (next: TokenFilters) => {
+      setFilters(next)
+      reset()
+    },
+    [setFilters, reset],
+  )
+  const nextCursor = cursorFromLink(links?.next)
+
+  return (
+    <section className="flex h-screen flex-col">
+      <PageHeader title="Tokens">
+        <Can permission="token.generate">
+          <Button
+            size="sm"
+            disabled={isLoading}
+            onClick={() => setCreateOpen(true)}
+          >
+            New Token
+          </Button>
+        </Can>
+      </PageHeader>
+
+      <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
+        <Tokens.FilterBar filters={filters} onChange={handleFiltersChange} />
+      </div>
+
+      <Tokens.Form.Create open={createOpen} onOpenChange={setCreateOpen} />
+
+      <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
+        <DataTable<Token>
+          data={tokens}
+          table={table}
+          columns={columns}
+          isLoading={isLoading}
+          onRowClick={(token) => navigateToResource(token)}
+        />
+      </ScrollArea>
+
+      <PageFooter>
+        <Pagination
+          page={page}
+          hasNext={!!nextCursor}
+          onPageChange={(nextPage) => goToPage(nextPage, nextCursor)}
+          isLoading={isLoading}
+        />
+      </PageFooter>
+    </section>
+  )
+}

--- a/src/pages/app/token/list.tsx
+++ b/src/pages/app/token/list.tsx
@@ -4,12 +4,11 @@ import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { useDataTable } from "@/hooks/use-data-table"
-import { useFilterSearch } from "@/hooks/use-filter-search"
 import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 import { useTokenTableColumns } from "@/hooks/use-token-table-columns"
 
-import { Token, type TokenFilters } from "@/types/tokens"
+import { Token, type TokenFilters, SubjectTokenRoles } from "@/types/tokens"
 
 import { useListTokens } from "@/queries/tokens"
 
@@ -26,7 +25,10 @@ export default function TokensList() {
   const columns = useTokenTableColumns()
   const navigateToResource = useResourceNavigate()
 
-  const [filters, setFilters] = useFilterSearch<TokenFilters>()
+  // pre-filter to customer-related tokens, e.g. user, license
+  const [filters, setFilters] = useState<TokenFilters>({
+    bearerRoles: [...SubjectTokenRoles],
+  })
   const { cursor, reset, goToPage } = useCursors(page, setPage)
 
   const [createOpen, setCreateOpen] = useState(false)
@@ -42,8 +44,9 @@ export default function TokensList() {
       setFilters(next)
       reset()
     },
-    [setFilters, reset],
+    [reset],
   )
+
   const nextCursor = cursorFromLink(links?.next)
 
   return (

--- a/src/pages/app/tokens.tsx
+++ b/src/pages/app/tokens.tsx
@@ -1,0 +1,22 @@
+import { Outlet, useParams } from "@tanstack/react-router"
+
+import * as Motion from "@/components/motion"
+import * as Page from "@/pages"
+
+export default function Tokens() {
+  const { id } = useParams({ strict: false })
+
+  const view = id ? "details" : "list"
+  const direction: 1 | -1 = view === "details" ? 1 : -1
+  const key = view === "list" ? "list" : `details-${id}`
+
+  return (
+    <Motion.Slide direction={direction}>
+      {view === "list" ? (
+        <Page.App.Token.List key={key} />
+      ) : (
+        <Outlet key={key} />
+      )}
+    </Motion.Slide>
+  )
+}

--- a/src/providers/environment-provider.tsx
+++ b/src/providers/environment-provider.tsx
@@ -1,12 +1,12 @@
 import { useState, useMemo, useCallback } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 
+import { toast } from "@/lib/toast"
+
+import { useEnsureEnvironmentToken } from "@/queries/tokens"
 import { EnvironmentContext } from "@/contexts/environment-context"
-import { useCreateEnvironmentToken } from "@/queries/tokens"
 
 import * as keygen from "@/keygen"
-import config from "@/keygen/config"
-import { toast } from "@/lib/toast"
 
 function CeEnvironmentProvider({
   children,
@@ -28,22 +28,7 @@ function EeEnvironmentProvider({
 }): React.ReactElement {
   const [code, setCode] = useState<string | null>(null)
   const queryClient = useQueryClient()
-  const { mutateAsync: createEnvironmentToken } = useCreateEnvironmentToken()
-
-  const getEnvironmentToken = useCallback(
-    async (environmentId: string): Promise<string> => {
-      const cacheKey = ["token", "environment", environmentId]
-
-      const cached = queryClient.getQueryData<string>(cacheKey)
-      if (cached) return cached
-
-      const tokenResource = await createEnvironmentToken({
-        environmentId: environmentId,
-      })
-      return tokenResource.attributes.token!
-    },
-    [createEnvironmentToken, queryClient],
-  )
+  const ensureEnvironmentToken = useEnsureEnvironmentToken()
 
   const select = useCallback(
     async (environmentId: string | null, environmentCode: string | null) => {
@@ -55,7 +40,7 @@ function EeEnvironmentProvider({
           keygen.client.setEnvironmentToken(null)
           keygen.client.setEnvironment(null)
         } else {
-          const token = await getEnvironmentToken(environmentId!)
+          const token = await ensureEnvironmentToken(environmentId!)
 
           keygen.client.setEnvironmentToken(token)
           keygen.client.setEnvironment(environmentCode)
@@ -72,7 +57,7 @@ function EeEnvironmentProvider({
         throw error
       }
     },
-    [getEnvironmentToken, queryClient],
+    [ensureEnvironmentToken, queryClient],
   )
 
   const value = useMemo(() => ({ code, select }), [code, select])
@@ -89,7 +74,7 @@ export function EnvironmentProvider({
 }: {
   children: React.ReactNode
 }): React.ReactElement {
-  if (config.isCE) {
+  if (keygen.config.isCE) {
     return <CeEnvironmentProvider>{children}</CeEnvironmentProvider>
   }
   return <EeEnvironmentProvider>{children}</EeEnvironmentProvider>

--- a/src/providers/environment-provider.tsx
+++ b/src/providers/environment-provider.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from "@tanstack/react-query"
 
 import { toast } from "@/lib/toast"
 
-import { useEnsureEnvironmentToken } from "@/queries/tokens"
+import { useGetOrCreateEnvironmentToken } from "@/queries/tokens"
 import { EnvironmentContext } from "@/contexts/environment-context"
 
 import * as keygen from "@/keygen"
@@ -28,7 +28,7 @@ function EeEnvironmentProvider({
 }): React.ReactElement {
   const [code, setCode] = useState<string | null>(null)
   const queryClient = useQueryClient()
-  const ensureEnvironmentToken = useEnsureEnvironmentToken()
+  const getOrCreateEnvironmentToken = useGetOrCreateEnvironmentToken()
 
   const select = useCallback(
     async (environmentId: string | null, environmentCode: string | null) => {
@@ -40,7 +40,7 @@ function EeEnvironmentProvider({
           keygen.client.setEnvironmentToken(null)
           keygen.client.setEnvironment(null)
         } else {
-          const token = await ensureEnvironmentToken(environmentId!)
+          const token = await getOrCreateEnvironmentToken(environmentId!)
 
           keygen.client.setEnvironmentToken(token)
           keygen.client.setEnvironment(environmentCode)
@@ -57,7 +57,7 @@ function EeEnvironmentProvider({
         throw error
       }
     },
-    [ensureEnvironmentToken, queryClient],
+    [getOrCreateEnvironmentToken, queryClient],
   )
 
   const value = useMemo(() => ({ code, select }), [code, select])

--- a/src/queries/tokens.ts
+++ b/src/queries/tokens.ts
@@ -76,7 +76,7 @@ export function useListTokens(
   }
 }
 
-export function useEnsureEnvironmentToken() {
+export function useGetOrCreateEnvironmentToken() {
   const queryClient = useQueryClient()
 
   return useCallback(
@@ -111,7 +111,7 @@ export function useEnsureEnvironmentToken() {
 export function useCreateToken() {
   const queryClient = useQueryClient()
   const { code } = useEnvironment()
-  const ensureEnvironmentToken = useEnsureEnvironmentToken()
+  const ensureEnvironmentToken = useGetOrCreateEnvironmentToken()
 
   return useMutation<Token, APIError, Schemas.Tokens.CreateValues>({
     mutationFn: async (values) => {

--- a/src/queries/tokens.ts
+++ b/src/queries/tokens.ts
@@ -1,49 +1,190 @@
-import { useQueryClient, useMutation } from "@tanstack/react-query"
-import { Token, CreateTokenVariables } from "@/types/tokens"
+import { useCallback } from "react"
+
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query"
+
+import * as Schemas from "@/schemas"
+
+import { useEnvironment } from "@/hooks/use-environment"
+
+import {
+  Token,
+  TokenResponse,
+  TokenBearerKind,
+  type TokenFilters,
+  TokenBearerResourceTypes,
+} from "@/types/tokens"
 import { APIError } from "@/types/api"
+
 import * as keygen from "@/keygen"
+
+export type { TokenFilters }
+
+export function useGetToken(tokenId: string) {
+  const { code } = useEnvironment()
+
+  return useQuery({
+    queryKey: ["tokens", tokenId, { environment: code }],
+    queryFn: async () => {
+      const response = await keygen.tokens.get({ id: tokenId })
+
+      if (!response.data) {
+        throw new Error("Token not found")
+      }
+
+      return response.data
+    },
+    enabled: !!tokenId,
+  })
+}
+
+export function useListTokens(
+  params?: {
+    cursor?: string | null
+    pageSize?: number
+    filters?: TokenFilters
+  },
+  options?: { enabled?: boolean },
+) {
+  const { code } = useEnvironment()
+
+  const query = useQuery({
+    queryKey: ["tokens", { environment: code, ...params }],
+    queryFn: async () => {
+      const response = await keygen.tokens.list(
+        params
+          ? {
+              pageCursor: params.cursor,
+              pageSize: params.pageSize,
+              filters: params.filters,
+            }
+          : {},
+      )
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response
+    },
+    enabled: options?.enabled,
+  })
+
+  return {
+    ...query,
+    data: query.data?.data ?? [],
+    links: query.data?.links,
+  }
+}
+
+export function useEnsureEnvironmentToken() {
+  const queryClient = useQueryClient()
+
+  return useCallback(
+    async (environmentId: string): Promise<string> => {
+      const cacheKey = ["token", "environment", environmentId]
+
+      const cached = queryClient.getQueryData<string>(cacheKey)
+      if (cached) return cached
+
+      const response = await keygen.tokens.create({
+        relationships: {
+          environment: { data: { type: "environments", id: environmentId } },
+        },
+      })
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      const token = response.data?.attributes.token
+      if (!token) {
+        throw new Error("Failed to create environment token")
+      }
+
+      queryClient.setQueryData(cacheKey, token)
+      return token
+    },
+    [queryClient],
+  )
+}
 
 export function useCreateToken() {
   const queryClient = useQueryClient()
+  const { code } = useEnvironment()
+  const ensureEnvironmentToken = useEnsureEnvironmentToken()
 
-  return useMutation<Token, APIError, CreateTokenVariables>({
-    mutationFn: ({ relationships }) =>
-      keygen.tokens
-        .create({ relationships })
-        .then((response) => response.data as Token),
-    onSuccess: (token, variables) => {
-      if (variables.cacheKey && token.attributes.token) {
-        queryClient.setQueryData<string>(
-          variables.cacheKey,
-          token.attributes.token,
-        )
+  return useMutation<Token, APIError, Schemas.Tokens.CreateValues>({
+    mutationFn: async (values) => {
+      let response: TokenResponse
+
+      if (values.bearerKind === TokenBearerKind.Admin) {
+        response = await keygen.tokens.create({ values })
+      } else {
+        const bearerType = TokenBearerResourceTypes[values.bearerKind]
+
+        if (values.bearerKind === TokenBearerKind.Environment) {
+          // environment tokens need to be created within their context,
+          // so authenticate with an environment-scoped admin token
+          const environmentId = values.bearerId! // required for non-admin bearers
+          const environmentToken = await ensureEnvironmentToken(environmentId)
+
+          response = await keygen.tokens.createForBearer({
+            values,
+            bearerType,
+            environment: environmentId,
+            environmentToken,
+          })
+        } else {
+          response = await keygen.tokens.createForBearer({ values, bearerType })
+        }
       }
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response.data
+    },
+
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["tokens", { environment: code }],
+      })
     },
   })
 }
 
-export function useCreateEnvironmentToken() {
-  const base = useCreateToken()
+export function useRevokeToken() {
+  const queryClient = useQueryClient()
+  const { code } = useEnvironment()
 
-  return {
-    ...base,
-    mutate: ({ environmentId }: { environmentId: string }) =>
-      base.mutate({
-        relationships: {
-          environment: {
-            data: { type: "environments", id: environmentId },
-          },
-        },
-        cacheKey: ["token", "environment", environmentId],
-      }),
-    mutateAsync: ({ environmentId }: { environmentId: string }) =>
-      base.mutateAsync({
-        relationships: {
-          environment: {
-            data: { type: "environments", id: environmentId },
-          },
-        },
-        cacheKey: ["token", "environment", environmentId],
-      }),
-  }
+  return useMutation<unknown, APIError, { id: string }>({
+    mutationFn: ({ id }) => keygen.tokens.revoke({ id }),
+
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ["tokens", { environment: code }],
+      })
+    },
+  })
+}
+
+export function useRegenerateToken() {
+  const queryClient = useQueryClient()
+
+  return useMutation<Token, APIError, { id: string }>({
+    mutationFn: async ({ id }) => {
+      const response = await keygen.tokens.regenerate({ id })
+
+      if (response.errors) {
+        throw new APIError(response.errors[0])
+      }
+
+      return response.data
+    },
+
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["tokens"] })
+    },
+  })
 }

--- a/src/routes/$accountId/app.tokens.$id.tsx
+++ b/src/routes/$accountId/app.tokens.$id.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import * as Page from "@/pages/index"
+
+export const Route = createFileRoute("/$accountId/app/tokens/$id")({
+  component: () => <Page.App.Token.Details />,
+})

--- a/src/routes/$accountId/app.tokens.tsx
+++ b/src/routes/$accountId/app.tokens.tsx
@@ -1,0 +1,29 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import * as Page from "@/pages/index"
+import { requirePermission } from "@/lib/permissions"
+import { TokenBearerType, type TokenFilters } from "@/types/tokens"
+
+function validateSearch(search: Record<string, unknown>): TokenFilters {
+  const filters: TokenFilters = {}
+
+  if (
+    typeof search.bearerType === "string" &&
+    (Object.values(TokenBearerType) as string[]).includes(search.bearerType)
+  ) {
+    filters.bearerType = search.bearerType as TokenBearerType
+  }
+  if (typeof search.bearerId === "string") filters.bearerId = search.bearerId
+  if (typeof search.environment === "string") {
+    filters.environment = search.environment
+  }
+
+  return filters
+}
+
+export const Route = createFileRoute("/$accountId/app/tokens")({
+  component: () => <Page.App.Tokens />,
+  validateSearch,
+  beforeLoad: ({ context }) =>
+    requirePermission(context.queryClient, "token.read"),
+})

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -45,3 +45,6 @@ export { WebhookEndpoints }
 
 import * as Auth from "./auth"
 export { Auth }
+
+import * as Tokens from "./tokens"
+export { Tokens }

--- a/src/schemas/tokens.ts
+++ b/src/schemas/tokens.ts
@@ -1,0 +1,40 @@
+import { FieldPath } from "react-hook-form"
+import { z } from "zod"
+
+import { CombineFormValues } from "@/types/forms"
+import { TokenBearerKind } from "@/types/tokens"
+
+const BaseShape = z.object({
+  bearerKind: z.nativeEnum(TokenBearerKind),
+  bearerId: z.string().trim().nullable().optional(),
+  name: z.string().trim().nullable().optional(),
+  expiry: z.string().nullable().optional(),
+  maxActivations: z.number().int().nullable().optional(),
+  maxDeactivations: z.number().int().nullable().optional(),
+  permissions: z.array(z.string()).nullable().optional(),
+})
+
+const BaseRules = <S extends typeof BaseShape>(schema: S) =>
+  schema.refine(
+    (data) => data.bearerKind === TokenBearerKind.Admin || !!data.bearerId,
+    { message: "Select a bearer", path: ["bearerId"] },
+  )
+
+export const BaseSchema = BaseRules(BaseShape)
+export const CreateSchema = BaseSchema
+
+export type BaseFormValues = z.input<typeof BaseSchema>
+export type CreateFormValues = z.input<typeof CreateSchema>
+
+export type BaseValues = z.output<typeof BaseSchema>
+export type CreateValues = z.output<typeof CreateSchema>
+export type AllValues = CombineFormValues<BaseValues, CreateValues, BaseValues>
+
+export type FieldNames = FieldPath<AllValues>
+
+export const SchemaMap = {
+  base: BaseSchema,
+  create: CreateSchema,
+} as const
+
+export type SchemaNames = keyof typeof SchemaMap

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,21 +1,22 @@
-import { Arch } from "@/types/arches"
 import { User } from "@/types/users"
+import { Arch } from "@/types/arches"
+import { Token } from "@/types/tokens"
 import { Group } from "@/types/groups"
 import { Engine } from "@/types/engines"
 import { Policy } from "@/types/policies"
-import { Package } from "@/types/packages"
-import { Machine } from "@/types/machines"
-import { Process } from "@/types/processes"
-import { Release } from "@/types/releases"
 import { Channel } from "@/types/channels"
+import { Release } from "@/types/releases"
 import { Product } from "@/types/products"
+import { Machine } from "@/types/machines"
+import { Package } from "@/types/packages"
 import { License } from "@/types/licenses"
-import { WebhookEndpoint } from "@/types/webhook-endpoints"
-import { WebhookEvent } from "@/types/webhook-events"
+import { Process } from "@/types/processes"
 import { Artifact } from "@/types/artifacts"
 import { Platform } from "@/types/platforms"
 import { Component } from "@/types/components"
 import { Entitlement } from "@/types/entitlements"
+import { WebhookEvent } from "@/types/webhook-events"
+import { WebhookEndpoint } from "@/types/webhook-endpoints"
 
 export type APIResponse<
   TData,
@@ -125,6 +126,7 @@ export type AnyResource =
   | Engine
   | WebhookEndpoint
   | WebhookEvent
+  | Token
 
 export type ResourceType =
   | "products"
@@ -146,6 +148,7 @@ export type ResourceType =
   | "engines"
   | "webhook-endpoints"
   | "webhook-events"
+  | "token"
 
 export enum APIVersion {
   V1_0 = "1.0",

--- a/src/types/tokens.ts
+++ b/src/types/tokens.ts
@@ -146,9 +146,61 @@ export const TokenFormFieldDescriptions: Readonly<
   bearerKind: "The type of bearer this token authenticates as.",
 }
 
+export enum TokenRole {
+  Admin = "admin",
+  User = "user",
+  Developer = "developer",
+  SalesAgent = "sales_agent",
+  SupportAgent = "support_agent",
+  ReadOnly = "read_only",
+  License = "license",
+  Product = "product",
+  Environment = "environment",
+}
+
+export const TokenRoleLabels: Readonly<Record<TokenRole, string>> = {
+  [TokenRole.Admin]: "Admin",
+  [TokenRole.User]: "User",
+  [TokenRole.Developer]: "Developer",
+  [TokenRole.SalesAgent]: "Sales",
+  [TokenRole.SupportAgent]: "Support",
+  [TokenRole.ReadOnly]: "Read-only",
+  [TokenRole.License]: "License",
+  [TokenRole.Product]: "Product",
+  [TokenRole.Environment]: "Environment",
+}
+
+export const SubjectTokenRoles: readonly TokenRole[] = [
+  TokenRole.User,
+  TokenRole.License,
+]
+
+export const InternalTokenRoles: readonly TokenRole[] = [
+  TokenRole.Admin,
+  TokenRole.Developer,
+  TokenRole.SalesAgent,
+  TokenRole.SupportAgent,
+  TokenRole.ReadOnly,
+  TokenRole.Product,
+  TokenRole.Environment,
+]
+
+export const AllTokenRoles: readonly TokenRole[] = [
+  TokenRole.Admin,
+  TokenRole.User,
+  TokenRole.Developer,
+  TokenRole.SalesAgent,
+  TokenRole.SupportAgent,
+  TokenRole.ReadOnly,
+  TokenRole.License,
+  TokenRole.Product,
+  TokenRole.Environment,
+]
+
 export type TokenFilters = {
   bearerType?: TokenBearerType
   bearerId?: string
+  bearerRoles?: TokenRole[]
   environment?: string
 }
 

--- a/src/types/tokens.ts
+++ b/src/types/tokens.ts
@@ -1,25 +1,42 @@
-import { Writable } from "@/types/utility"
 import { APIResponse, Resource, Relationship, Linkage } from "@/types/api"
+import { Writable } from "@/types/utility"
 
-export interface TokenAttributes {
-  kind: string
+export const TokenKinds = [
+  "admin-token",
+  "user-token",
+  "product-token",
+  "activation-token",
+  "environment-token",
+  "developer-token",
+  "sales-token",
+  "support-token",
+  "read-only-token",
+] as const
+
+export type TokenKind = (typeof TokenKinds)[number]
+
+export type TokenAttributes = {
+  kind: TokenKind
   token?: string
   name?: string | null
   expiry?: string | null
-  created: string
-  updated: string
   permissions?: string[] | null
   maxActivations?: number | null
   activations?: number | null
   maxDeactivations?: number | null
   deactivations?: number | null
+  created: string
+  updated: string
 }
 
 export type TokenRelationships = {
   account: Relationship<Linkage<"accounts">>
   environment?: Relationship<Linkage<"environments">>
   bearer?: Relationship<
-    Linkage<"users"> | Linkage<"products"> | Linkage<"licenses">
+    | Linkage<"users">
+    | Linkage<"products">
+    | Linkage<"licenses">
+    | Linkage<"environments">
   >
 }
 
@@ -28,19 +45,116 @@ export type Token = Resource<"tokens", TokenAttributes, TokenRelationships>
 export type TokenResponse = APIResponse<Token>
 export type TokensListResponse = APIResponse<Token[]>
 
-export type CreateTokenPayload =
-  | {
-      environment: Exclude<TokenRelationships["environment"], undefined>
-      bearer?: never
-    }
-  | {
-      bearer: Exclude<TokenRelationships["bearer"], undefined>
-      environment?: never
-    }
-
-export interface CreateTokenVariables {
-  relationships: CreateTokenPayload
-  cacheKey?: (string | number)[]
+export enum TokenBearerType {
+  User = "user",
+  License = "license",
+  Product = "product",
+  Environment = "environment",
 }
 
-export type UpdateTokenPayload = Partial<Writable<TokenAttributes>>
+export enum TokenBearerKind {
+  Admin = "admin",
+  User = "user",
+  License = "license",
+  Product = "product",
+  Environment = "environment",
+}
+
+export const TokenBearerKindLabels: Readonly<Record<TokenBearerKind, string>> =
+  {
+    [TokenBearerKind.Admin]: "Admin",
+    [TokenBearerKind.User]: "User",
+    [TokenBearerKind.License]: "License",
+    [TokenBearerKind.Product]: "Product",
+    [TokenBearerKind.Environment]: "Environment",
+  }
+
+export const TokenBearerKindDescriptions: Readonly<
+  Record<TokenBearerKind, string>
+> = {
+  [TokenBearerKind.Admin]:
+    "Authenticates as you, with your account permissions.",
+  [TokenBearerKind.User]: "Authenticates as one of your users.",
+  [TokenBearerKind.License]: "Authenticates as a license.",
+  [TokenBearerKind.Product]:
+    "Authenticates as a product, scoped to its resources.",
+  [TokenBearerKind.Environment]: "Authenticates as an environment.",
+}
+
+export const InternalTokenKinds: readonly TokenKind[] = [
+  "admin-token",
+  "developer-token",
+  "sales-token",
+  "support-token",
+  "read-only-token",
+  "product-token",
+  "environment-token",
+]
+
+export const TokenKindLabels: Readonly<Record<TokenKind, string>> = {
+  "admin-token": "Admin",
+  "user-token": "User",
+  "product-token": "Product",
+  "activation-token": "License",
+  "environment-token": "Environment",
+  "developer-token": "Developer",
+  "sales-token": "Sales",
+  "support-token": "Support",
+  "read-only-token": "Read-only",
+}
+
+export const TokenKindDescriptions: Readonly<Record<TokenKind, string>> = {
+  "admin-token": "Authenticates as an admin, with full account access.",
+  "user-token": "Authenticates as one of your users.",
+  "product-token": "Authenticates as a product, scoped to its resources.",
+  "activation-token":
+    "A license activation token, authenticating as a license.",
+  "environment-token": "Authenticates as an environment.",
+  "developer-token":
+    "Authenticates as a developer, with management access except billing.",
+  "sales-token": "Authenticates as a sales agent.",
+  "support-token": "Authenticates as a support agent.",
+  "read-only-token": "Authenticates as a read-only user.",
+}
+
+export const TokenAttributeDescriptions: Readonly<
+  Record<keyof Writable<TokenAttributes>, string>
+> = {
+  kind: "The kind of token, based on its bearer.",
+  token:
+    "The raw token of the token. This attribute is only available to read directly after token generation.",
+  name: "The name of the token, if any.",
+  expiry:
+    "The timestamp for when the token expires. Requests using an expired token will be rejected.",
+  permissions: "The permissions for the token",
+  activations:
+    "The number of machine activations that have been performed by this token. This attribute is only applicable to license tokens.",
+  maxActivations:
+    "The maximum amount of machine activations this token may perform. This attribute is only applicable to license tokens.",
+  deactivations:
+    "The number of machine deactivations that have been performed by this token. This attribute is only applicable to license tokens.",
+  maxDeactivations:
+    "The maximum amount of machine deactivations this token may perform. This attribute is only applicable to license tokens.",
+}
+
+export const TokenFormFieldDescriptions: Readonly<
+  typeof TokenAttributeDescriptions & { bearer: string; bearerKind: string }
+> = {
+  ...TokenAttributeDescriptions,
+  name: "An optional name for the token. This can be used to easily identify tokens at a glance.",
+  bearer: "The specific resource this token belongs to and authenticates as.",
+  bearerKind: "The type of bearer this token authenticates as.",
+}
+
+export type TokenFilters = {
+  bearerType?: TokenBearerType
+  bearerId?: string
+  environment?: string
+}
+
+export const TokenBearerResourceTypes: Readonly<Record<string, string>> = {
+  [TokenBearerKind.User]: "users",
+  [TokenBearerKind.License]: "licenses",
+  [TokenBearerKind.Product]: "products",
+  [TokenBearerKind.Environment]: "environments",
+}


### PR DESCRIPTION
Closes #248. Adds API tokens support to Portal, accessible across two pages: `Access > Tokens` for managing tokens that are pre-filtered for `user` and `license`, typically for managing customer/user-related tokens, and then a separate section in `Settings > Developers` for managing `admin`, `environment` and `product`, and other internal role tokens, which are typically used for integrations.

<img width="700" src="https://github.com/user-attachments/assets/641cc3f1-ae48-42de-bdae-b5860b91d226" />
<img width="700" src="https://github.com/user-attachments/assets/10dbcfcc-21ff-488b-8e4d-210aa57af47a" />
<img width="700" src="https://github.com/user-attachments/assets/1386aa24-64ad-4521-8d08-143d279ef179" />
<img width="700" src="https://github.com/user-attachments/assets/e03078ee-6161-432d-b0c4-f9037ebf1e1f" />
<img width="700" src="https://github.com/user-attachments/assets/4439176b-9b76-48f2-8bc8-c207b6211f05" />