### PR TITLE
Fix broken breadcrumbs after certain navigations

### DIFF
--- a/src/components/resource-link.tsx
+++ b/src/components/resource-link.tsx
@@ -8,7 +8,6 @@ import {
 } from "@/components/ui/tooltip"
 
 import { type Linkage } from "@/types/api"
-import { InternalRoles } from "@/types/users"
 
 import { useGetArch } from "@/queries/arches"
 import { useGetUser } from "@/queries/users"
@@ -64,7 +63,6 @@ interface ResourceLinkViewProps {
   isError?: boolean
   buttonClassName?: string
   truncate?: boolean
-  to?: string
 }
 
 function ResourceLinkView({
@@ -74,7 +72,6 @@ function ResourceLinkView({
   isError,
   buttonClassName,
   truncate = false,
-  to = `/$accountId/app/${linkage.type}/$id`,
 }: ResourceLinkViewProps): ReactElement {
   if (isLoading) return <Skeleton className="h-5 w-32 rounded-sm" />
 
@@ -88,7 +85,7 @@ function ResourceLinkView({
       <Tooltip>
         <TooltipTrigger className="cursor-pointer">
           <GoToButton
-            path={to}
+            path={`/$accountId/app/${linkage.type}/$id`}
             params={{ accountId: keygen.config.id, id: linkage.id }}
             label={text}
             disabled
@@ -108,7 +105,7 @@ function ResourceLinkView({
 
   return (
     <GoToButton
-      path={to}
+      path={`/$accountId/app/${linkage.type}/$id`}
       params={{ accountId: keygen.config.id, id: linkage.id }}
       label={text}
       buttonClassName={buttonClassName}
@@ -174,29 +171,7 @@ const RESOURCE_LINKS: Record<
     (d) => d?.attributes.name || d?.attributes.fingerprint,
   ),
   processes: makeResourceLink(useGetProcess, (d) => d?.attributes.pid),
-  users: function UserLink({
-    linkage,
-    buttonClassName,
-    truncate,
-  }: ResolvedLinkProps): ReactElement {
-    const { data, isLoading, isError } = useGetUser(linkage.id)
-
-    return (
-      <ResourceLinkView
-        linkage={linkage}
-        to={
-          data && InternalRoles.includes(data.attributes.role)
-            ? "/$accountId/app/team/$id"
-            : "/$accountId/app/users/$id"
-        }
-        label={data ? getUserLabel(data) : null}
-        isLoading={isLoading}
-        isError={isError}
-        buttonClassName={buttonClassName}
-        truncate={truncate}
-      />
-    )
-  },
+  users: makeResourceLink(useGetUser, (d) => (d ? getUserLabel(d) : null)),
   packages: makeResourceLink(useGetPackage, (d) =>
     d ? getPackageLabel(d) : null,
   ),

--- a/src/components/resource-link.tsx
+++ b/src/components/resource-link.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/tooltip"
 
 import { type Linkage } from "@/types/api"
+import { InternalRoles } from "@/types/users"
 
 import { useGetArch } from "@/queries/arches"
 import { useGetUser } from "@/queries/users"
@@ -63,6 +64,7 @@ interface ResourceLinkViewProps {
   isError?: boolean
   buttonClassName?: string
   truncate?: boolean
+  to?: string
 }
 
 function ResourceLinkView({
@@ -72,6 +74,7 @@ function ResourceLinkView({
   isError,
   buttonClassName,
   truncate = false,
+  to = `/$accountId/app/${linkage.type}/$id`,
 }: ResourceLinkViewProps): ReactElement {
   if (isLoading) return <Skeleton className="h-5 w-32 rounded-sm" />
 
@@ -85,7 +88,7 @@ function ResourceLinkView({
       <Tooltip>
         <TooltipTrigger className="cursor-pointer">
           <GoToButton
-            path={`/$accountId/app/${linkage.type}/$id`}
+            path={to}
             params={{ accountId: keygen.config.id, id: linkage.id }}
             label={text}
             disabled
@@ -105,7 +108,7 @@ function ResourceLinkView({
 
   return (
     <GoToButton
-      path={`/$accountId/app/${linkage.type}/$id`}
+      path={to}
       params={{ accountId: keygen.config.id, id: linkage.id }}
       label={text}
       buttonClassName={buttonClassName}
@@ -171,7 +174,29 @@ const RESOURCE_LINKS: Record<
     (d) => d?.attributes.name || d?.attributes.fingerprint,
   ),
   processes: makeResourceLink(useGetProcess, (d) => d?.attributes.pid),
-  users: makeResourceLink(useGetUser, (d) => (d ? getUserLabel(d) : null)),
+  users: function UserLink({
+    linkage,
+    buttonClassName,
+    truncate,
+  }: ResolvedLinkProps): ReactElement {
+    const { data, isLoading, isError } = useGetUser(linkage.id)
+
+    return (
+      <ResourceLinkView
+        linkage={linkage}
+        to={
+          data && InternalRoles.includes(data.attributes.role)
+            ? "/$accountId/app/team/$id"
+            : "/$accountId/app/users/$id"
+        }
+        label={data ? getUserLabel(data) : null}
+        isLoading={isLoading}
+        isError={isError}
+        buttonClassName={buttonClassName}
+        truncate={truncate}
+      />
+    )
+  },
   packages: makeResourceLink(useGetPackage, (d) =>
     d ? getPackageLabel(d) : null,
   ),

--- a/src/components/users/form/edit.tsx
+++ b/src/components/users/form/edit.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from "react"
 import { useForm, useWatch } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useParams } from "@tanstack/react-router"
 
 import { Separator } from "@/components/ui/separator"
 
@@ -17,15 +16,16 @@ import * as Forms from "@/components/forms"
 import * as Users from "@/components/users"
 
 interface EditUserFormProps {
+  id: string
   open: boolean
   onOpenChange: (open: boolean) => void
 }
 
 export default function EditUserForm({
+  id,
   open,
   onOpenChange,
 }: EditUserFormProps) {
-  const { id } = useParams({ from: "/$accountId/app/users/$id" })
   const { data: user } = useGetUser(id)
   const updateUser = useUpdateUser(user?.id ?? "")
   const changeGroup = useChangeUserGroup()

--- a/src/hooks/use-breadcrumb-back-navigate.ts
+++ b/src/hooks/use-breadcrumb-back-navigate.ts
@@ -1,0 +1,26 @@
+import { useLocation } from "@tanstack/react-router"
+
+declare module "@tanstack/react-router" {
+  interface HistoryState {
+    from?: { pathname: string }
+  }
+}
+
+export function useBreadcrumbBackNavigate(): (
+  fallback: () => void,
+  listPath?: string,
+) => void {
+  const location = useLocation()
+
+  return (fallback, listPath) => {
+    const target = listPath ?? location.pathname.replace(/\/[^/]+$/, "")
+
+    if (location.state.from?.pathname === target && window.history.length > 1) {
+      window.history.back()
+
+      return
+    }
+
+    fallback()
+  }
+}

--- a/src/hooks/use-breadcrumb-back-navigate.ts
+++ b/src/hooks/use-breadcrumb-back-navigate.ts
@@ -13,7 +13,7 @@ export function useBreadcrumbBackNavigate(): (
   const navigate = useNavigate()
   const location = useLocation()
 
-  return (fallback, listPath) => {
+  return async (fallback, listPath) => {
     const target = listPath ?? location.pathname.replace(/\/[^/]+$/, "")
 
     if (location.state.from?.pathname === target && window.history.length > 1) {
@@ -25,7 +25,7 @@ export function useBreadcrumbBackNavigate(): (
     if (fallback) {
       fallback()
     } else {
-      navigate({ to: ".." })
+      await navigate({ to: ".." })
     }
   }
 }

--- a/src/hooks/use-breadcrumb-back-navigate.ts
+++ b/src/hooks/use-breadcrumb-back-navigate.ts
@@ -1,4 +1,4 @@
-import { useLocation } from "@tanstack/react-router"
+import { useLocation, useNavigate } from "@tanstack/react-router"
 
 declare module "@tanstack/react-router" {
   interface HistoryState {
@@ -7,9 +7,10 @@ declare module "@tanstack/react-router" {
 }
 
 export function useBreadcrumbBackNavigate(): (
-  fallback: () => void,
+  fallback?: () => void,
   listPath?: string,
 ) => void {
+  const navigate = useNavigate()
   const location = useLocation()
 
   return (fallback, listPath) => {
@@ -21,6 +22,10 @@ export function useBreadcrumbBackNavigate(): (
       return
     }
 
-    fallback()
+    if (fallback) {
+      fallback()
+    } else {
+      navigate({ to: ".." })
+    }
   }
 }

--- a/src/hooks/use-resource-navigate.ts
+++ b/src/hooks/use-resource-navigate.ts
@@ -1,4 +1,4 @@
-import { useNavigate } from "@tanstack/react-router"
+import { useLocation, useNavigate } from "@tanstack/react-router"
 
 import type { AnyResource } from "@/types/api"
 
@@ -8,6 +8,7 @@ export type NavigableResource = Pick<AnyResource, "type" | "id">
 
 export function useResourceNavigate() {
   const navigate = useNavigate()
+  const location = useLocation()
 
   return async (resource: NavigableResource | null): Promise<void> => {
     if (!resource) return
@@ -18,6 +19,9 @@ export function useResourceNavigate() {
         accountId: keygen.config.id,
         id: resource.id,
       },
+      // save where we came from so the detail's breadcrumb can return to this
+      // exact list with any filters applied, when it's the canonical parent
+      state: (prev) => ({ ...prev, from: { pathname: location.pathname } }),
     })
   }
 }

--- a/src/pages/app/artifact/details.tsx
+++ b/src/pages/app/artifact/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -90,6 +90,7 @@ export default function ArtifactDetails() {
   const releaseId = artifact?.relationships.release?.data?.id || ""
   const { data: release } = useGetRelease(releaseId)
 
+  const navigate = useNavigate()
   const back = useBackNavigate()
 
   const isMobile = useMobile()
@@ -133,7 +134,7 @@ export default function ArtifactDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Artifacts
                 </BreadcrumbLink>

--- a/src/pages/app/artifact/details.tsx
+++ b/src/pages/app/artifact/details.tsx
@@ -57,6 +57,7 @@ import { useGetArtifact, useRemoveArtifact } from "@/queries/artifacts"
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 
 import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
@@ -92,6 +93,7 @@ export default function ArtifactDetails() {
 
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
 
   const isMobile = useMobile()
   const [tab, setTab] = useSidebarTab()
@@ -134,7 +136,7 @@ export default function ArtifactDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Artifacts
                 </BreadcrumbLink>

--- a/src/pages/app/artifact/details.tsx
+++ b/src/pages/app/artifact/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -91,7 +91,6 @@ export default function ArtifactDetails() {
   const releaseId = artifact?.relationships.release?.data?.id || ""
   const { data: release } = useGetRelease(releaseId)
 
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
 
@@ -136,7 +135,7 @@ export default function ArtifactDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Artifacts
                 </BreadcrumbLink>

--- a/src/pages/app/component/details.tsx
+++ b/src/pages/app/component/details.tsx
@@ -44,6 +44,7 @@ import { useGetComponent, useRemoveComponent } from "@/queries/components"
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 
 import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
@@ -76,6 +77,7 @@ export default function ComponentDetails() {
 
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
 
   const isMobile = useMobile()
   const [tab, setTab] = useSidebarTab()
@@ -116,7 +118,7 @@ export default function ComponentDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Components
                 </BreadcrumbLink>

--- a/src/pages/app/component/details.tsx
+++ b/src/pages/app/component/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -75,7 +75,6 @@ export default function ComponentDetails() {
   } = useGetComponent(id)
   const removeComponent = useRemoveComponent(id)
 
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
 
@@ -118,7 +117,7 @@ export default function ComponentDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Components
                 </BreadcrumbLink>

--- a/src/pages/app/component/details.tsx
+++ b/src/pages/app/component/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -74,6 +74,7 @@ export default function ComponentDetails() {
   } = useGetComponent(id)
   const removeComponent = useRemoveComponent(id)
 
+  const navigate = useNavigate()
   const back = useBackNavigate()
 
   const isMobile = useMobile()
@@ -115,7 +116,7 @@ export default function ComponentDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Components
                 </BreadcrumbLink>

--- a/src/pages/app/entitlement/details.tsx
+++ b/src/pages/app/entitlement/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -73,6 +73,7 @@ export default function EntitlementDetails() {
 
   const deleteEntitlement = useRemoveEntitlement(id)
 
+  const navigate = useNavigate()
   const back = useBackNavigate()
 
   const isMobile = useMobile()
@@ -118,7 +119,7 @@ export default function EntitlementDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Entitlements
                 </BreadcrumbLink>

--- a/src/pages/app/entitlement/details.tsx
+++ b/src/pages/app/entitlement/details.tsx
@@ -42,6 +42,7 @@ import { EntitlementAttributeDescriptions } from "@/types/entitlements"
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 import { useGetEntitlement, useRemoveEntitlement } from "@/queries/entitlements"
 
 import { toast } from "@/lib/toast"
@@ -75,6 +76,7 @@ export default function EntitlementDetails() {
 
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
 
   const isMobile = useMobile()
   const [tab, setTab] = useSidebarTab()
@@ -119,7 +121,7 @@ export default function EntitlementDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Entitlements
                 </BreadcrumbLink>

--- a/src/pages/app/entitlement/details.tsx
+++ b/src/pages/app/entitlement/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -74,7 +74,6 @@ export default function EntitlementDetails() {
 
   const deleteEntitlement = useRemoveEntitlement(id)
 
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
 
@@ -121,7 +120,7 @@ export default function EntitlementDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Entitlements
                 </BreadcrumbLink>

--- a/src/pages/app/event-log/details.tsx
+++ b/src/pages/app/event-log/details.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -52,6 +52,7 @@ import CollapsibleCard from "@/components/collapsible-card"
 export default function EventLogDetails() {
   const { id } = useParams({ from: "/$accountId/app/event-logs/$id" })
   const { data: eventLog, isFetching, isError } = useGetEventLog(id)
+  const navigate = useNavigate()
   const back = useBackNavigate()
   const isMobile = useMobile()
 
@@ -79,7 +80,7 @@ export default function EventLogDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Event Logs
                 </BreadcrumbLink>

--- a/src/pages/app/event-log/details.tsx
+++ b/src/pages/app/event-log/details.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -53,7 +53,6 @@ import CollapsibleCard from "@/components/collapsible-card"
 export default function EventLogDetails() {
   const { id } = useParams({ from: "/$accountId/app/event-logs/$id" })
   const { data: eventLog, isFetching, isError } = useGetEventLog(id)
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
   const isMobile = useMobile()
@@ -82,7 +81,7 @@ export default function EventLogDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Event Logs
                 </BreadcrumbLink>

--- a/src/pages/app/event-log/details.tsx
+++ b/src/pages/app/event-log/details.tsx
@@ -29,6 +29,7 @@ import { useGetEventLog } from "@/queries/event-logs"
 
 import { useMobile } from "@/hooks/use-mobile"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 
 import { copyToClipboard } from "@/lib/clipboard"
 import {
@@ -54,6 +55,7 @@ export default function EventLogDetails() {
   const { data: eventLog, isFetching, isError } = useGetEventLog(id)
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
   const isMobile = useMobile()
 
   useEffect(() => {
@@ -80,7 +82,7 @@ export default function EventLogDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Event Logs
                 </BreadcrumbLink>

--- a/src/pages/app/group/details.tsx
+++ b/src/pages/app/group/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -88,7 +88,6 @@ export default function GroupDetails() {
     isError: ownersError,
   } = useListGroupOwners(id)
 
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
 
@@ -131,7 +130,7 @@ export default function GroupDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Groups
                 </BreadcrumbLink>

--- a/src/pages/app/group/details.tsx
+++ b/src/pages/app/group/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -87,6 +87,7 @@ export default function GroupDetails() {
     isError: ownersError,
   } = useListGroupOwners(id)
 
+  const navigate = useNavigate()
   const back = useBackNavigate()
 
   const isMobile = useMobile()
@@ -128,7 +129,7 @@ export default function GroupDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Groups
                 </BreadcrumbLink>

--- a/src/pages/app/group/details.tsx
+++ b/src/pages/app/group/details.tsx
@@ -49,6 +49,7 @@ import {
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 
 import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
@@ -89,6 +90,7 @@ export default function GroupDetails() {
 
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
 
   const isMobile = useMobile()
   const [tab, setTab] = useSidebarTab()
@@ -129,7 +131,7 @@ export default function GroupDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Groups
                 </BreadcrumbLink>

--- a/src/pages/app/index.ts
+++ b/src/pages/app/index.ts
@@ -5,6 +5,7 @@ export { default as Entitlements } from "./entitlements"
 export { default as Licenses } from "./licenses"
 export { default as Machines } from "./machines"
 export { default as Users } from "./users"
+export { default as Teams } from "./teams"
 export { default as Groups } from "./groups"
 export { default as Components } from "./components"
 export { default as Processes } from "./processes"
@@ -38,6 +39,9 @@ export { Machine }
 
 import * as User from "./user"
 export { User }
+
+import * as Team from "./team"
+export { Team }
 
 import * as Group from "./group"
 export { Group }

--- a/src/pages/app/license/details.tsx
+++ b/src/pages/app/license/details.tsx
@@ -62,7 +62,6 @@ import {
   LicenseStatusDescriptions,
   LicenseAttributeDescriptions,
 } from "@/types/licenses"
-import { InternalRoles } from "@/types/users"
 
 import { useGetPolicy } from "@/queries/policies"
 import {
@@ -718,11 +717,7 @@ export default function LicenseDetails() {
                       {licenseUsers.map((user) => (
                         <GoToButton
                           key={user.id}
-                          path={
-                            InternalRoles.includes(user.attributes.role)
-                              ? "/$accountId/app/team/$id"
-                              : "/$accountId/app/users/$id"
-                          }
+                          path="/$accountId/app/users/$id"
                           params={{ accountId: keygen.config.id, id: user.id }}
                           label={getUserLabel(user)}
                         />

--- a/src/pages/app/license/details.tsx
+++ b/src/pages/app/license/details.tsx
@@ -79,6 +79,7 @@ import {
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 
 import { toast } from "@/lib/toast"
 import { getUserLabel } from "@/lib/users"
@@ -157,6 +158,7 @@ export default function LicenseDetails() {
 
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
 
   const isMobile = useMobile()
   const [tab, setTab] = useSidebarTab()
@@ -267,7 +269,7 @@ export default function LicenseDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Licenses
                 </BreadcrumbLink>

--- a/src/pages/app/license/details.tsx
+++ b/src/pages/app/license/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -156,7 +156,6 @@ export default function LicenseDetails() {
     isError: licenseUsersError,
   } = useListLicenseUsers(id)
 
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
 
@@ -269,7 +268,7 @@ export default function LicenseDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Licenses
                 </BreadcrumbLink>

--- a/src/pages/app/license/details.tsx
+++ b/src/pages/app/license/details.tsx
@@ -62,6 +62,7 @@ import {
   LicenseStatusDescriptions,
   LicenseAttributeDescriptions,
 } from "@/types/licenses"
+import { InternalRoles } from "@/types/users"
 
 import { useGetPolicy } from "@/queries/policies"
 import {
@@ -717,7 +718,11 @@ export default function LicenseDetails() {
                       {licenseUsers.map((user) => (
                         <GoToButton
                           key={user.id}
-                          path="/$accountId/app/users/$id"
+                          path={
+                            InternalRoles.includes(user.attributes.role)
+                              ? "/$accountId/app/team/$id"
+                              : "/$accountId/app/users/$id"
+                          }
                           params={{ accountId: keygen.config.id, id: user.id }}
                           label={getUserLabel(user)}
                         />

--- a/src/pages/app/license/details.tsx
+++ b/src/pages/app/license/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -155,6 +155,7 @@ export default function LicenseDetails() {
     isError: licenseUsersError,
   } = useListLicenseUsers(id)
 
+  const navigate = useNavigate()
   const back = useBackNavigate()
 
   const isMobile = useMobile()
@@ -266,7 +267,7 @@ export default function LicenseDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Licenses
                 </BreadcrumbLink>

--- a/src/pages/app/machine/details.tsx
+++ b/src/pages/app/machine/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -82,7 +82,6 @@ export default function MachineDetails() {
   const removeMachine = useRemoveMachine(id)
   const resetHeartbeat = useResetMachineHeartbeat(id)
 
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
 
@@ -137,7 +136,7 @@ export default function MachineDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Machines
                 </BreadcrumbLink>

--- a/src/pages/app/machine/details.tsx
+++ b/src/pages/app/machine/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -81,6 +81,7 @@ export default function MachineDetails() {
   const removeMachine = useRemoveMachine(id)
   const resetHeartbeat = useResetMachineHeartbeat(id)
 
+  const navigate = useNavigate()
   const back = useBackNavigate()
 
   const isMobile = useMobile()
@@ -134,7 +135,7 @@ export default function MachineDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Machines
                 </BreadcrumbLink>

--- a/src/pages/app/machine/details.tsx
+++ b/src/pages/app/machine/details.tsx
@@ -48,6 +48,7 @@ import {
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 
 import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
@@ -83,6 +84,7 @@ export default function MachineDetails() {
 
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
 
   const isMobile = useMobile()
   const [tab, setTab] = useSidebarTab()
@@ -135,7 +137,7 @@ export default function MachineDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Machines
                 </BreadcrumbLink>

--- a/src/pages/app/package/details.tsx
+++ b/src/pages/app/package/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -78,7 +78,6 @@ export default function PackageDetails() {
   const productId = pkg?.relationships.product?.data?.id || ""
   const { data: product } = useGetProduct(productId)
 
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
 
@@ -123,7 +122,7 @@ export default function PackageDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Packages
                 </BreadcrumbLink>

--- a/src/pages/app/package/details.tsx
+++ b/src/pages/app/package/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -77,6 +77,7 @@ export default function PackageDetails() {
   const productId = pkg?.relationships.product?.data?.id || ""
   const { data: product } = useGetProduct(productId)
 
+  const navigate = useNavigate()
   const back = useBackNavigate()
 
   const isMobile = useMobile()
@@ -120,7 +121,7 @@ export default function PackageDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Packages
                 </BreadcrumbLink>

--- a/src/pages/app/package/details.tsx
+++ b/src/pages/app/package/details.tsx
@@ -51,6 +51,7 @@ import { useGetPackage, useRemovePackage } from "@/queries/packages"
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 
 import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
@@ -79,6 +80,7 @@ export default function PackageDetails() {
 
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
 
   const isMobile = useMobile()
   const [tab, setTab] = useSidebarTab()
@@ -121,7 +123,7 @@ export default function PackageDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Packages
                 </BreadcrumbLink>

--- a/src/pages/app/policy/details.tsx
+++ b/src/pages/app/policy/details.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react"
 import { useState } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -112,6 +112,7 @@ export default function PolicyDetails() {
     isError: entitlementsError,
   } = useListPolicyEntitlements(id)
 
+  const navigate = useNavigate()
   const back = useBackNavigate()
 
   const isMobile = useMobile()
@@ -156,7 +157,7 @@ export default function PolicyDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Policies
                 </BreadcrumbLink>

--- a/src/pages/app/policy/details.tsx
+++ b/src/pages/app/policy/details.tsx
@@ -57,6 +57,7 @@ import {
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 
 import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
@@ -114,6 +115,7 @@ export default function PolicyDetails() {
 
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
 
   const isMobile = useMobile()
   const [tab, setTab] = useSidebarTab()
@@ -157,7 +159,7 @@ export default function PolicyDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Policies
                 </BreadcrumbLink>

--- a/src/pages/app/policy/details.tsx
+++ b/src/pages/app/policy/details.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react"
 import { useState } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -113,7 +113,6 @@ export default function PolicyDetails() {
     isError: entitlementsError,
   } = useListPolicyEntitlements(id)
 
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
 
@@ -159,7 +158,7 @@ export default function PolicyDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Policies
                 </BreadcrumbLink>

--- a/src/pages/app/process/details.tsx
+++ b/src/pages/app/process/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -91,7 +91,6 @@ export default function ProcessDetails() {
   } = useGetProcess(id)
   const removeProcess = useRemoveProcess(id)
 
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
 
@@ -134,7 +133,7 @@ export default function ProcessDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Processes
                 </BreadcrumbLink>

--- a/src/pages/app/process/details.tsx
+++ b/src/pages/app/process/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -90,6 +90,7 @@ export default function ProcessDetails() {
   } = useGetProcess(id)
   const removeProcess = useRemoveProcess(id)
 
+  const navigate = useNavigate()
   const back = useBackNavigate()
 
   const isMobile = useMobile()
@@ -131,7 +132,7 @@ export default function ProcessDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Processes
                 </BreadcrumbLink>

--- a/src/pages/app/process/details.tsx
+++ b/src/pages/app/process/details.tsx
@@ -53,6 +53,7 @@ import { useGetProcess, useRemoveProcess } from "@/queries/processes"
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 
 import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
@@ -92,6 +93,7 @@ export default function ProcessDetails() {
 
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
 
   const isMobile = useMobile()
   const [tab, setTab] = useSidebarTab()
@@ -132,7 +134,7 @@ export default function ProcessDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Processes
                 </BreadcrumbLink>

--- a/src/pages/app/product/details.tsx
+++ b/src/pages/app/product/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, type ReactNode } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -84,6 +84,7 @@ export default function ProductDetails() {
   const { data: product, isLoading, isFetching, isError } = useGetProduct(id)
   const deleteProduct = useRemoveProduct(id)
 
+  const navigate = useNavigate()
   const back = useBackNavigate()
 
   const isMobile = useMobile()
@@ -127,7 +128,7 @@ export default function ProductDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Products
                 </BreadcrumbLink>

--- a/src/pages/app/product/details.tsx
+++ b/src/pages/app/product/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, type ReactNode } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -85,7 +85,6 @@ export default function ProductDetails() {
   const { data: product, isLoading, isFetching, isError } = useGetProduct(id)
   const deleteProduct = useRemoveProduct(id)
 
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
 
@@ -130,7 +129,7 @@ export default function ProductDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Products
                 </BreadcrumbLink>

--- a/src/pages/app/product/details.tsx
+++ b/src/pages/app/product/details.tsx
@@ -51,6 +51,7 @@ import {
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 import { useGetProduct, useRemoveProduct } from "@/queries/products"
 
 import { toast } from "@/lib/toast"
@@ -86,6 +87,7 @@ export default function ProductDetails() {
 
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
 
   const isMobile = useMobile()
   const [tab, setTab] = useSidebarTab()
@@ -128,7 +130,7 @@ export default function ProductDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Products
                 </BreadcrumbLink>

--- a/src/pages/app/release/details.tsx
+++ b/src/pages/app/release/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -188,7 +188,6 @@ export default function ReleaseDetails() {
     isError: artifactsError,
   } = useListReleaseArtifacts(id)
 
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
 
@@ -255,7 +254,7 @@ export default function ReleaseDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Releases
                 </BreadcrumbLink>

--- a/src/pages/app/release/details.tsx
+++ b/src/pages/app/release/details.tsx
@@ -78,6 +78,7 @@ import {
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 
 import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
@@ -189,6 +190,7 @@ export default function ReleaseDetails() {
 
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
 
   const isMobile = useMobile()
   const [tab, setTab] = useSidebarTab()
@@ -253,7 +255,7 @@ export default function ReleaseDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Releases
                 </BreadcrumbLink>

--- a/src/pages/app/release/details.tsx
+++ b/src/pages/app/release/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -187,6 +187,7 @@ export default function ReleaseDetails() {
     isError: artifactsError,
   } = useListReleaseArtifacts(id)
 
+  const navigate = useNavigate()
   const back = useBackNavigate()
 
   const isMobile = useMobile()
@@ -252,7 +253,7 @@ export default function ReleaseDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Releases
                 </BreadcrumbLink>

--- a/src/pages/app/request-log/details.tsx
+++ b/src/pages/app/request-log/details.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -51,6 +51,7 @@ import CollapsibleCard from "@/components/collapsible-card"
 export default function RequestLogDetails() {
   const { id } = useParams({ from: "/$accountId/app/request-logs/$id" })
   const { data: requestLog, isFetching, isError } = useGetRequestLog(id)
+  const navigate = useNavigate()
   const back = useBackNavigate()
   const isMobile = useMobile()
 
@@ -75,7 +76,7 @@ export default function RequestLogDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Request Logs
                 </BreadcrumbLink>

--- a/src/pages/app/request-log/details.tsx
+++ b/src/pages/app/request-log/details.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -52,7 +52,6 @@ import CollapsibleCard from "@/components/collapsible-card"
 export default function RequestLogDetails() {
   const { id } = useParams({ from: "/$accountId/app/request-logs/$id" })
   const { data: requestLog, isFetching, isError } = useGetRequestLog(id)
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
   const isMobile = useMobile()
@@ -78,7 +77,7 @@ export default function RequestLogDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Request Logs
                 </BreadcrumbLink>

--- a/src/pages/app/request-log/details.tsx
+++ b/src/pages/app/request-log/details.tsx
@@ -27,6 +27,7 @@ import { useGetRequestLog } from "@/queries/request-logs"
 
 import { useMobile } from "@/hooks/use-mobile"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 
 import {
   formatRequestLogRequest,
@@ -53,6 +54,7 @@ export default function RequestLogDetails() {
   const { data: requestLog, isFetching, isError } = useGetRequestLog(id)
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
   const isMobile = useMobile()
 
   useEffect(() => {
@@ -76,7 +78,7 @@ export default function RequestLogDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Request Logs
                 </BreadcrumbLink>

--- a/src/pages/app/settings/index.ts
+++ b/src/pages/app/settings/index.ts
@@ -1,5 +1,4 @@
 export { default as General } from "./general"
-export { default as Team } from "./team"
 export { default as Security } from "./security"
 export { default as Permissions } from "./permissions"
 export { default as Developers } from "./developers"

--- a/src/pages/app/team/details.tsx
+++ b/src/pages/app/team/details.tsx
@@ -17,7 +17,6 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu"
 import {
   Breadcrumb,
@@ -29,7 +28,6 @@ import {
 } from "@/components/ui/breadcrumb"
 
 import {
-  Ban,
   Copy,
   Logs,
   Menu,
@@ -37,7 +35,6 @@ import {
   SquarePen,
   SquarePlus,
   CircleCheck,
-  ChevronDown,
   CirclePause,
   EllipsisVertical,
 } from "lucide-react"
@@ -51,13 +48,7 @@ import {
   UserRoleLabels,
 } from "@/types/users"
 
-import {
-  useGetUser,
-  useRemoveUser,
-  useBanUser,
-  useUnbanUser,
-  useForgotPassword,
-} from "@/queries/users"
+import { useGetUser, useRemoveUser, useForgotPassword } from "@/queries/users"
 
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
@@ -82,10 +73,9 @@ import CollapsibleMenu from "@/components/collapsible-menu"
 import CollapsibleCard from "@/components/collapsible-card"
 import ConfirmationModal from "@/components/confirmation-modal"
 
-const UserStatusIcons: Record<UserStatus, React.ReactNode> = {
+const UserStatusIcons: Partial<Record<UserStatus, React.ReactNode>> = {
   [UserStatus.Active]: <CircleCheck className="size-3" />,
   [UserStatus.Inactive]: <CirclePause className="size-3" />,
-  [UserStatus.Banned]: <Ban className="size-3" />,
 }
 
 export default function TeamDetails() {
@@ -98,8 +88,6 @@ export default function TeamDetails() {
   } = useGetUser(id)
 
   const deleteUser = useRemoveUser(id)
-  const banUser = useBanUser(id)
-  const unbanUser = useUnbanUser(id)
   const resetPassword = useForgotPassword()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
@@ -111,8 +99,6 @@ export default function TeamDetails() {
     delete: false,
     attributes: false,
     resetPassword: false,
-    ban: false,
-    unban: false,
   })
 
   useEffect(() => {
@@ -138,26 +124,6 @@ export default function TeamDetails() {
         await back()
       },
     })
-  }
-
-  const handleBanUser = async () => {
-    try {
-      await banUser.mutateAsync()
-      toast({ message: "User banned", variant: "success" })
-      toggleOpen("ban", false)
-    } catch {
-      toast({ message: "Failed to ban user", variant: "error" })
-    }
-  }
-
-  const handleUnbanUser = async () => {
-    try {
-      await unbanUser.mutateAsync()
-      toast({ message: "User unbanned", variant: "success" })
-      toggleOpen("unban", false)
-    } catch {
-      toast({ message: "Failed to unban user", variant: "error" })
-    }
   }
 
   const handleResetPassword = async () => {
@@ -202,7 +168,6 @@ export default function TeamDetails() {
           {isMobile ? (
             <Can.Any
               permissions={[
-                "user.ban",
                 "user.password.reset",
                 "user.update",
                 "user.delete",
@@ -219,33 +184,6 @@ export default function TeamDetails() {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent className="mr-4 p-0">
-                  {user?.attributes.status === UserStatus.Banned ? (
-                    <Can permission="user.unban">
-                      <DropdownMenuItem
-                        onClick={(e) => {
-                          toggleOpen("unban", true)
-                          e.currentTarget.blur()
-                        }}
-                        className="pb-2 text-base"
-                      >
-                        Unban
-                      </DropdownMenuItem>
-                      <Separator />
-                    </Can>
-                  ) : (
-                    <Can permission="user.ban">
-                      <DropdownMenuItem
-                        onClick={(e) => {
-                          toggleOpen("ban", true)
-                          e.currentTarget.blur()
-                        }}
-                        className="pb-2 text-base"
-                      >
-                        Ban
-                      </DropdownMenuItem>
-                      <Separator />
-                    </Can>
-                  )}
                   <Can permission="user.password.reset">
                     <DropdownMenuItem
                       onClick={(e) => {
@@ -286,52 +224,17 @@ export default function TeamDetails() {
             </Can.Any>
           ) : (
             <div className="flex items-center space-x-2">
-              <Can.Any permissions={["user.ban", "user.password.reset"]}>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="outline" disabled={userLoading}>
-                      Actions
-                      <ChevronDown className="size-4 transition-transform duration-200 [[data-state=open]_&]:rotate-180" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    {user?.attributes.status === UserStatus.Banned ? (
-                      <Can permission="user.unban">
-                        <DropdownMenuItem
-                          onClick={(e) => {
-                            toggleOpen("unban", true)
-                            e.currentTarget.blur()
-                          }}
-                        >
-                          Unban
-                        </DropdownMenuItem>
-                      </Can>
-                    ) : (
-                      <Can permission="user.ban">
-                        <DropdownMenuItem
-                          onClick={(e) => {
-                            toggleOpen("ban", true)
-                            e.currentTarget.blur()
-                          }}
-                        >
-                          Ban
-                        </DropdownMenuItem>
-                        <DropdownMenuSeparator />
-                      </Can>
-                    )}
-                    <Can permission="user.password.reset">
-                      <DropdownMenuItem
-                        onClick={(e) => {
-                          toggleOpen("resetPassword", true)
-                          e.currentTarget.blur()
-                        }}
-                      >
-                        Reset password
-                      </DropdownMenuItem>
-                    </Can>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </Can.Any>
+              <Can permission="user.password.reset">
+                <Button
+                  variant="outline"
+                  disabled={userLoading}
+                  onClick={() => {
+                    toggleOpen("resetPassword", true)
+                  }}
+                >
+                  Reset password
+                </Button>
+              </Can>
               <Can permission="user.update">
                 <Button
                   variant="outline"
@@ -649,25 +552,6 @@ export default function TeamDetails() {
         disabled={userLoading || resetPassword.isPending}
         onClose={() => toggleOpen("resetPassword", false)}
         onConfirm={handleResetPassword}
-      />
-
-      <ConfirmationModal
-        title={`Ban ${user?.attributes.fullName || user?.attributes.email}?`}
-        description="Are you sure you want to ban this user? They will no longer be able to authenticate with the API."
-        open={open.ban}
-        disabled={banUser.isPending}
-        onClose={() => toggleOpen("ban", false)}
-        onConfirm={handleBanUser}
-        variant="destructive"
-      />
-
-      <ConfirmationModal
-        title={`Unban ${user?.attributes.fullName || user?.attributes.email}?`}
-        description="Are you sure you want to unban this user? They will be able to authenticate with the API again."
-        open={open.unban}
-        disabled={unbanUser.isPending}
-        onClose={() => toggleOpen("unban", false)}
-        onConfirm={handleUnbanUser}
       />
     </section>
   )

--- a/src/pages/app/team/details.tsx
+++ b/src/pages/app/team/details.tsx
@@ -92,8 +92,8 @@ const UserStatusIcons: Record<UserStatus, React.ReactNode> = {
   [UserStatus.Banned]: <Ban className="size-3" />,
 }
 
-export default function UserDetails() {
-  const { id } = useParams({ from: "/$accountId/app/users/$id" })
+export default function TeamDetails() {
+  const { id } = useParams({ from: "/$accountId/app/team/$id" })
   const {
     data: user,
     isLoading: userLoading,
@@ -193,7 +193,7 @@ export default function UserDetails() {
                   className="cursor-pointer"
                   onClick={() => breadcrumbBack()}
                 >
-                  Users
+                  Team
                 </BreadcrumbLink>
               </BreadcrumbItem>
               <BreadcrumbSeparator />

--- a/src/pages/app/team/details.tsx
+++ b/src/pages/app/team/details.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react"
 import { useParams } from "@tanstack/react-router"
 
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Separator } from "@/components/ui/separator"
@@ -54,7 +53,6 @@ import {
 
 import {
   useGetUser,
-  useListUserProducts,
   useRemoveUser,
   useBanUser,
   useUnbanUser,
@@ -69,7 +67,6 @@ import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
 
-import * as keygen from "@/keygen"
 import * as Users from "@/components/users"
 import * as Property from "@/components/property"
 import * as Attribute from "@/components/attribute"
@@ -79,7 +76,6 @@ import Metadata from "@/components/metadata"
 import PageHeader from "@/components/page-header"
 import TabsSwitch from "@/components/tabs-switch"
 import BackButton from "@/components/back-button"
-import GoToButton from "@/components/go-to-button"
 import TooltipBadge from "@/components/tooltip-badge"
 import ResourceLink from "@/components/resource-link"
 import CollapsibleMenu from "@/components/collapsible-menu"
@@ -101,12 +97,6 @@ export default function TeamDetails() {
     isError: userError,
   } = useGetUser(id)
 
-  const {
-    data: userProducts = [],
-    isLoading: userProductsLoading,
-    isFetching: userProductsFetching,
-    isError: userProductsError,
-  } = useListUserProducts(id)
   const deleteUser = useRemoveUser(id)
   const banUser = useBanUser(id)
   const unbanUser = useUnbanUser(id)
@@ -453,42 +443,6 @@ export default function TeamDetails() {
                   </div>
                 </CollapsibleCard>
 
-                <CollapsibleCard
-                  title="Products"
-                  subtitle={
-                    <Badge className="ml-2 min-h-5 min-w-5 text-sm text-content-muted">
-                      {userProducts.length}
-                    </Badge>
-                  }
-                >
-                  {userProductsError ? (
-                    <Badge variant="destructive">ERROR</Badge>
-                  ) : userProductsLoading || userProductsFetching ? (
-                    <div className="flex w-full justify-between">
-                      <Skeleton className="h-5 w-48 rounded-sm" />
-                      <Skeleton className="h-5 w-24 rounded-sm" />
-                    </div>
-                  ) : userProducts.length > 0 ? (
-                    <div className="grid gap-2">
-                      {userProducts.map((product) => (
-                        <GoToButton
-                          key={product.id}
-                          path="/$accountId/app/products/$id"
-                          params={{
-                            accountId: keygen.config.id,
-                            id: product.id,
-                          }}
-                          label={product.attributes.name}
-                        />
-                      ))}
-                    </div>
-                  ) : (
-                    <span className="px-2 text-sm text-content-subdued">
-                      None
-                    </span>
-                  )}
-                </CollapsibleCard>
-
                 <CollapsibleCard title="Relationships">
                   <div className="grid gap-4">
                     <Attribute.Field
@@ -507,30 +461,6 @@ export default function TeamDetails() {
                       value={
                         <ResourceLink
                           linkage={user.relationships.group?.data}
-                        />
-                      }
-                    />
-                    <Attribute.Field
-                      variant="text"
-                      label="Licenses"
-                      value={
-                        <GoToButton
-                          path="/$accountId/app/licenses"
-                          params={{ accountId: keygen.config.id }}
-                          search={{ user: id }}
-                          label="View all"
-                        />
-                      }
-                    />
-                    <Attribute.Field
-                      variant="text"
-                      label="Machines"
-                      value={
-                        <GoToButton
-                          path="/$accountId/app/machines"
-                          params={{ accountId: keygen.config.id }}
-                          search={{ user: id }}
-                          label="View all"
                         />
                       }
                     />

--- a/src/pages/app/team/index.ts
+++ b/src/pages/app/team/index.ts
@@ -1,0 +1,2 @@
+export { default as List } from "./list"
+export { default as Details } from "./details"

--- a/src/pages/app/team/list.tsx
+++ b/src/pages/app/team/list.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo } from "react"
+import { useLocation, useNavigate } from "@tanstack/react-router"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -14,10 +15,10 @@ import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { usePermissions } from "@/hooks/use-permissions"
 import { useTeamTableColumns } from "@/hooks/use-team-table-columns"
-import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import { User, UserRole, InternalRoles, type UserFilters } from "@/types/users"
 
+import * as keygen from "@/keygen"
 import * as Users from "@/components/users"
 import Can from "@/components/can"
 import DataTable from "@/components/data-table"
@@ -77,7 +78,8 @@ export default function TeamPage() {
   const maxAdmins = plan?.attributes?.maxAdmins
   const planName = plan?.attributes?.name
 
-  const navigateToResource = useResourceNavigate()
+  const navigate = useNavigate()
+  const location = useLocation()
 
   const [open, setOpen] = useState({ inviteTeammate: false })
 
@@ -135,7 +137,16 @@ export default function TeamPage() {
           table={table}
           columns={columns}
           isLoading={usersLoading}
-          onRowClick={(user) => navigateToResource(user)}
+          onRowClick={(user) =>
+            navigate({
+              to: "/$accountId/app/team/$id",
+              params: { accountId: keygen.config.id, id: user.id },
+              state: (prev) => ({
+                ...prev,
+                from: { pathname: location.pathname },
+              }),
+            })
+          }
         />
       </ScrollArea>
 

--- a/src/pages/app/teams.tsx
+++ b/src/pages/app/teams.tsx
@@ -1,0 +1,26 @@
+import { Outlet, useParams } from "@tanstack/react-router"
+
+import { UserView } from "@/types/users"
+
+import * as Motion from "@/components/motion"
+import * as Page from "@/pages"
+
+export default function Teams() {
+  const { id } = useParams({ strict: false })
+
+  const view = id ? UserView.Details : UserView.List
+
+  const direction: 1 | -1 = view === UserView.Details ? 1 : -1
+
+  const key = view === UserView.List ? "list" : `details-${id}`
+
+  return (
+    <Motion.Slide direction={direction}>
+      {view === UserView.List ? (
+        <Page.App.Team.List key={key} />
+      ) : (
+        <Outlet key={key} />
+      )}
+    </Motion.Slide>
+  )
+}

--- a/src/pages/app/token/details.tsx
+++ b/src/pages/app/token/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -67,6 +67,7 @@ export default function TokenDetails() {
   const revokeToken = useRevokeToken()
   const regenerateToken = useRegenerateToken()
 
+  const navigate = useNavigate()
   const back = useBackNavigate()
   const isMobile = useMobile()
   const [tab, setTab] = useSidebarTab()
@@ -148,7 +149,7 @@ export default function TokenDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Tokens
                 </BreadcrumbLink>

--- a/src/pages/app/token/details.tsx
+++ b/src/pages/app/token/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -68,7 +68,6 @@ export default function TokenDetails() {
   const revokeToken = useRevokeToken()
   const regenerateToken = useRegenerateToken()
 
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
   const isMobile = useMobile()
@@ -151,7 +150,7 @@ export default function TokenDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Tokens
                 </BreadcrumbLink>

--- a/src/pages/app/token/details.tsx
+++ b/src/pages/app/token/details.tsx
@@ -29,6 +29,7 @@ import { Notice } from "@/components/notice"
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 import {
   useGetToken,
   useRevokeToken,
@@ -69,6 +70,7 @@ export default function TokenDetails() {
 
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
   const isMobile = useMobile()
   const [tab, setTab] = useSidebarTab()
 
@@ -149,7 +151,7 @@ export default function TokenDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Tokens
                 </BreadcrumbLink>

--- a/src/pages/app/user/details.tsx
+++ b/src/pages/app/user/details.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -50,6 +50,7 @@ import {
   UserStatusVariants,
   UserStatusDescriptions,
   UserRoleLabels,
+  InternalRoles,
 } from "@/types/users"
 
 import {
@@ -110,7 +111,11 @@ export default function UserDetails() {
   const banUser = useBanUser(id)
   const unbanUser = useUnbanUser(id)
   const resetPassword = useForgotPassword()
+  const navigate = useNavigate()
   const back = useBackNavigate()
+
+  const isTeammate =
+    user != null && InternalRoles.includes(user.attributes.role)
 
   const isMobile = useMobile()
   const [tab, setTab] = useSidebarTab()
@@ -189,9 +194,16 @@ export default function UserDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() =>
+                    isTeammate
+                      ? navigate({
+                          to: "/$accountId/app/team",
+                          params: { accountId: keygen.config.id },
+                        })
+                      : navigate({ to: ".." })
+                  }
                 >
-                  Users
+                  {isTeammate ? "Team" : "Users"}
                 </BreadcrumbLink>
               </BreadcrumbItem>
               <BreadcrumbSeparator />

--- a/src/pages/app/user/details.tsx
+++ b/src/pages/app/user/details.tsx
@@ -65,6 +65,7 @@ import {
 import { useMobile } from "@/hooks/use-mobile"
 import { useSidebarTab } from "@/hooks/use-sidebar-tab"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 
 import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
@@ -113,6 +114,7 @@ export default function UserDetails() {
   const resetPassword = useForgotPassword()
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
 
   const isTeammate =
     user != null && InternalRoles.includes(user.attributes.role)
@@ -195,12 +197,16 @@ export default function UserDetails() {
                 <BreadcrumbLink
                   className="cursor-pointer"
                   onClick={() =>
-                    isTeammate
-                      ? navigate({
-                          to: "/$accountId/app/team",
-                          params: { accountId: keygen.config.id },
-                        })
-                      : navigate({ to: ".." })
+                    breadcrumbBack(
+                      () =>
+                        isTeammate
+                          ? navigate({
+                              to: "/$accountId/app/team",
+                              params: { accountId: keygen.config.id },
+                            })
+                          : navigate({ to: ".." }),
+                      isTeammate ? `/${keygen.config.id}/app/team` : undefined,
+                    )
                   }
                 >
                   {isTeammate ? "Team" : "Users"}

--- a/src/pages/app/user/details.tsx
+++ b/src/pages/app/user/details.tsx
@@ -197,16 +197,16 @@ export default function UserDetails() {
                 <BreadcrumbLink
                   className="cursor-pointer"
                   onClick={() =>
-                    breadcrumbBack(
-                      () =>
-                        isTeammate
-                          ? navigate({
+                    isTeammate
+                      ? breadcrumbBack(
+                          () =>
+                            navigate({
                               to: "/$accountId/app/team",
                               params: { accountId: keygen.config.id },
-                            })
-                          : navigate({ to: ".." }),
-                      isTeammate ? `/${keygen.config.id}/app/team` : undefined,
-                    )
+                            }),
+                          `/${keygen.config.id}/app/team`,
+                        )
+                      : breadcrumbBack()
                   }
                 >
                   {isTeammate ? "Team" : "Users"}

--- a/src/pages/app/webhook-endpoint/details.tsx
+++ b/src/pages/app/webhook-endpoint/details.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -87,6 +87,7 @@ export default function WebhookEndpointDetails() {
 
   const environment = webhookEndpoint?.relationships.environment?.data
 
+  const navigate = useNavigate()
   const back = useBackNavigate()
   const isMobile = useMobile()
   const truncateUrl = truncator("middle", { maxLength: isMobile ? 16 : 32 })
@@ -129,7 +130,7 @@ export default function WebhookEndpointDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Webhook Endpoints
                 </BreadcrumbLink>

--- a/src/pages/app/webhook-endpoint/details.tsx
+++ b/src/pages/app/webhook-endpoint/details.tsx
@@ -45,6 +45,7 @@ import {
 
 import { useMobile } from "@/hooks/use-mobile"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 
 import { toast } from "@/lib/toast"
 import { truncator } from "@/lib/truncate"
@@ -89,6 +90,7 @@ export default function WebhookEndpointDetails() {
 
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
   const isMobile = useMobile()
   const truncateUrl = truncator("middle", { maxLength: isMobile ? 16 : 32 })
   const [open, setOpen] = useState({
@@ -130,7 +132,7 @@ export default function WebhookEndpointDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Webhook Endpoints
                 </BreadcrumbLink>

--- a/src/pages/app/webhook-endpoint/details.tsx
+++ b/src/pages/app/webhook-endpoint/details.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -88,7 +88,6 @@ export default function WebhookEndpointDetails() {
 
   const environment = webhookEndpoint?.relationships.environment?.data
 
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
   const isMobile = useMobile()
@@ -132,7 +131,7 @@ export default function WebhookEndpointDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Webhook Endpoints
                 </BreadcrumbLink>

--- a/src/pages/app/webhook-event/details.tsx
+++ b/src/pages/app/webhook-event/details.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
@@ -88,7 +88,6 @@ export default function WebhookEventDetails() {
 
   const environment = webhookEvent?.relationships.environment?.data
 
-  const navigate = useNavigate()
   const back = useBackNavigate()
   const breadcrumbBack = useBreadcrumbBackNavigate()
   const navigateToResource = useResourceNavigate()
@@ -140,7 +139,7 @@ export default function WebhookEventDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
+                  onClick={() => breadcrumbBack()}
                 >
                   Webhook Events
                 </BreadcrumbLink>

--- a/src/pages/app/webhook-event/details.tsx
+++ b/src/pages/app/webhook-event/details.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { useParams } from "@tanstack/react-router"
+import { useNavigate, useParams } from "@tanstack/react-router"
 
 import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
@@ -87,6 +87,7 @@ export default function WebhookEventDetails() {
 
   const environment = webhookEvent?.relationships.environment?.data
 
+  const navigate = useNavigate()
   const back = useBackNavigate()
   const navigateToResource = useResourceNavigate()
   const isMobile = useMobile()
@@ -137,7 +138,7 @@ export default function WebhookEventDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => back()}
+                  onClick={() => navigate({ to: ".." })}
                 >
                   Webhook Events
                 </BreadcrumbLink>

--- a/src/pages/app/webhook-event/details.tsx
+++ b/src/pages/app/webhook-event/details.tsx
@@ -44,6 +44,7 @@ import {
 
 import { useMobile } from "@/hooks/use-mobile"
 import { useBackNavigate } from "@/hooks/use-back-navigate"
+import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 
 import { toast } from "@/lib/toast"
@@ -89,6 +90,7 @@ export default function WebhookEventDetails() {
 
   const navigate = useNavigate()
   const back = useBackNavigate()
+  const breadcrumbBack = useBreadcrumbBackNavigate()
   const navigateToResource = useResourceNavigate()
   const isMobile = useMobile()
   const [open, setOpen] = useState({ delete: false, attributes: false })
@@ -138,7 +140,7 @@ export default function WebhookEventDetails() {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   className="cursor-pointer"
-                  onClick={() => navigate({ to: ".." })}
+                  onClick={() => breadcrumbBack(() => navigate({ to: ".." }))}
                 >
                   Webhook Events
                 </BreadcrumbLink>

--- a/src/routes/$accountId/app.team.$id.tsx
+++ b/src/routes/$accountId/app.team.$id.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router"
+import * as Page from "@/pages/index"
+
+export const Route = createFileRoute("/$accountId/app/team/$id")({
+  component: () => <Page.App.Team.Details />,
+})

--- a/src/routes/$accountId/app.team.tsx
+++ b/src/routes/$accountId/app.team.tsx
@@ -19,7 +19,7 @@ function validateSearch(search: Record<string, unknown>): UserFilters {
 }
 
 export const Route = createFileRoute("/$accountId/app/team")({
-  component: () => <Page.App.Settings.Team />,
+  component: () => <Page.App.Teams />,
   validateSearch,
   beforeLoad: ({ context }) =>
     requireAllPermissions(context.queryClient, ["admin.read", "user.read"]),


### PR DESCRIPTION
Closes #217. Breadcrumbs used `useBackNavigate()` which used windows history, so it indiscriminately went to the last known path and would break under certain navigations, e.g. `/request-logs/$id` > requestor user page > breadcrumb would nav back to `/request-logs/$id` rather than the users list.

This fixes that with `useBreadcrumbBackNavigate()`, which conditionally handles navigating from list > details and preserves state (i.e. any applied filters) when navigating back to list, and navigating from e.g. relationship links and using the associated resource details page breadcrumbs to navigate to the list view works correctly.

Also addresses a Users/Teams coupling issue that was making navigations difficult to work with under certain conditions, since they were sharing the same details page component. It's now separated into `teams/` and `users/` with their own list and details pages.