### PR TITLE
Add default Portal session token expiry

### DIFF
--- a/src/keygen/authenticate.ts
+++ b/src/keygen/authenticate.ts
@@ -1,3 +1,5 @@
+import { addWeeks } from "date-fns"
+
 import config from "@/keygen/config"
 import client from "@/keygen/client"
 import { AuthResponse } from "@/types/auth"
@@ -5,6 +7,7 @@ import { AuthResponse } from "@/types/auth"
 config.validate()
 
 const LOGIN_TOKEN_NAME = "Portal Token"
+const SESSION_EXPIRY_WEEKS = 2
 
 interface AuthProps {
   email: string
@@ -23,10 +26,15 @@ export async function authenticate({
     unescape(encodeURIComponent(`${email || ""}:${password || ""}`)),
   )
 
+  const expiry = addWeeks(new Date(), SESSION_EXPIRY_WEEKS).toISOString()
+
   const body = JSON.stringify({
     data: {
       type: "tokens",
-      attributes: { name: LOGIN_TOKEN_NAME },
+      attributes: {
+        name: LOGIN_TOKEN_NAME,
+        expiry,
+      },
     },
     ...(otp != null ? { meta: { otp } } : {}),
   })


### PR DESCRIPTION
Closes #258. Fixes generating tokens that never expire with a 2-week default expiry.

<img width="700" src="https://github.com/user-attachments/assets/f41e8f67-a98a-4781-976c-db66a20adf4c" />