### PR TITLE
Add scheme to policy create forms

### DIFF
--- a/src/components/notice.tsx
+++ b/src/components/notice.tsx
@@ -69,4 +69,4 @@ function NoticeDescription({
 Notice.Title = NoticeTitle
 Notice.Description = NoticeDescription
 
-export { Notice, noticeVariants }
+export { Notice }

--- a/src/components/notice.tsx
+++ b/src/components/notice.tsx
@@ -1,0 +1,72 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import {
+  Info,
+  TriangleAlert,
+  OctagonAlert,
+  type LucideIcon,
+} from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const noticeVariants = cva(
+  "flex items-start gap-2 rounded-md p-3 text-pretty",
+  {
+    variants: {
+      variant: {
+        default: "bg-background-1 text-content-muted",
+        primary: "bg-primary/20 text-primary",
+        secondary: "bg-secondary/20 text-secondary",
+        warning: "bg-warning/20 text-warning",
+        destructive: "bg-destructive/20 text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+)
+
+export type NoticeVariant = NonNullable<
+  VariantProps<typeof noticeVariants>["variant"]
+>
+
+const noticeIcons: Record<NoticeVariant, LucideIcon> = {
+  default: Info,
+  primary: Info,
+  secondary: Info,
+  warning: TriangleAlert,
+  destructive: OctagonAlert,
+}
+
+function Notice({
+  className,
+  variant = "default",
+  children,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof noticeVariants>) {
+  const Icon = noticeIcons[variant ?? "default"]
+
+  return (
+    <div className={cn(noticeVariants({ variant }), className)} {...props}>
+      <Icon className="mt-0.5 size-4 shrink-0" />
+      <div className="flex flex-col text-xs">{children}</div>
+    </div>
+  )
+}
+
+function NoticeTitle({ className, ...props }: React.ComponentProps<"strong">) {
+  return <strong className={cn(className)} {...props} />
+}
+
+function NoticeDescription({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return <span className={cn("text-pretty", className)} {...props} />
+}
+
+Notice.Title = NoticeTitle
+Notice.Description = NoticeDescription
+
+export { Notice, noticeVariants }

--- a/src/components/policies/form/create.tsx
+++ b/src/components/policies/form/create.tsx
@@ -5,6 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
+import { Separator } from "@/components/ui/separator"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import {
   Tooltip,
@@ -38,10 +39,10 @@ import {
 
 import * as Schemas from "@/schemas"
 import {
-  PolicyTemplateSelection,
   TimingTemplates,
   AccessTemplates,
   MeteredTemplates,
+  PolicyTemplateSelection,
 } from "@/schemas/policies"
 
 import { toast } from "@/lib/toast"
@@ -58,7 +59,9 @@ import { useCreateEntitlement } from "@/queries/entitlements"
 
 import * as Forms from "@/components/forms"
 import * as Policies from "@/components/policies"
+import CollapsibleCard from "@/components/collapsible-card"
 import DocumentationLink from "@/components/documentation-link"
+import { Notice } from "@/components/notice"
 import { CardSelector, CardOption } from "@/components/card-selector"
 import { BadgeGroup, BadgeGroupItem } from "@/components/badge-group"
 
@@ -86,19 +89,21 @@ export default function CreatePolicyForm({
 
   const schema = useMemo(
     () =>
-      Schemas.Policies.composeSchema<
-        Schemas.Policies.CreateFormValues,
-        Schemas.Policies.CreateValues
-      >(
-        {
-          timing: selection?.timing ?? null,
-          access: selection?.access ?? [],
-          metered: selection?.metered ?? [],
-          offline: selection?.offline ?? false,
-        },
-        { product: true },
-      ),
-    [selection],
+      mode === "scratch"
+        ? Schemas.Policies.CreateSchema
+        : Schemas.Policies.composeSchema<
+            Schemas.Policies.CreateFormValues,
+            Schemas.Policies.CreateValues
+          >(
+            {
+              timing: selection?.timing ?? null,
+              access: selection?.access ?? [],
+              metered: selection?.metered ?? [],
+              offline: selection?.offline ?? false,
+            },
+            { product: true },
+          ),
+    [mode, selection],
   )
 
   const form = useForm<
@@ -860,6 +865,7 @@ function TemplatesForm({
                 "checkInInterval",
                 "checkInIntervalCount",
                 "authenticationStrategy",
+                ...(selection.offline ? (["scheme"] as const) : []),
                 "metadata",
               ]}
             >
@@ -884,6 +890,34 @@ function TemplatesForm({
                 </Forms.Section.Columns>
                 <Policies.Form.Fields schema="create" include={["metadata"]} />
               </Forms.Section.Card>
+
+              {selection.offline && (
+                <CollapsibleCard
+                  title="Offline configuration"
+                  defaultOpen={false}
+                  containerClass="m-4 w-auto"
+                >
+                  <div className="flex flex-col gap-4">
+                    <Policies.Form.Fields
+                      schema="create"
+                      include={["scheme"]}
+                    />
+                    <Notice variant="warning">
+                      <Notice.Title>
+                        Setting a cryptographic scheme on this policy will
+                        cryptographically sign its license keys.
+                      </Notice.Title>
+                      <Notice.Description>
+                        This will make the data embedded in each key immutable.
+                        For most use cases, checking out a license file is
+                        recommended instead. License files do not require a
+                        cryptographic scheme. Avoid combining signed keys with
+                        license files.
+                      </Notice.Description>
+                    </Notice>
+                  </div>
+                </CollapsibleCard>
+              )}
 
               <DocumentationLink page="policies" />
             </Forms.Section.Step>
@@ -1043,6 +1077,7 @@ function ScratchForm({
               "floating",
               "protected",
               "usePool",
+              "scheme",
               "checkInInterval",
               "checkInIntervalCount",
               "maxUses",
@@ -1066,6 +1101,32 @@ function ScratchForm({
                 ]}
                 fieldVariant="stacking"
               />
+
+              <Separator className="my-8" />
+
+              <CollapsibleCard
+                title="Offline configuration"
+                defaultOpen={false}
+                containerClass="w-full"
+              >
+                <Policies.Form.Fields
+                  schema="create"
+                  include={["scheme"]}
+                  fieldVariant="stacking"
+                />
+                <Notice variant="warning">
+                  <Notice.Title>
+                    Setting a cryptographic scheme on this policy will
+                    cryptographically sign its license keys.
+                  </Notice.Title>
+                  <Notice.Description>
+                    This will make the data embedded in each key immutable. For
+                    most use cases, checking out a license file is recommended
+                    instead. License files do not require a cryptographic
+                    scheme. Avoid combining signed keys with license files.
+                  </Notice.Description>
+                </Notice>
+              </CollapsibleCard>
             </Forms.Section.Stacking>
 
             <DocumentationLink page="policies" />

--- a/src/components/policies/form/duplicate.tsx
+++ b/src/components/policies/form/duplicate.tsx
@@ -22,6 +22,7 @@ import { settleCreateEntitlements } from "@/lib/entitlements"
 import * as Forms from "@/components/forms"
 import * as Loading from "@/components/loading"
 import * as Policies from "@/components/policies"
+import { Notice } from "@/components/notice"
 import { Separator } from "@/components/ui/separator"
 
 interface DuplicatePolicyFormProps {
@@ -226,6 +227,30 @@ export default function DuplicatePolicyForm({
                   mode={mode}
                   include={["entitlements.attach", "entitlements.create"]}
                 />
+              </Forms.Section.Column>
+            </Forms.Section.Columns>
+
+            <Separator className="my-8" />
+
+            <Forms.Section.Columns title="Offline configuration">
+              <Forms.Section.Column>
+                <Policies.Form.Fields
+                  schema="create"
+                  mode={mode}
+                  include={["scheme"]}
+                />
+                <Notice variant="warning">
+                  <Notice.Title>
+                    Setting a cryptographic scheme on this policy will
+                    cryptographically sign its license keys.
+                  </Notice.Title>
+                  <Notice.Description>
+                    This will make the data embedded in each key immutable. For
+                    most use cases, checking out a license file is recommended
+                    instead. License files do not require a cryptographic
+                    scheme. Avoid combining signed keys with license files.
+                  </Notice.Description>
+                </Notice>
               </Forms.Section.Column>
             </Forms.Section.Columns>
           </Forms.Layout.Sheet>

--- a/src/components/policies/form/duplicate.tsx
+++ b/src/components/policies/form/duplicate.tsx
@@ -24,6 +24,7 @@ import * as Loading from "@/components/loading"
 import * as Policies from "@/components/policies"
 import { Notice } from "@/components/notice"
 import { Separator } from "@/components/ui/separator"
+import CollapsibleCard from "@/components/collapsible-card"
 
 interface DuplicatePolicyFormProps {
   open: boolean
@@ -232,8 +233,12 @@ export default function DuplicatePolicyForm({
 
             <Separator className="my-8" />
 
-            <Forms.Section.Columns title="Offline configuration">
-              <Forms.Section.Column>
+            <CollapsibleCard
+              title="Offline configuration"
+              defaultOpen={false}
+              containerClass="w-full"
+            >
+              <div className="flex flex-col gap-4">
                 <Policies.Form.Fields
                   schema="create"
                   mode={mode}
@@ -251,8 +256,8 @@ export default function DuplicatePolicyForm({
                     scheme. Avoid combining signed keys with license files.
                   </Notice.Description>
                 </Notice>
-              </Forms.Section.Column>
-            </Forms.Section.Columns>
+              </div>
+            </CollapsibleCard>
           </Forms.Layout.Sheet>
         )}
       </Forms.Container.Dialog>

--- a/src/components/policies/form/fields.tsx
+++ b/src/components/policies/form/fields.tsx
@@ -1,6 +1,7 @@
 import { useFormContext, useFieldArray, useWatch } from "react-hook-form"
 
 import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -51,6 +52,8 @@ import {
   MachineLeasingStrategy,
   CheckInInterval,
   ProcessLeasingStrategy,
+  Scheme,
+  SchemeDeprecated,
   PolicyMode,
 } from "@/types/policies"
 import { type FieldVariant } from "@/components/forms/field"
@@ -552,6 +555,16 @@ export default function PoliciesFormFields({
               <RequireVersionScopeField
                 key="requireVersionScope"
                 autoFocus={autoFocus === "requireVersionScope"}
+                descriptions={descriptions}
+                mode={mode}
+              />
+            )
+          case "scheme":
+            return (
+              <SchemeField
+                key="scheme"
+                autoFocus={autoFocus === "scheme"}
+                fieldVariant={fieldVariant}
                 descriptions={descriptions}
                 mode={mode}
               />
@@ -2970,6 +2983,67 @@ function UsePoolField({
               />
             </FormControl>
           </Forms.Field.Header>
+        </FormItem>
+      )}
+    />
+  )
+}
+
+function SchemeField({
+  autoFocus,
+  fieldVariant = "row",
+  descriptions,
+  mode = PolicyMode.Create,
+}: {
+  autoFocus?: boolean
+  fieldVariant?: FieldVariant
+  descriptions: Descriptions
+  mode?: PolicyMode
+}) {
+  const form = useFormContext<Schemas.Policies.AllValues>()
+  const shouldMount = useDeferredMount({
+    delay: mode === PolicyMode.Create ? 0 : 500,
+  })
+
+  if (!shouldMount) {
+    return (
+      <div className="w-full justify-between space-y-2 md:flex">
+        <Skeleton className="h-5 w-24 rounded-sm" />
+        <Skeleton className="h-9 w-full rounded-sm md:w-48" />
+      </div>
+    )
+  }
+
+  return (
+    <FormField
+      control={form.control}
+      name="scheme"
+      render={({ field, fieldState }) => (
+        <FormItem>
+          <Forms.Field.Header
+            label="Scheme"
+            variant={fieldVariant}
+            tooltip={descriptions.scheme}
+          >
+            <NullableSelect<Scheme>
+              value={field.value}
+              onChange={(value) => field.onChange(value)}
+              invalid={!!fieldState.error}
+              autoFocus={autoFocus}
+              placeholder="None"
+              clearLabel="None"
+            >
+              {Object.values(Scheme).map((scheme) => (
+                <SelectItem key={scheme} value={scheme}>
+                  {PolicyOptionLabels.scheme[scheme]}
+                  {SchemeDeprecated[scheme] && (
+                    <Badge variant="disabled">Deprecated</Badge>
+                  )}
+                </SelectItem>
+              ))}
+            </NullableSelect>
+          </Forms.Field.Header>
+          <FormMessage />
         </FormItem>
       )}
     />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -58,7 +58,9 @@ function DialogContent({
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
-      {disableOverlay ? null : <DialogOverlay />}
+      <DialogOverlay
+        className={disableOverlay ? "bg-transparent" : undefined}
+      />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(

--- a/src/pages/app/token/details.tsx
+++ b/src/pages/app/token/details.tsx
@@ -22,15 +22,9 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb"
 
-import {
-  Copy,
-  Menu,
-  Logs,
-  GitFork,
-  SquarePen,
-  SquarePlus,
-  TriangleAlert,
-} from "lucide-react"
+import { Copy, Menu, Logs, GitFork, SquarePen, SquarePlus } from "lucide-react"
+
+import { Notice } from "@/components/notice"
 
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
@@ -202,23 +196,19 @@ export default function TokenDetails() {
               <BackButton className="mb-8" />
 
               {token.attributes.kind === "admin-token" && (
-                <div className="mb-6 flex items-start gap-2 rounded-md bg-warning/20 p-3 text-sm text-pretty text-warning">
-                  <TriangleAlert className="mt-0.5 size-4 shrink-0" />
-                  <p className="flex flex-col text-xs">
-                    <strong>
-                      Admin tokens should be used sparingly for API
-                      integrations.
-                    </strong>
-                    <span className="text-pretty">
-                      Admin tokens are automatically revoked when the admin's
-                      password is changed, when its second factors are changed,
-                      or when the admin's role or permissions are changed. As
-                      such, we <strong>DO NOT</strong> recommend using admin
-                      tokens for API integrations. Doing so could cause your API
-                      integration to break unexpectedly.
-                    </span>
-                  </p>
-                </div>
+                <Notice variant="warning" className="mb-8">
+                  <Notice.Title>
+                    Admin tokens should be used sparingly for API integrations.
+                  </Notice.Title>
+                  <Notice.Description>
+                    Admin tokens are automatically revoked when the admin's
+                    password is changed, when its second factors are changed, or
+                    when the admin's role or permissions are changed. As such,
+                    we <strong>DO NOT</strong> recommend using admin tokens for
+                    API integrations. Doing so could cause your API integration
+                    to break unexpectedly.
+                  </Notice.Description>
+                </Notice>
               )}
 
               <div className="mb-2 flex items-center gap-2">

--- a/src/schemas/policies.ts
+++ b/src/schemas/policies.ts
@@ -4,6 +4,8 @@ import { z } from "zod"
 import { CombineFormValues } from "@/types/forms"
 import {
   Policy,
+  isScheme,
+  Scheme,
   CheckInInterval,
   AuthenticationStrategy,
   ExpirationStrategy,
@@ -316,8 +318,35 @@ export const ProductShape = z.object({
   }),
 })
 
+export const SchemeShape = z.object({
+  scheme: z.nativeEnum(Scheme).nullish().default(null),
+})
+
+export type SchemeValues = BaseValues & { scheme?: Scheme | null }
+
+export const SchemeRules = <TInput, TOutput extends SchemeValues>(
+  schema: AnySchema<TInput, TOutput>,
+): AnySchema<TInput, TOutput> =>
+  schema
+    .refine(
+      (values: SchemeValues) => values.scheme == null || !values.usePool,
+      {
+        path: ["scheme"],
+        message: "Cannot be used with a pooled policy",
+      },
+    )
+    .refine(
+      (values: SchemeValues) => values.scheme == null || !values.usePool,
+      {
+        path: ["usePool"],
+        message: "Cannot be used with a scheme",
+      },
+    ) as AnySchema<TInput, TOutput>
+
 export const BaseSchema = BaseRules(BaseShape)
-export const CreateSchema = BaseRules(BaseShape.merge(ProductShape))
+export const CreateSchema = SchemeRules(
+  BaseRules(BaseShape.merge(ProductShape).merge(SchemeShape)),
+)
 export const UpdateSchema = BaseSchema
 
 export type BaseFormValues = z.input<typeof BaseSchema>
@@ -339,7 +368,7 @@ export type AllValues = CombineFormValues<
 
 export type FieldNames = Exclude<
   FieldPath<AllValues>,
-  "scheme" | "encrypted" | "entitlements" | "product.id"
+  "encrypted" | "entitlements" | "product.id"
 >
 
 export enum TimingTemplates {
@@ -650,7 +679,7 @@ export function composeSchema<
     shape = shape.merge(ProcessBasedShape)
   if (metered.includes(MeteredTemplates.LeaseBased))
     shape = shape.merge(LeaseBasedShape)
-  if (selection.offline) shape = shape.merge(OfflineShape)
+  if (selection.offline) shape = shape.merge(OfflineShape).merge(SchemeShape)
 
   let schema = shape as unknown as AnySchema<BaseFormValues, BaseValues>
   if (selection.timing === TimingTemplates.Timed) {
@@ -670,6 +699,9 @@ export function composeSchema<
   }
   if (metered.includes(MeteredTemplates.LeaseBased)) {
     schema = LeaseBasedRules(schema)
+  }
+  if (selection.offline) {
+    schema = SchemeRules(schema)
   }
 
   return schema as AnySchema<TInput, TOutput>
@@ -759,6 +791,9 @@ export function getFormValuesFromPolicy<
     return {
       ...base,
       product: { id: policy.relationships.product?.data?.id ?? "" },
+      scheme: isScheme(policy.attributes.scheme)
+        ? policy.attributes.scheme
+        : null,
     } as unknown as T
   }
 

--- a/src/types/policies.ts
+++ b/src/types/policies.ts
@@ -106,6 +106,31 @@ export enum TransferStrategy {
   ResetExpiry = "RESET_EXPIRY",
 }
 
+export enum Scheme {
+  Ed25519Sign = "ED25519_SIGN",
+  EcdsaP256Sign = "ECDSA_P256_SIGN",
+  Rsa2048Pkcs1PssSignV2 = "RSA_2048_PKCS1_PSS_SIGN_V2",
+  Rsa2048Pkcs1SignV2 = "RSA_2048_PKCS1_SIGN_V2",
+  Rsa2048JwtRs256 = "RSA_2048_JWT_RS256",
+  Rsa2048Pkcs1Encrypt = "RSA_2048_PKCS1_ENCRYPT",
+  Rsa2048Pkcs1PssSign = "RSA_2048_PKCS1_PSS_SIGN",
+  Rsa2048Pkcs1Sign = "RSA_2048_PKCS1_SIGN",
+}
+
+export const isScheme = (value: string | null | undefined): value is Scheme =>
+  value != null && (Object.values(Scheme) as string[]).includes(value)
+
+export const SchemeDeprecated: Readonly<Record<Scheme, boolean>> = {
+  [Scheme.Ed25519Sign]: false,
+  [Scheme.EcdsaP256Sign]: false,
+  [Scheme.Rsa2048Pkcs1PssSignV2]: false,
+  [Scheme.Rsa2048Pkcs1SignV2]: false,
+  [Scheme.Rsa2048JwtRs256]: false,
+  [Scheme.Rsa2048Pkcs1Encrypt]: false,
+  [Scheme.Rsa2048Pkcs1PssSign]: true,
+  [Scheme.Rsa2048Pkcs1Sign]: true,
+}
+
 export type PolicyAttributes = {
   name: string
   duration: number | null
@@ -436,5 +461,15 @@ export const PolicyOptionLabels = {
   transferStrategy: {
     [TransferStrategy.KeepExpiry]: "Keep Expiry",
     [TransferStrategy.ResetExpiry]: "Reset Expiry",
+  },
+  scheme: {
+    [Scheme.Ed25519Sign]: "Ed25519",
+    [Scheme.EcdsaP256Sign]: "ECDSA P-256",
+    [Scheme.Rsa2048Pkcs1PssSignV2]: "RSA 2048 PKCS1 PSS v2",
+    [Scheme.Rsa2048Pkcs1SignV2]: "RSA 2048 PKCS1 v2",
+    [Scheme.Rsa2048JwtRs256]: "RSA 2048 JWT RS256",
+    [Scheme.Rsa2048Pkcs1Encrypt]: "RSA 2048 PKCS1 Encrypt",
+    [Scheme.Rsa2048Pkcs1PssSign]: "RSA 2048 PKCS1 PSS",
+    [Scheme.Rsa2048Pkcs1Sign]: "RSA 2048 PKCS1",
   },
 } as const


### PR DESCRIPTION
Closes #291, closes #295. Adds the `scheme` attribute to policy template, scratch and duplicate forms. Also adds a new reusable `<Notice />` component for notice callouts when we need them, e.g. the admin token call out in `/app/tokens`.

Also fixes an issue (#295) where scroll via mouse wheel was broken in multi-dialog forms, such as the policy create forms here.

In the template flow, `scheme` is included in advanced with a collapsed card by default to keep it out of the way from normal user interaction:
<img width="700" src="https://github.com/user-attachments/assets/342136ac-7c4f-494b-92b9-f2833245811a" />

Scratch form's `scheme` attribute is located in a collapsed card as well, at the bottom of the `Requirements` section:
<img width="700" src="https://github.com/user-attachments/assets/294d2c06-3136-4483-9429-921bf4ff068e" />

Duplicate policy is located at the bottom of the form in a collapsible card that's closed by default, as well:
<img width="700" src="https://github.com/user-attachments/assets/802a5779-da33-484c-b252-f147fca05982" />


