### PR TITLE
Add slug field to registration form

### DIFF
--- a/src/components/auth/form/fields.tsx
+++ b/src/components/auth/form/fields.tsx
@@ -13,6 +13,7 @@ import {
 
 import * as Schemas from "@/schemas"
 
+import { accountSlugFromEmail } from "@/lib/auth"
 import { truncator } from "@/lib/truncate"
 import { getRecentAccounts } from "@/lib/accounts"
 
@@ -196,8 +197,12 @@ function SlugField({
   autoFocus,
   mode = "select",
 }: FieldProps & { mode?: "select" | "create" }) {
-  const form = useFormContext<{ slug: string }>()
+  const form = useFormContext<{ slug: string; email?: string }>()
   const isCreate = mode === "create"
+
+  const slugPlaceholder = isCreate
+    ? accountSlugFromEmail(form.getValues("email"))
+    : ""
 
   const options = useMemo(
     () =>
@@ -232,7 +237,7 @@ function SlugField({
                   autoComplete="off"
                   spellCheck={false}
                   autoFocus={autoFocus}
-                  placeholder="example-com"
+                  placeholder={slugPlaceholder || "example-com"}
                 />
               </FormControl>
             ) : (

--- a/src/components/auth/form/fields.tsx
+++ b/src/components/auth/form/fields.tsx
@@ -65,6 +65,14 @@ export default function AuthFormFields({
             )
           case "slug":
             return <SlugField key="slug" autoFocus={autoFocus === "slug"} />
+          case "newSlug":
+            return (
+              <SlugField
+                key="newSlug"
+                mode="create"
+                autoFocus={autoFocus === "newSlug"}
+              />
+            )
           case "remember":
             return <RememberField key="remember" />
           case "otp":
@@ -184,8 +192,12 @@ function ConfirmPasswordField({ autoFocus }: FieldProps) {
   )
 }
 
-function SlugField({ autoFocus }: FieldProps) {
+function SlugField({
+  autoFocus,
+  mode = "select",
+}: FieldProps & { mode?: "select" | "create" }) {
   const form = useFormContext<{ slug: string }>()
+  const isCreate = mode === "create"
 
   const options = useMemo(
     () =>
@@ -205,19 +217,35 @@ function SlugField({ autoFocus }: FieldProps) {
       render={({ field, fieldState }) => (
         <FormItem>
           <Forms.Field.Header
-            label="Account"
-            tooltip={AuthFormFieldDescriptions.slug}
+            label={isCreate ? "Account slug" : "Account"}
+            tooltip={
+              isCreate
+                ? AuthFormFieldDescriptions.newSlug
+                : AuthFormFieldDescriptions.slug
+            }
             variant="stacking"
           >
-            <SuggestInput
-              value={field.value}
-              onChange={field.onChange}
-              options={options}
-              emptyMessage="No recent accounts"
-              placeholder="Enter account ID or slug..."
-              invalid={Boolean(fieldState.error)}
-              autoFocus={autoFocus}
-            />
+            {isCreate ? (
+              <FormControl>
+                <Input
+                  {...field}
+                  autoComplete="off"
+                  spellCheck={false}
+                  autoFocus={autoFocus}
+                  placeholder="example-com"
+                />
+              </FormControl>
+            ) : (
+              <SuggestInput
+                value={field.value}
+                onChange={field.onChange}
+                options={options}
+                emptyMessage="No recent accounts"
+                placeholder="Enter account ID or slug..."
+                invalid={Boolean(fieldState.error)}
+                autoFocus={autoFocus}
+              />
+            )}
           </Forms.Field.Header>
           <FormMessage />
         </FormItem>

--- a/src/components/auth/form/register.tsx
+++ b/src/components/auth/form/register.tsx
@@ -5,7 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 
 import { Button } from "@/components/ui/button"
 
-import { cn, dasherize } from "@/lib/utils"
+import { cn } from "@/lib/utils"
 import { handleFormError } from "@/lib/form-errors"
 
 import * as Schemas from "@/schemas"
@@ -82,10 +82,7 @@ export default function RegisterForm() {
         (apiError.code?.startsWith("SLUG_") === true ||
           apiError.source?.pointer === "/data/attributes/slug")
 
-      // show and prefill slug field
       if (isSlugError && !showSlug) {
-        const domain = values.email.split("@")[1] ?? ""
-        form.setValue("slug", dasherize(domain))
         setShowSlug(true)
       }
 

--- a/src/components/auth/form/register.tsx
+++ b/src/components/auth/form/register.tsx
@@ -5,7 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 
 import { Button } from "@/components/ui/button"
 
-import { cn } from "@/lib/utils"
+import { cn, dasherize } from "@/lib/utils"
 import { handleFormError } from "@/lib/form-errors"
 
 import * as Schemas from "@/schemas"
@@ -34,11 +34,12 @@ export default function RegisterForm() {
   const form = useForm<Schemas.Auth.RegisterValues>({
     resolver: zodResolver(Schemas.Auth.RegisterSchema),
     mode: "onChange",
-    defaultValues: { email: "", password: "" },
+    defaultValues: { email: "", password: "", slug: "" },
   })
 
   const createAccount = useCreateAccount()
   const [isRegistered, setIsRegistered] = useState(false)
+  const [showSlug, setShowSlug] = useState(false)
 
   async function onSubmit(values: Schemas.Auth.RegisterValues) {
     try {
@@ -75,10 +76,23 @@ export default function RegisterForm() {
 
       console.error(error)
 
+      const apiError = error instanceof APIError ? error : undefined
+      const isSlugError =
+        apiError != null &&
+        (apiError.code?.startsWith("SLUG_") === true ||
+          apiError.source?.pointer === "/data/attributes/slug")
+
+      // show and prefill slug field
+      if (isSlugError && !showSlug) {
+        const domain = values.email.split("@")[1] ?? ""
+        form.setValue("slug", dasherize(domain))
+        setShowSlug(true)
+      }
+
       await handleFormError({
         form,
         toastMessage: "We couldn't create your account",
-        apiError: error instanceof APIError ? error : undefined,
+        apiError,
       })
     }
   }
@@ -132,6 +146,13 @@ export default function RegisterForm() {
                     include={["email", "password"]}
                     autoFocus="email"
                   />
+
+                  {showSlug && (
+                    <Auth.Form.Fields
+                      include={["newSlug"]}
+                      autoFocus="newSlug"
+                    />
+                  )}
                 </div>
 
                 <div className="flex flex-col space-y-4">

--- a/src/components/auth/form/register.tsx
+++ b/src/components/auth/form/register.tsx
@@ -77,10 +77,7 @@ export default function RegisterForm() {
       console.error(error)
 
       const apiError = error instanceof APIError ? error : undefined
-      const isSlugError =
-        apiError != null &&
-        (apiError.code?.startsWith("SLUG_") === true ||
-          apiError.source?.pointer === "/data/attributes/slug")
+      const isSlugError = apiError?.source?.pointer === "/data/attributes/slug"
 
       if (isSlugError && !showSlug) {
         setShowSlug(true)

--- a/src/keygen/accounts/create.ts
+++ b/src/keygen/accounts/create.ts
@@ -10,7 +10,7 @@ config.validate()
 export default async function create(
   values: Schemas.Auth.RegisterValues,
 ): Promise<AccountResponse> {
-  const { email, password } = values
+  const { email, password, slug } = values
 
   if (!config.defaultPlanId) {
     throw new Error("VITE_KEYGEN_DEFAULT_PLAN_ID is not configured.")
@@ -19,6 +19,7 @@ export default async function create(
   const body = {
     data: {
       type: "accounts",
+      ...(slug ? { attributes: { slug } } : {}),
       relationships: {
         plan: {
           data: { type: "plans", id: config.defaultPlanId },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,8 +1,17 @@
 import * as keygen from "@/keygen"
 
+import { dasherize } from "@/lib/utils"
+
 // whether the given token is the one authenticating the current Portal session
 export function isCurrentToken(tokenId: string): boolean {
   return tokenId === keygen.client.currentTokenId
+}
+
+// get account slug from an email address, e.g. "example-com" from "example.com"
+export function accountSlugFromEmail(email: string | undefined | null): string {
+  const domain = email?.split("@")[1] ?? ""
+
+  return dasherize(domain)
 }
 
 interface ResetToken {

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -31,6 +31,16 @@ export type VerifyValues = z.output<typeof VerifySchema>
 export const RegisterSchema = z.object({
   email: z.string().email("Please enter a valid email."),
   password: z.string().min(8, "Password must be at least 8 characters."),
+  slug: z
+    .string()
+    .trim()
+    .transform(dasherize)
+    .pipe(
+      z
+        .string()
+        .regex(/^[a-z0-9][-a-z0-9]+$/, "Please enter a valid account slug.")
+        .or(z.literal("")),
+    ),
 })
 export type RegisterValues = z.output<typeof RegisterSchema>
 
@@ -57,4 +67,5 @@ export type FieldNames =
   | "confirmPassword"
   | "remember"
   | "slug"
+  | "newSlug"
   | "otp"

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -77,6 +77,8 @@ export const AuthFormFieldDescriptions: Readonly<Record<FieldNames, string>> = {
   newPassword: "Choose a new password. Must be at least 8 characters.",
   confirmPassword: "Re-enter your new password to confirm it.",
   slug: 'This can either be your Keygen account\'s "slug" or its unique ID.',
+  newSlug:
+    "A unique identifier for your account, used in URLs and API requests.",
   remember: "Keep your session active on this device.",
   otp: "The 6-digit code from your two-factor authentication app.",
 } as const


### PR DESCRIPTION
Closes #273. Adds a new slug field to the registration form that's only visible after trigging a `SLUG`-related error from the API after submitting, i.e. `SLUG_TAKEN`

Standard form before error:
<img width="700" src="https://github.com/user-attachments/assets/08518b85-b5d3-4fbd-b577-87f3afe22578" />

After `SLUG_TAKEN` error:
<img width="700"  src="https://github.com/user-attachments/assets/89660e59-eeda-4bc1-9211-1268dbdbda84" />
