### PR TITLE
Fix truncation for event/request log relationship identifiers

### DIFF
--- a/src/components/collapsible-card.tsx
+++ b/src/components/collapsible-card.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/collapsible"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
+import { ScrollArea } from "@/components/ui/scroll-area"
 
 import { ChevronDown, ChevronUp } from "lucide-react"
 
@@ -82,16 +83,23 @@ export default function CollapsibleCard({
                 transition={{ duration: 0.2, ease: [0.42, 0, 0.58, 1] }}
                 className="overflow-hidden"
               >
-                <CardContent className={cn("p-4", contentClass)}>
-                  {Children.map(children, (child, index) => (
-                    <Fragment key={index}>
-                      {child}
-                      {index < Children.count(children) - 1 && (
-                        <Separator className="my-4" />
-                      )}
-                    </Fragment>
-                  ))}
-                </CardContent>
+                <div
+                  className="w-full min-w-0"
+                  style={{ contain: "inline-size" }}
+                >
+                  <ScrollArea orientation="horizontal">
+                    <CardContent className={cn("p-4", contentClass)}>
+                      {Children.map(children, (child, index) => (
+                        <Fragment key={index}>
+                          {child}
+                          {index < Children.count(children) - 1 && (
+                            <Separator className="my-4" />
+                          )}
+                        </Fragment>
+                      ))}
+                    </CardContent>
+                  </ScrollArea>
+                </div>
               </motion.div>
             </CollapsibleContent>
           )}

--- a/src/pages/app/event-log/details.tsx
+++ b/src/pages/app/event-log/details.tsx
@@ -136,18 +136,19 @@ export default function EventLogDetails() {
                         <ResourceLink
                           linkage={environment}
                           emptyLabel="Global"
+                          truncate
                         />
                       }
                     />
                     <Attribute.Field
                       variant="text"
                       label="Requestor"
-                      value={<ResourceLink linkage={requestor} />}
+                      value={<ResourceLink linkage={requestor} truncate />}
                     />
                     <Attribute.Field
                       variant="text"
                       label="Resource"
-                      value={<ResourceLink linkage={resource} />}
+                      value={<ResourceLink linkage={resource} truncate />}
                     />
                   </div>
                 </CollapsibleCard>

--- a/src/pages/app/request-log/details.tsx
+++ b/src/pages/app/request-log/details.tsx
@@ -159,18 +159,19 @@ export default function RequestLogDetails() {
                         <ResourceLink
                           linkage={environment}
                           emptyLabel="Global"
+                          truncate
                         />
                       }
                     />
                     <Attribute.Field
                       variant="text"
                       label="Requestor"
-                      value={<ResourceLink linkage={requestor} />}
+                      value={<ResourceLink linkage={requestor} truncate />}
                     />
                     <Attribute.Field
                       variant="text"
                       label="Resource"
-                      value={<ResourceLink linkage={resource} />}
+                      value={<ResourceLink linkage={resource} truncate />}
                     />
                   </div>
                 </CollapsibleCard>


### PR DESCRIPTION
Closes #268. Also adds a horizontal scroll area that applies to all `<CollapsibleCard />` components, which should fix the inherent layout issue if it surfaces again.

<img width="700" src="https://github.com/user-attachments/assets/42fb7c1b-4933-476f-b524-e8590c9b5e58" />