### PR TITLE
Fix non-gregorian duration display

### DIFF
--- a/src/components/duration-input.tsx
+++ b/src/components/duration-input.tsx
@@ -15,15 +15,17 @@ import {
   PopoverContent,
 } from "@/components/ui/popover"
 
+import {
+  SECONDS_PER_MINUTE,
+  SECONDS_PER_HOUR,
+  SECONDS_PER_DAY,
+  SECONDS_PER_WEEK,
+  SECONDS_PER_MONTH,
+  SECONDS_PER_YEAR,
+} from "@/lib/temporal"
 import { cn } from "@/lib/utils"
-import { useMobile } from "@/hooks/use-mobile"
 
-const SECONDS_PER_MINUTE = 60
-const SECONDS_PER_HOUR = 3600
-const SECONDS_PER_DAY = 86400
-const SECONDS_PER_WEEK = 604800
-const SECONDS_PER_MONTH = 2629746
-const SECONDS_PER_YEAR = 31556952
+import { useMobile } from "@/hooks/use-mobile"
 
 type Unit = { key: string; label: string; seconds: number | null }
 

--- a/src/lib/temporal.ts
+++ b/src/lib/temporal.ts
@@ -1,5 +1,12 @@
 import type { Duration } from "date-fns"
 
+export const SECONDS_PER_MINUTE = 60
+export const SECONDS_PER_HOUR = 3600
+export const SECONDS_PER_DAY = 86400
+export const SECONDS_PER_WEEK = 604800
+export const SECONDS_PER_MONTH = 2629746
+export const SECONDS_PER_YEAR = 31556952
+
 const ISO_DURATION_RE =
   /P(?:([\d]+\.?[\d]*|\.[\d]+)Y)?(?:([\d]+\.?[\d]*|\.[\d]+)M)?(?:([\d]+\.?[\d]*|\.[\d]+)W)?(?:([\d]+\.?[\d]*|\.[\d]+)D)?(?:T(?:([\d]+\.?[\d]*|\.[\d]+)H)?(?:([\d]+\.?[\d]*|\.[\d]+)M)?(?:([\d]+\.?[\d]*|\.[\d]+)S)?)?$/
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,15 @@
 import { clsx, type ClassValue } from "clsx"
+import type { Duration } from "date-fns"
 import { twMerge } from "tailwind-merge"
+
+import {
+  SECONDS_PER_MINUTE,
+  SECONDS_PER_HOUR,
+  SECONDS_PER_DAY,
+  SECONDS_PER_WEEK,
+  SECONDS_PER_MONTH,
+  SECONDS_PER_YEAR,
+} from "@/lib/temporal"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -101,32 +111,42 @@ export function labelize(value?: string | null, map?: Record<string, string>) {
   return (map && map[value]) || titleCase(value)
 }
 
-const MINUTE = 60
-const HOUR = 3600
-const DAY = 86400
-const WEEK = 604800
-const MONTH = 2592000
-const YEAR = 31536000
+const DURATION_UNITS: [keyof Duration, number][] = [
+  ["years", SECONDS_PER_YEAR],
+  ["months", SECONDS_PER_MONTH],
+  ["weeks", SECONDS_PER_WEEK],
+  ["days", SECONDS_PER_DAY],
+  ["hours", SECONDS_PER_HOUR],
+  ["minutes", SECONDS_PER_MINUTE],
+  ["seconds", 1],
+]
 
-export function secondsToParts(total?: number | null) {
+export function secondsToParts(total?: number | null): Duration | null {
   if (total == null || total === 0) return null
 
-  let seconds = Math.max(0, Math.floor(total))
+  const seconds = Math.max(0, Math.floor(total))
 
-  const years = Math.trunc(seconds / YEAR)
-  seconds -= years * YEAR
-  const months = Math.trunc(seconds / MONTH)
-  seconds -= months * MONTH
-  const weeks = Math.trunc(seconds / WEEK)
-  seconds -= weeks * WEEK
-  const days = Math.trunc(seconds / DAY)
-  seconds -= days * DAY
-  const hours = Math.trunc(seconds / HOUR)
-  seconds -= hours * HOUR
-  const minutes = Math.trunc(seconds / MINUTE)
-  seconds -= minutes * MINUTE
+  // when the value is a whole number of a single unit, show just
+  // that unit so it reads back the way it was entered, e.g. 1 year
+  for (const [unit, size] of DURATION_UNITS) {
+    if (size > 1 && seconds % size === 0) {
+      const part: Duration = {}
+      part[unit] = seconds / size
+      return part
+    }
+  }
 
-  return { years, months, weeks, days, hours, minutes, seconds }
+  // otherwise break it down across units
+  let remaining = seconds
+  const parts: Duration = {}
+  for (const [unit, size] of DURATION_UNITS) {
+    const count = Math.trunc(remaining / size)
+    if (count > 0) {
+      parts[unit] = count
+      remaining -= count * size
+    }
+  }
+  return parts
 }
 
 export function splitLastWord(s: string): { head: string; tail: string } {


### PR DESCRIPTION
Closes #173.

e.g. selecting `1 Year` for policy duration now displays the correct unit/value:
<img width="700" src="https://github.com/user-attachments/assets/353e6ad3-aa77-4542-b976-57644899c7bf" />
