### PR TITLE
Update token bearer filter's env type to autoselect current env

### DIFF
--- a/src/components/filter-bar/index.ts
+++ b/src/components/filter-bar/index.ts
@@ -10,5 +10,8 @@ export { default as TemporalFilter } from "./temporal-filter"
 export { default as ResourceFilter } from "./resource-filter"
 export { default as ResourcesFilter } from "./resources-filter"
 export { default as MetadataFilter } from "./metadata-filter"
-export { default as PolymorphicResourceFilter } from "./polymorphic-resource-filter"
+export {
+  default as PolymorphicResourceFilter,
+  type PolymorphicResourceType,
+} from "./polymorphic-resource-filter"
 export { default as StringFilter } from "./string-filter"

--- a/src/components/filter-bar/polymorphic-resource-filter.tsx
+++ b/src/components/filter-bar/polymorphic-resource-filter.tsx
@@ -35,6 +35,10 @@ export type PolymorphicResourceType = {
   value: string
   label: string
   resource?: SearchableResource
+  // a predefined id for types whose value is known ahead of time —
+  // selecting the type applies the filter immediately and the id is
+  // displayed as a read-only segment
+  fixed?: string
 }
 
 export type PolymorphicResourceValue = { type: string; id: string }
@@ -77,6 +81,15 @@ export default function PolymorphicResourceFilter({
   }
 
   function handleTypeChange(type: string) {
+    const fixed = types.find((t) => t.value === type)?.fixed
+
+    if (fixed) {
+      filter.handleChange({ type, id: fixed })
+      setTypeOpen(false)
+      setResourceOpen(false)
+      return
+    }
+
     filter.handleDraftChange({ type, id: "" })
     setTypeOpen(false)
     setResourceOpen(true)
@@ -128,7 +141,11 @@ export default function PolymorphicResourceFilter({
       {current.type ? (
         <>
           <FilterSegment>eq</FilterSegment>
-          {selectedType?.resource ? (
+          {selectedType?.fixed ? (
+            <FilterSegment>
+              {displayValue ?? truncate(selectedType.fixed)}
+            </FilterSegment>
+          ) : selectedType?.resource ? (
             <ResourceSelectSegment
               key={selectedType.value}
               state={filter.state}

--- a/src/components/tokens/filter-bar.tsx
+++ b/src/components/tokens/filter-bar.tsx
@@ -1,6 +1,10 @@
+import { useMemo } from "react"
 import { KeyRound, Shield } from "lucide-react"
 
 import * as Filters from "@/components/filter-bar"
+
+import { useEdition } from "@/hooks/use-edition"
+import { useEnvironment } from "@/hooks/use-environment"
 
 import {
   TokenBearerType,
@@ -9,24 +13,6 @@ import {
   AllTokenRoles,
   type TokenFilters,
 } from "@/types/tokens"
-
-const BEARER_TYPES: ReadonlyArray<{
-  value: TokenBearerType
-  label: string
-  resource?: "users" | "licenses" | "products"
-}> = [
-  { value: TokenBearerType.User, label: "User", resource: "users" },
-  { value: TokenBearerType.License, label: "License", resource: "licenses" },
-  { value: TokenBearerType.Product, label: "Product", resource: "products" },
-  // environments aren't a searchable resource, so this falls
-  // back to the polymorphic filter's raw id input
-  { value: TokenBearerType.Environment, label: "Environment" },
-]
-
-const ROLE_OPTIONS = AllTokenRoles.map((role) => ({
-  value: role,
-  label: TokenRoleLabels[role],
-}))
 
 interface TokenFilterBarProps {
   filters: TokenFilters
@@ -37,8 +23,61 @@ export default function TokenFilterBar({
   filters,
   onChange,
 }: TokenFilterBarProps) {
-  const roles = filters.bearerRoles ?? [...AllTokenRoles]
-  const allRolesSelected = roles.length === AllTokenRoles.length
+  const { isCE } = useEdition()
+  const { id: environmentId } = useEnvironment()
+
+  const bearerTypes = useMemo(
+    () =>
+      [
+        { value: TokenBearerType.User, label: "User", resource: "users" },
+        {
+          value: TokenBearerType.License,
+          label: "License",
+          resource: "licenses",
+        },
+        {
+          value: TokenBearerType.Product,
+          label: "Product",
+          resource: "products",
+        },
+        // environment tokens are only visible inside their own environment, so
+        // the bearer can only ever be the current environment. in addition, we
+        // want to hide the option in the global env and in CE.
+        ...(environmentId != null
+          ? [
+              {
+                value: TokenBearerType.Environment,
+                label: "Environment",
+                fixed: environmentId,
+              },
+            ]
+          : []),
+      ] satisfies ReadonlyArray<Filters.PolymorphicResourceType>,
+    [environmentId],
+  )
+
+  // environments are EE-only, so hide the environment role in CE
+  const availableRoles = useMemo(
+    () =>
+      isCE
+        ? AllTokenRoles.filter((role) => role !== TokenRole.Environment)
+        : AllTokenRoles,
+    [isCE],
+  )
+
+  const roleOptions = useMemo(
+    () =>
+      availableRoles.map((role) => ({
+        value: role,
+        label: TokenRoleLabels[role],
+      })),
+    [availableRoles],
+  )
+
+  const roles = (filters.bearerRoles ?? [...availableRoles]).filter((role) =>
+    availableRoles.includes(role),
+  )
+  const allRolesSelected = roles.length === availableRoles.length
 
   const filterCount = (filters.bearerId ? 1 : 0) + (allRolesSelected ? 0 : 1)
 
@@ -50,13 +89,12 @@ export default function TokenFilterBar({
   return (
     <Filters.FilterBar
       filterCount={filterCount}
-      onClearAll={() => onChange({ bearerRoles: [...AllTokenRoles] })}
+      onClearAll={() => onChange({ bearerRoles: [...availableRoles] })}
     >
       <Filters.PolymorphicResourceFilter
         label="Bearer"
         icon={KeyRound}
-        placeholder="Environment ID"
-        types={BEARER_TYPES}
+        types={bearerTypes}
         value={bearerValue}
         onChange={(next) =>
           onChange({
@@ -69,13 +107,13 @@ export default function TokenFilterBar({
       <Filters.ArrayFilter
         label="Role"
         icon={Shield}
-        options={ROLE_OPTIONS}
+        options={roleOptions}
         value={allRolesSelected ? undefined : roles}
         onChange={(next) =>
           onChange({
             ...filters,
             bearerRoles: (next as TokenRole[] | undefined) ?? [
-              ...AllTokenRoles,
+              ...availableRoles,
             ],
           })
         }

--- a/src/contexts/environment-context.tsx
+++ b/src/contexts/environment-context.tsx
@@ -1,11 +1,13 @@
 import { createContext } from "react"
 
 export interface EnvironmentContextValue {
+  id: string | null
   code: string | null
   select: (id: string | null, code: string | null) => Promise<void> | void
 }
 
 export const EnvironmentContext = createContext<EnvironmentContextValue>({
+  id: null,
   code: null,
   select: () => {},
 })

--- a/src/providers/environment-provider.tsx
+++ b/src/providers/environment-provider.tsx
@@ -13,7 +13,10 @@ function CeEnvironmentProvider({
 }: {
   children: React.ReactNode
 }): React.ReactElement {
-  const value = useMemo(() => ({ code: null, select: async () => {} }), [])
+  const value = useMemo(
+    () => ({ id: null, code: null, select: async () => {} }),
+    [],
+  )
   return (
     <EnvironmentContext.Provider value={value}>
       {children}
@@ -26,6 +29,7 @@ function EeEnvironmentProvider({
 }: {
   children: React.ReactNode
 }): React.ReactElement {
+  const [id, setId] = useState<string | null>(null)
   const [code, setCode] = useState<string | null>(null)
   const queryClient = useQueryClient()
   const getOrCreateEnvironmentToken = useGetOrCreateEnvironmentToken()
@@ -46,6 +50,7 @@ function EeEnvironmentProvider({
           keygen.client.setEnvironment(environmentCode)
         }
 
+        setId(environmentId)
         setCode(environmentCode)
         await queryClient.invalidateQueries({
           predicate: (q) => q.queryKey[0] !== "environments",
@@ -60,7 +65,7 @@ function EeEnvironmentProvider({
     [getOrCreateEnvironmentToken, queryClient],
   )
 
-  const value = useMemo(() => ({ code, select }), [code, select])
+  const value = useMemo(() => ({ id, code, select }), [id, code, select])
 
   return (
     <EnvironmentContext.Provider value={value}>


### PR DESCRIPTION
Instead of showing an input that can only ever be one value, it now autoselect's the current env:

<img width="1722" height="663" alt="image" src="https://github.com/user-attachments/assets/e8d4f8f0-9c70-4071-b685-1ad89d7602ab" />
