### PR TITLE
Fix sparkline chart bottom margins

### DIFF
--- a/src/components/analytics/event-charts.tsx
+++ b/src/components/analytics/event-charts.tsx
@@ -90,7 +90,7 @@ function EventSparkCard({
             <LineChart
               accessibilityLayer
               data={chart.data}
-              margin={{ top: 4, right: 8, bottom: 0, left: 0 }}
+              margin={{ top: 4, right: 8, bottom: 2, left: 0 }}
             >
               <CartesianGrid vertical={false} strokeDasharray="3 3" />
               <XAxis hide dataKey="date" height={0} />

--- a/src/components/analytics/gauge-card.tsx
+++ b/src/components/analytics/gauge-card.tsx
@@ -109,7 +109,7 @@ export default function GaugeCard({
                 <LineChart
                   accessibilityLayer
                   data={chart.data}
-                  margin={{ top: 4, right: 8, bottom: 0, left: 2 }}
+                  margin={{ top: 4, right: 8, bottom: 2, left: 2 }}
                 >
                   <XAxis hide dataKey="date" height={0} />
                   <YAxis hide width={0} />


### PR DESCRIPTION
Resolves an issue where the bottom of some charts was getting cut off.

Before:

<img width="1128" height="372" alt="image" src="https://github.com/user-attachments/assets/6113a62e-282a-4f8c-8c9b-eb5d14ed153a" />

After:

<img width="1128" height="372" alt="image" src="https://github.com/user-attachments/assets/89dd2fe7-a83b-4acf-840c-bea25d722a7b" />

