### PR TITLE
Add raw JSON support to metadata form fields

### DIFF
--- a/src/components/artifacts/form/fields.tsx
+++ b/src/components/artifacts/form/fields.tsx
@@ -28,7 +28,7 @@ import { type FieldVariant } from "@/components/forms/field"
 
 import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
-import KeyValueInput from "@/components/key-value-input"
+import MetadataInput from "@/components/metadata-input"
 
 type Descriptions = typeof ArtifactFormFieldDescriptions
 
@@ -145,7 +145,6 @@ export default function ArtifactsFormFields({
               <MetadataField
                 key="metadata"
                 autoFocus={autoFocus === "metadata"}
-                fieldVariant={fieldVariant}
                 descriptions={descriptions}
               />
             )
@@ -539,11 +538,9 @@ function ReleaseIdField({
 
 function MetadataField({
   autoFocus,
-  fieldVariant = "stacking",
   descriptions,
 }: {
   autoFocus?: boolean
-  fieldVariant?: FieldVariant
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Artifacts.AllValues>()
@@ -554,19 +551,12 @@ function MetadataField({
       name="metadata"
       render={() => (
         <FormItem>
-          <Forms.Field.Header
-            label="Metadata"
-            variant={fieldVariant}
+          <MetadataInput<Schemas.Artifacts.AllValues>
+            name="metadata"
             tooltip={descriptions.metadata}
             optional
-          >
-            <FormControl>
-              <KeyValueInput<Schemas.Artifacts.AllValues>
-                name="metadata"
-                autoFocus={autoFocus}
-              />
-            </FormControl>
-          </Forms.Field.Header>
+            autoFocus={autoFocus}
+          />
         </FormItem>
       )}
     />

--- a/src/components/code-input.tsx
+++ b/src/components/code-input.tsx
@@ -1,0 +1,237 @@
+import { useRef } from "react"
+
+import { Textarea } from "@/components/ui/textarea"
+
+import { cn } from "@/lib/utils"
+
+// characters that auto-close
+const PAIRS: Readonly<Record<string, string>> = {
+  "{": "}",
+  "[": "]",
+  "(": ")",
+  '"': '"',
+}
+
+// subset that opens an indented block on newline
+const BRACKETS: Readonly<Record<string, string>> = {
+  "{": "}",
+  "[": "]",
+  "(": ")",
+}
+
+const CLOSERS: ReadonlySet<string> = new Set(Object.values(PAIRS))
+
+interface CodeInputProps {
+  value: string
+  onChange: (value: string) => void
+  id?: string
+  placeholder?: string
+  disabled?: boolean
+  autoFocus?: boolean
+  spellCheck?: boolean
+  invalid?: boolean
+  minRows?: number
+  indent?: string
+  className?: string
+}
+
+export default function CodeInput({
+  value,
+  onChange,
+  id,
+  placeholder,
+  disabled,
+  autoFocus,
+  spellCheck = false,
+  invalid,
+  minRows = 3,
+  indent = "  ",
+  className,
+}: CodeInputProps): React.ReactElement {
+  const ref = useRef<HTMLTextAreaElement>(null)
+
+  // apply new value and restore caret/selection afterwards since the
+  // textarea is controlled and React would otherwise reset it to the end
+  const apply = (
+    next: string,
+    selectionStart: number,
+    selectionEnd = selectionStart,
+  ) => {
+    onChange(next)
+
+    requestAnimationFrame(() => {
+      const el = ref.current
+      if (el) {
+        el.selectionStart = selectionStart
+        el.selectionEnd = selectionEnd
+      }
+    })
+  }
+
+  // tab indent the current line or every line the selection touches
+  const handleTab = (
+    text: string,
+    start: number,
+    end: number,
+    shift: boolean,
+  ) => {
+    const multiline = text.slice(start, end).includes("\n")
+
+    if (!shift && !multiline) {
+      apply(
+        text.slice(0, start) + indent + text.slice(end),
+        start + indent.length,
+      )
+
+      return
+    }
+
+    const blockStart = text.lastIndexOf("\n", start - 1) + 1
+    const lines = text.slice(blockStart, end).split("\n")
+
+    if (shift) {
+      const dedent = new RegExp(`^ {1,${indent.length}}`)
+      let removedFromFirst = 0
+      let removedTotal = 0
+
+      const dedented = lines
+        .map((line, i) => {
+          const removed = dedent.exec(line)?.[0].length ?? 0
+          if (i === 0) removedFromFirst = removed
+          removedTotal += removed
+
+          return line.slice(removed)
+        })
+        .join("\n")
+
+      apply(
+        text.slice(0, blockStart) + dedented + text.slice(end),
+        Math.max(blockStart, start - removedFromFirst),
+        end - removedTotal,
+      )
+
+      return
+    }
+
+    const indented = lines.map((line) => indent + line).join("\n")
+    apply(
+      text.slice(0, blockStart) + indented + text.slice(end),
+      start + indent.length,
+      end + indent.length * lines.length,
+    )
+  }
+
+  // open an indented block between a bracket and its closer
+  const handleEnter = (text: string, start: number, end: number) => {
+    const lineStart = text.lastIndexOf("\n", start - 1) + 1
+    const currentIndent =
+      /^[ \t]*/.exec(text.slice(lineStart, start))?.[0] ?? ""
+    const before = text[start - 1]
+    const after = text[end]
+
+    if (before && BRACKETS[before]) {
+      const inner = currentIndent + indent
+
+      // if caret sits between an opener and its closer, expand into a block
+      if (after === BRACKETS[before]) {
+        apply(
+          text.slice(0, start) +
+            "\n" +
+            inner +
+            "\n" +
+            currentIndent +
+            text.slice(end),
+          start + 1 + inner.length,
+        )
+
+        return
+      }
+
+      // if caret sits just after an opener, add one indent level
+      apply(
+        text.slice(0, start) + "\n" + inner + text.slice(end),
+        start + 1 + inner.length,
+      )
+
+      return
+    }
+
+    apply(
+      text.slice(0, start) + "\n" + currentIndent + text.slice(end),
+      start + 1 + currentIndent.length,
+    )
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const {
+      value: text,
+      selectionStart: start,
+      selectionEnd: end,
+    } = e.currentTarget
+
+    if (e.key === "Tab") {
+      e.preventDefault()
+      handleTab(text, start, end, e.shiftKey)
+
+      return
+    }
+
+    if (e.key === "Enter") {
+      e.preventDefault()
+      handleEnter(text, start, end)
+
+      return
+    }
+
+    // step over an auto-inserted closer instead of typing a second one
+    if (start === end && CLOSERS.has(e.key) && text[start] === e.key) {
+      e.preventDefault()
+      apply(text, start + 1)
+
+      return
+    }
+
+    // auto-close an opener, wrapping any selected text
+    if (e.key in PAIRS) {
+      e.preventDefault()
+      const selected = text.slice(start, end)
+      apply(
+        text.slice(0, start) +
+          e.key +
+          selected +
+          PAIRS[e.key] +
+          text.slice(end),
+        start + 1,
+        end + 1,
+      )
+
+      return
+    }
+
+    // delete both halves of an empty pair together
+    if (e.key === "Backspace" && start === end) {
+      const before = text[start - 1]
+      if (before && PAIRS[before] === text[start]) {
+        e.preventDefault()
+        apply(text.slice(0, start - 1) + text.slice(start + 1), start - 1)
+      }
+    }
+  }
+
+  return (
+    <Textarea
+      ref={ref}
+      id={id}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={handleKeyDown}
+      disabled={disabled}
+      autoFocus={autoFocus}
+      spellCheck={spellCheck}
+      placeholder={placeholder}
+      aria-invalid={invalid ? true : undefined}
+      className={cn("resize-none font-mono text-xs", className)}
+      style={{ minHeight: `calc(${minRows} * 1lh + 1rem + 2px)` }}
+    />
+  )
+}

--- a/src/components/components/form/fields.tsx
+++ b/src/components/components/form/fields.tsx
@@ -21,7 +21,7 @@ import { useListMachines } from "@/queries/machines"
 
 import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
-import KeyValueInput from "@/components/key-value-input"
+import MetadataInput from "@/components/metadata-input"
 
 type Descriptions = typeof ComponentFormFieldDescriptions
 
@@ -97,7 +97,6 @@ export default function ComponentsFormFields({
               <MetadataField
                 key="metadata"
                 autoFocus={autoFocus === "metadata"}
-                fieldVariant={fieldVariant}
                 descriptions={descriptions}
               />
             )
@@ -246,11 +245,9 @@ function MachineIdField({
 
 function MetadataField({
   autoFocus,
-  fieldVariant = "stacking",
   descriptions,
 }: {
   autoFocus?: boolean
-  fieldVariant?: FieldVariant
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Components.BaseValues>()
@@ -261,18 +258,11 @@ function MetadataField({
       name="metadata"
       render={() => (
         <FormItem>
-          <Forms.Field.Header
-            label="Metadata"
-            variant={fieldVariant}
+          <MetadataInput<Schemas.Components.BaseValues>
+            name="metadata"
             tooltip={descriptions.metadata}
-          >
-            <FormControl>
-              <KeyValueInput<Schemas.Components.BaseValues>
-                name="metadata"
-                autoFocus={autoFocus}
-              />
-            </FormControl>
-          </Forms.Field.Header>
+            autoFocus={autoFocus}
+          />
         </FormItem>
       )}
     />

--- a/src/components/entitlements/form/fields.tsx
+++ b/src/components/entitlements/form/fields.tsx
@@ -17,7 +17,7 @@ import {
 import { type FieldVariant } from "@/components/forms/field"
 
 import * as Forms from "@/components/forms"
-import KeyValueInput from "@/components/key-value-input"
+import MetadataInput from "@/components/metadata-input"
 type Descriptions = typeof EntitlementFormFieldDescriptions
 
 interface EntitlementsFormFieldsProps {
@@ -82,7 +82,6 @@ export default function EntitlementsFormFields({
               <MetadataField
                 key="metadata"
                 autoFocus={autoFocus === "metadata"}
-                fieldVariant={fieldVariant}
                 descriptions={descriptions}
               />
             )
@@ -193,11 +192,9 @@ function CodeField({
 
 function MetadataField<T extends FieldValues>({
   autoFocus,
-  fieldVariant = "stacking",
   descriptions,
 }: {
   autoFocus?: boolean
-  fieldVariant?: FieldVariant
   descriptions: Descriptions
 }) {
   const form = useFormContext<T>()
@@ -208,19 +205,12 @@ function MetadataField<T extends FieldValues>({
       name={"metadata" as never}
       render={() => (
         <FormItem>
-          <Forms.Field.Header
-            label="Metadata"
-            variant={fieldVariant}
-            optional
+          <MetadataInput<T>
+            name={"metadata" as never}
             tooltip={descriptions.metadata}
-          >
-            <FormControl>
-              <KeyValueInput<T>
-                name={"metadata" as never}
-                autoFocus={autoFocus}
-              />
-            </FormControl>
-          </Forms.Field.Header>
+            optional
+            autoFocus={autoFocus}
+          />
         </FormItem>
       )}
     />

--- a/src/components/forms/field/header.tsx
+++ b/src/components/forms/field/header.tsx
@@ -26,6 +26,7 @@ interface FieldHeaderProps {
   variant?: FieldVariant
   optional?: boolean
   hint?: string
+  action?: React.ReactNode
   children: React.ReactNode
   className?: string
 }
@@ -38,6 +39,7 @@ export default function FieldHeader({
   variant = "row",
   optional = false,
   hint,
+  action,
   children,
   className,
 }: FieldHeaderProps) {
@@ -54,7 +56,7 @@ export default function FieldHeader({
         className,
       )}
     >
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-2">
         <div className="group flex items-center gap-2">
           <label className="inline text-sm text-content-muted">
             {head && <>{head} </>}
@@ -112,10 +114,16 @@ export default function FieldHeader({
             </span>
           </label>
         </div>
-        {(hint || optional) && (isMobile || variant === "stacking") && (
-          <span className="text-xs text-content-subdued">
-            {hint ?? "Optional"}
-          </span>
+        {(action ||
+          ((hint || optional) && (isMobile || variant === "stacking"))) && (
+          <div className="flex items-center gap-2">
+            {(hint || optional) && (isMobile || variant === "stacking") && (
+              <span className="text-xs text-content-subdued">
+                {hint ?? "Optional"}
+              </span>
+            )}
+            {action}
+          </div>
         )}
       </div>
 

--- a/src/components/groups/form/fields.tsx
+++ b/src/components/groups/form/fields.tsx
@@ -18,7 +18,7 @@ import {
 import { type FieldVariant } from "@/components/forms/field"
 
 import * as Forms from "@/components/forms"
-import KeyValueInput from "@/components/key-value-input"
+import MetadataInput from "@/components/metadata-input"
 
 type Descriptions = typeof GroupFormFieldDescriptions
 
@@ -104,7 +104,6 @@ export default function GroupsFormFields({
               <MetadataField
                 key="metadata"
                 autoFocus={autoFocus === "metadata"}
-                fieldVariant={fieldVariant}
                 descriptions={descriptions}
               />
             )
@@ -308,11 +307,9 @@ function MaxMachinesField({
 
 function MetadataField({
   autoFocus,
-  fieldVariant = "stacking",
   descriptions,
 }: {
   autoFocus?: boolean
-  fieldVariant?: FieldVariant
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Groups.BaseValues>()
@@ -323,18 +320,12 @@ function MetadataField({
       name="metadata"
       render={() => (
         <FormItem>
-          <Forms.Field.Header
-            label="Metadata"
-            variant={fieldVariant}
+          <MetadataInput<Schemas.Groups.BaseValues>
+            name="metadata"
             tooltip={descriptions.metadata}
-          >
-            <FormControl>
-              <KeyValueInput<Schemas.Groups.BaseValues>
-                name="metadata"
-                autoFocus={autoFocus}
-              />
-            </FormControl>
-          </Forms.Field.Header>
+            optional
+            autoFocus={autoFocus}
+          />
         </FormItem>
       )}
     />

--- a/src/components/key-value-input.tsx
+++ b/src/components/key-value-input.tsx
@@ -89,7 +89,9 @@ export default function KeyValueInput<
           return row
         }
 
-        // reset the value when changing to a more restricted type
+        // reset the value when changing to a more restricted type, but
+        // keep it when switching between string and json so in-progress
+        // work is not lost.
         let { value } = row
 
         if (type === "boolean") {

--- a/src/components/key-value-input.tsx
+++ b/src/components/key-value-input.tsx
@@ -89,9 +89,7 @@ export default function KeyValueInput<
           return row
         }
 
-        // reset the value when changing to a more restricted type, but
-        // keep it when switching between string and json so in-progress
-        // work is not lost.
+        // reset the value when changing to a more restricted type
         let { value } = row
 
         if (type === "boolean") {

--- a/src/components/licenses/form/fields.tsx
+++ b/src/components/licenses/form/fields.tsx
@@ -41,7 +41,7 @@ import { type FieldVariant } from "@/components/forms/field"
 import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
 import * as Calendars from "@/components/calendars"
-import KeyValueInput from "@/components/key-value-input"
+import MetadataInput from "@/components/metadata-input"
 import ByteSizeInput from "@/components/byte-size-input"
 
 type Descriptions = typeof LicenseFormFieldDescriptions
@@ -966,19 +966,12 @@ function MetadataField({
       name="metadata"
       render={() => (
         <FormItem>
-          <Forms.Field.Header
-            label="Metadata"
-            variant="stacking"
-            optional
+          <MetadataInput<Schemas.Licenses.BaseValues>
+            name="metadata"
             tooltip={descriptions.metadata}
-          >
-            <FormControl>
-              <KeyValueInput<Schemas.Licenses.BaseValues>
-                name="metadata"
-                autoFocus={autoFocus}
-              />
-            </FormControl>
-          </Forms.Field.Header>
+            optional
+            autoFocus={autoFocus}
+          />
         </FormItem>
       )}
     />

--- a/src/components/machines/form/fields.tsx
+++ b/src/components/machines/form/fields.tsx
@@ -23,7 +23,7 @@ import { type FieldVariant } from "@/components/forms/field"
 
 import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
-import KeyValueInput from "@/components/key-value-input"
+import MetadataInput from "@/components/metadata-input"
 import ByteSizeInput from "@/components/byte-size-input"
 
 type Descriptions = typeof MachineFormFieldDescriptions
@@ -162,7 +162,6 @@ export default function MachinesFormFields({
               <MetadataField
                 key="metadata"
                 autoFocus={autoFocus === "metadata"}
-                fieldVariant={fieldVariant}
                 descriptions={descriptions}
               />
             )
@@ -570,11 +569,9 @@ function DiskField({
 
 function MetadataField({
   autoFocus,
-  fieldVariant = "stacking",
   descriptions,
 }: {
   autoFocus?: boolean
-  fieldVariant?: FieldVariant
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Machines.BaseValues>()
@@ -585,18 +582,12 @@ function MetadataField({
       name="metadata"
       render={() => (
         <FormItem>
-          <Forms.Field.Header
-            label="Metadata"
-            variant={fieldVariant}
+          <MetadataInput<Schemas.Machines.BaseValues>
+            name="metadata"
             tooltip={descriptions.metadata}
-          >
-            <FormControl>
-              <KeyValueInput<Schemas.Machines.BaseValues>
-                name="metadata"
-                autoFocus={autoFocus}
-              />
-            </FormControl>
-          </Forms.Field.Header>
+            optional
+            autoFocus={autoFocus}
+          />
         </FormItem>
       )}
     />

--- a/src/components/metadata-input.tsx
+++ b/src/components/metadata-input.tsx
@@ -1,0 +1,243 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import { useController, FieldPath, FieldValues } from "react-hook-form"
+
+import { CircleAlert, CurlyBraces, Text } from "lucide-react"
+
+import {
+  metadataPairsToRecord,
+  parseMetadataObjectText,
+  recordToMetadataPairs,
+  type MetadataPair,
+} from "@/schemas/metadata"
+
+import * as Forms from "@/components/forms"
+import CodeInput from "@/components/code-input"
+import KeyValueInput from "@/components/key-value-input"
+
+import { cn } from "@/lib/utils"
+
+type MetadataMode = "fields" | "raw"
+
+const RAW_INVALID_PAIR: MetadataPair = {
+  id: "__raw_invalid__",
+  key: "",
+  type: "integer",
+  value: "",
+}
+
+interface MetadataInputProps<TFormValues extends FieldValues> {
+  name: FieldPath<TFormValues>
+  label?: string
+  tooltip?: string | null
+  optional?: boolean
+  disabled?: boolean
+  autoFocus?: boolean
+  className?: string
+}
+
+export default function MetadataInput<
+  TFormValues extends Record<string, unknown>,
+>({
+  name,
+  label = "Metadata",
+  tooltip,
+  optional,
+  disabled,
+  autoFocus,
+  className,
+}: MetadataInputProps<TFormValues>): React.ReactElement {
+  const { field } = useController<TFormValues, FieldPath<TFormValues>>({ name })
+
+  const rows = useMemo(
+    () => (field.value as MetadataPair[] | undefined) ?? [],
+    [field.value],
+  )
+
+  const [mode, setMode] = useState<MetadataMode>("fields")
+  const [rawText, setRawText] = useState("")
+  const [rawError, setRawError] = useState<string | null>(null)
+
+  // last structured pairs we know to be valid
+  const lastValidRows = useRef<MetadataPair[]>(rows)
+
+  const enterRaw = () => {
+    lastValidRows.current = rows
+
+    const record = metadataPairsToRecord(rows)
+    setRawText(
+      Object.keys(record).length > 0 ? JSON.stringify(record, null, 2) : "",
+    )
+    setRawError(null)
+    setMode("raw")
+  }
+
+  const enterFields = () => {
+    // valid raw edit already synced into field value
+    if (rawError) {
+      field.onChange(lastValidRows.current)
+      setRawError(null)
+    }
+    setMode("fields")
+  }
+
+  const changeMode = (next: MetadataMode) => {
+    if (next === mode) return
+
+    if (next === "raw") {
+      enterRaw()
+    } else {
+      enterFields()
+    }
+  }
+
+  const onRawChange = (text: string) => {
+    setRawText(text)
+
+    const result = parseMetadataObjectText(text)
+    if (result.ok) {
+      const pairs = recordToMetadataPairs(result.value)
+      lastValidRows.current = pairs
+      setRawError(null)
+      field.onChange(pairs)
+    } else {
+      setRawError(result.error)
+      field.onChange([{ ...RAW_INVALID_PAIR }])
+    }
+  }
+
+  return (
+    <Forms.Field.Header
+      label={label}
+      variant="stacking"
+      optional={optional}
+      tooltip={tooltip}
+      className={className}
+      action={
+        <ModeToggle mode={mode} onChange={changeMode} disabled={disabled} />
+      }
+    >
+      {mode === "raw" ? (
+        <div className="space-y-2">
+          <CodeInput
+            value={rawText}
+            onChange={onRawChange}
+            disabled={disabled}
+            autoFocus
+            placeholder={'{\n  "key": "value"\n}'}
+            invalid={!!rawError}
+          />
+          {rawError ? (
+            <p className="flex items-center gap-1 text-sm text-destructive">
+              <CircleAlert className="mt-0.25 h-4 w-4 shrink-0" />
+              {rawError}
+            </p>
+          ) : null}
+        </div>
+      ) : (
+        <KeyValueInput<TFormValues>
+          name={name}
+          autoFocus={autoFocus}
+          disabled={disabled}
+        />
+      )}
+    </Forms.Field.Header>
+  )
+}
+
+const MODE_OPTIONS: {
+  value: MetadataMode
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+}[] = [
+  { value: "fields", label: "Fields", icon: Text },
+  { value: "raw", label: "Raw", icon: CurlyBraces },
+]
+
+function ModeToggle({
+  mode,
+  onChange,
+  disabled,
+}: {
+  mode: MetadataMode
+  onChange: (mode: MetadataMode) => void
+  disabled?: boolean
+}) {
+  const listRef = useRef<HTMLDivElement>(null)
+  const indicatorRef = useRef<HTMLSpanElement>(null)
+  const mounted = useRef(false)
+
+  // slide pill to active option
+  const placeIndicator = useCallback(() => {
+    const active = listRef.current?.querySelector<HTMLElement>(
+      `[data-mode="${mode}"]`,
+    )
+    const indicator = indicatorRef.current
+    if (!active || !indicator) {
+      return
+    }
+
+    if (!mounted.current) {
+      indicator.style.transition = "none"
+    }
+
+    indicator.style.left = `${active.offsetLeft}px`
+    indicator.style.width = `${active.offsetWidth}px`
+
+    if (!mounted.current) {
+      indicator.getBoundingClientRect()
+      indicator.style.transition = ""
+      mounted.current = true
+    }
+  }, [mode])
+
+  useLayoutEffect(placeIndicator, [placeIndicator])
+
+  useEffect(() => {
+    window.addEventListener("resize", placeIndicator)
+    return () => window.removeEventListener("resize", placeIndicator)
+  }, [placeIndicator])
+
+  return (
+    <div
+      ref={listRef}
+      aria-label="Metadata editor mode"
+      className="relative inline-flex items-center gap-0.5 rounded-md bg-background-1 p-0.5 text-xs"
+    >
+      <span
+        ref={indicatorRef}
+        aria-hidden
+        className="pointer-events-none absolute inset-y-0.5 left-0 w-0 rounded-sm bg-background-2 shadow-sm transition-[left,width] duration-200 ease-out motion-reduce:transition-none"
+      />
+      {MODE_OPTIONS.map(({ value, label, icon: Icon }) => {
+        const selected = mode === value
+
+        return (
+          <button
+            key={value}
+            type="button"
+            data-mode={value}
+            aria-pressed={selected}
+            disabled={disabled}
+            onClick={() => onChange(value)}
+            className={cn(
+              "relative z-10 flex items-center gap-1 rounded-sm px-2 py-1 transition-colors disabled:opacity-50",
+              selected
+                ? "text-content-loud"
+                : "cursor-pointer text-content-subdued hover:text-content-muted",
+            )}
+          >
+            <Icon className="h-3 w-3" />
+            {label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/packages/form/fields.tsx
+++ b/src/components/packages/form/fields.tsx
@@ -27,7 +27,7 @@ import { type FieldVariant } from "@/components/forms/field"
 
 import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
-import KeyValueInput from "@/components/key-value-input"
+import MetadataInput from "@/components/metadata-input"
 import { CardSelector, CardOption } from "@/components/card-selector"
 
 type Descriptions = typeof PackageFormFieldDescriptions
@@ -98,7 +98,6 @@ export default function PackagesFormFields({
               <MetadataField
                 key="metadata"
                 autoFocus={autoFocus === "metadata"}
-                fieldVariant={fieldVariant}
                 descriptions={descriptions}
               />
             )
@@ -342,11 +341,9 @@ function ProductIdField({
 
 function MetadataField({
   autoFocus,
-  fieldVariant = "stacking",
   descriptions,
 }: {
   autoFocus?: boolean
-  fieldVariant?: FieldVariant
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Packages.AllValues>()
@@ -357,19 +354,12 @@ function MetadataField({
       name="metadata"
       render={() => (
         <FormItem>
-          <Forms.Field.Header
-            label="Metadata"
-            variant={fieldVariant}
+          <MetadataInput<Schemas.Packages.AllValues>
+            name="metadata"
             tooltip={descriptions.metadata}
             optional
-          >
-            <FormControl>
-              <KeyValueInput<Schemas.Packages.AllValues>
-                name="metadata"
-                autoFocus={autoFocus}
-              />
-            </FormControl>
-          </Forms.Field.Header>
+            autoFocus={autoFocus}
+          />
         </FormItem>
       )}
     />

--- a/src/components/policies/form/fields.tsx
+++ b/src/components/policies/form/fields.tsx
@@ -57,7 +57,7 @@ import { type FieldVariant } from "@/components/forms/field"
 
 import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
-import KeyValueInput from "@/components/key-value-input"
+import MetadataInput from "@/components/metadata-input"
 import NullableSelect from "@/components/nullable-select"
 import DurationInput from "@/components/duration-input"
 import ByteSizeInput from "@/components/byte-size-input"
@@ -817,18 +817,11 @@ function MetadataField({
       name="metadata"
       render={() => (
         <FormItem>
-          <Forms.Field.Header
-            label="Metadata"
-            variant="stacking"
+          <MetadataInput<Schemas.Policies.AllFormValues>
+            name="metadata"
             tooltip={descriptions.metadata}
-          >
-            <FormControl>
-              <KeyValueInput<Schemas.Policies.AllFormValues>
-                name="metadata"
-                autoFocus={autoFocus}
-              />
-            </FormControl>
-          </Forms.Field.Header>
+            autoFocus={autoFocus}
+          />
         </FormItem>
       )}
     />

--- a/src/components/processes/form/fields.tsx
+++ b/src/components/processes/form/fields.tsx
@@ -27,7 +27,7 @@ import { type FieldVariant } from "@/components/forms/field"
 
 import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
-import KeyValueInput from "@/components/key-value-input"
+import MetadataInput from "@/components/metadata-input"
 
 type Descriptions = typeof ProcessFormFieldDescriptions
 
@@ -93,7 +93,6 @@ export default function ProcessesFormFields({
               <MetadataField
                 key="metadata"
                 autoFocus={autoFocus === "metadata"}
-                fieldVariant={fieldVariant}
                 descriptions={descriptions}
               />
             )
@@ -226,11 +225,9 @@ function MachineIdField({
 
 function MetadataField({
   autoFocus,
-  fieldVariant = "stacking",
   descriptions,
 }: {
   autoFocus?: boolean
-  fieldVariant?: FieldVariant
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Processes.BaseValues>()
@@ -241,19 +238,12 @@ function MetadataField({
       name="metadata"
       render={() => (
         <FormItem>
-          <Forms.Field.Header
-            label="Metadata"
-            variant={fieldVariant}
+          <MetadataInput<Schemas.Processes.BaseValues>
+            name="metadata"
             tooltip={descriptions.metadata}
             optional
-          >
-            <FormControl>
-              <KeyValueInput<Schemas.Processes.BaseValues>
-                name="metadata"
-                autoFocus={autoFocus}
-              />
-            </FormControl>
-          </Forms.Field.Header>
+            autoFocus={autoFocus}
+          />
         </FormItem>
       )}
     />

--- a/src/components/products/form/fields.tsx
+++ b/src/components/products/form/fields.tsx
@@ -25,7 +25,7 @@ import { type FieldVariant } from "@/components/forms/field"
 import * as Forms from "@/components/forms"
 import TagInput from "@/components/tag-input"
 import MultiSelect from "@/components/multi-select"
-import KeyValueInput from "@/components/key-value-input"
+import MetadataInput from "@/components/metadata-input"
 import { CardSelector, CardOption } from "@/components/card-selector"
 
 type Descriptions = typeof ProductFormFieldDescriptions
@@ -126,7 +126,6 @@ export default function ProductsFormFields({
               <MetadataField
                 key="metadata"
                 autoFocus={autoFocus === "metadata"}
-                fieldVariant={fieldVariant}
                 descriptions={descriptions}
               />
             )
@@ -396,11 +395,9 @@ function PlatformsField({
 
 function MetadataField({
   autoFocus,
-  fieldVariant = "stacking",
   descriptions,
 }: {
   autoFocus?: boolean
-  fieldVariant?: FieldVariant
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Products.AllValues>()
@@ -411,19 +408,12 @@ function MetadataField({
       name="metadata"
       render={() => (
         <FormItem>
-          <Forms.Field.Header
-            label="Metadata"
-            variant={fieldVariant}
+          <MetadataInput<Schemas.Products.AllValues>
+            name="metadata"
             tooltip={descriptions.metadata}
             optional
-          >
-            <FormControl>
-              <KeyValueInput<Schemas.Products.AllValues>
-                name="metadata"
-                autoFocus={autoFocus}
-              />
-            </FormControl>
-          </Forms.Field.Header>
+            autoFocus={autoFocus}
+          />
         </FormItem>
       )}
     />

--- a/src/components/releases/form/fields.tsx
+++ b/src/components/releases/form/fields.tsx
@@ -47,7 +47,7 @@ import { type FieldVariant } from "@/components/forms/field"
 import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
 import * as Calendars from "@/components/calendars"
-import KeyValueInput from "@/components/key-value-input"
+import MetadataInput from "@/components/metadata-input"
 import { CardSelector, CardOption } from "@/components/card-selector"
 import VersionInput from "@/components/version-input"
 import { recomposeVersion } from "@/lib/releases"
@@ -152,7 +152,6 @@ export default function ReleasesFormFields({
               <MetadataField
                 key="metadata"
                 autoFocus={autoFocus === "metadata"}
-                fieldVariant={fieldVariant}
                 descriptions={descriptions}
               />
             )
@@ -688,11 +687,9 @@ function PackageIdField({
 
 function MetadataField({
   autoFocus,
-  fieldVariant = "stacking",
   descriptions,
 }: {
   autoFocus?: boolean
-  fieldVariant?: FieldVariant
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Releases.AllValues>()
@@ -703,19 +700,12 @@ function MetadataField({
       name="metadata"
       render={() => (
         <FormItem>
-          <Forms.Field.Header
-            label="Metadata"
-            variant={fieldVariant}
+          <MetadataInput<Schemas.Releases.AllValues>
+            name="metadata"
             tooltip={descriptions.metadata}
             optional
-          >
-            <FormControl>
-              <KeyValueInput<Schemas.Releases.AllValues>
-                name="metadata"
-                autoFocus={autoFocus}
-              />
-            </FormControl>
-          </Forms.Field.Header>
+            autoFocus={autoFocus}
+          />
         </FormItem>
       )}
     />

--- a/src/components/users/form/fields.tsx
+++ b/src/components/users/form/fields.tsx
@@ -39,7 +39,7 @@ import { type FieldVariant } from "@/components/forms/field"
 import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
 import MultiSelect from "@/components/multi-select"
-import KeyValueInput from "@/components/key-value-input"
+import MetadataInput from "@/components/metadata-input"
 import TooltipSelectItem from "@/components/tooltip-select-item"
 
 type Descriptions = typeof UserFormFieldDescriptions
@@ -193,7 +193,6 @@ export default function UsersFormFields({
               <MetadataField
                 key="metadata"
                 autoFocus={autoFocus === "metadata"}
-                fieldVariant={fieldVariant}
                 descriptions={descriptions}
               />
             )
@@ -638,11 +637,9 @@ function InternalPermissionsField({
 
 function MetadataField({
   autoFocus,
-  fieldVariant = "stacking",
   descriptions,
 }: {
   autoFocus?: boolean
-  fieldVariant?: FieldVariant
   descriptions: Descriptions
 }) {
   const form = useFormContext<Schemas.Users.BaseValues>()
@@ -653,18 +650,12 @@ function MetadataField({
       name="metadata"
       render={() => (
         <FormItem>
-          <Forms.Field.Header
-            label="Metadata"
-            variant={fieldVariant}
+          <MetadataInput<Schemas.Users.BaseValues>
+            name="metadata"
             tooltip={descriptions.metadata}
-          >
-            <FormControl>
-              <KeyValueInput<Schemas.Users.BaseValues>
-                name="metadata"
-                autoFocus={autoFocus}
-              />
-            </FormControl>
-          </Forms.Field.Header>
+            optional
+            autoFocus={autoFocus}
+          />
         </FormItem>
       )}
     />

--- a/src/schemas/metadata.ts
+++ b/src/schemas/metadata.ts
@@ -204,6 +204,32 @@ export function metadataValueToType(v: unknown): MetadataType {
   return "string"
 }
 
+// parse a raw metadata JSON object string (as edited in "raw" mode) into a
+// record. an empty string is treated as an empty object. arrays, primitives and
+// null are rejected since top-level metadata must be a JSON object.
+export function parseMetadataObjectText(
+  text: string,
+):
+  | { ok: true; value: Record<string, MetadataValue> }
+  | { ok: false; error: string } {
+  const trimmed = text.trim()
+  if (!trimmed) {
+    return { ok: true, value: {} }
+  }
+
+  const parsed = tryParseJson(trimmed)
+  if (!parsed) {
+    return { ok: false, error: "Metadata must be valid JSON" }
+  }
+
+  const value = parsed.value
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return { ok: false, error: "Metadata must be a JSON object" }
+  }
+
+  return { ok: true, value: value as Record<string, MetadataValue> }
+}
+
 // convert a raw metadata value into its input-string representation
 export function metadataValueToString(v: unknown): string {
   if (v === null || v === undefined) return ""
@@ -230,7 +256,7 @@ export function recordToMetadataPairs(
 }
 
 // convert a MetadataPair[] into a Record<string, MetadataValue> for serialization
-function metadataPairsToRecord(
+export function metadataPairsToRecord(
   pairs: MetadataPair[],
 ): Record<string, MetadataValue> {
   const out: Record<string, MetadataValue> = {}

--- a/src/schemas/metadata.ts
+++ b/src/schemas/metadata.ts
@@ -204,9 +204,7 @@ export function metadataValueToType(v: unknown): MetadataType {
   return "string"
 }
 
-// parse a raw metadata JSON object string (as edited in "raw" mode) into a
-// record. an empty string is treated as an empty object. arrays, primitives and
-// null are rejected since top-level metadata must be a JSON object.
+// parse a raw metadata JSON object string into a record.
 export function parseMetadataObjectText(
   text: string,
 ):


### PR DESCRIPTION
Closes #272. Adds a toggle on all metadata fields for switching between `Fields` and `Raw` JSON input modes.

Fields is the default which has a key/value input:
<img width="700" src="https://github.com/user-attachments/assets/6f2c6a8e-97cb-4a11-a9ed-a3c349093466" />

Raw is an alternative input mode for metadata fields that allow users to write or paste valid JSON instead:
<img width="700" src="https://github.com/user-attachments/assets/169536a5-5965-42b8-8db5-7814708c6dd4" />

Raw includes some editor conveniences, such as tab indentation, indented newlines, auto-closing braces/quotes, etc. basically some general assists you'd expect from a code editor.