### PR TITLE
Fix license usage counts

### DIFF
--- a/src/lib/licenses.ts
+++ b/src/lib/licenses.ts
@@ -2,6 +2,7 @@ import { Policy } from "@/types/policies"
 import { License, LicenseAttributeDescriptions } from "@/types/licenses"
 
 import { formatByteLimitDisplay, formatRawByteLimitDisplay } from "@/lib/bytes"
+import { capitalize } from "@/lib/utils"
 
 import { AttributeType } from "@/components/attribute/value"
 
@@ -109,6 +110,18 @@ export function getMachineMetricCount(
   return typeof value === "number" ? value : 0
 }
 
+export function getMachineCount(license: License): number {
+  const value = license.relationships.machines?.meta?.count
+
+  return typeof value === "number" ? value : 0
+}
+
+export function getUserCount(license: License): number {
+  const value = license.relationships.users?.meta?.count
+
+  return typeof value === "number" ? value : 0
+}
+
 function getByteLimitDisplay(
   license: License,
   policy: Policy | null | undefined,
@@ -183,11 +196,9 @@ export function getUsersLimitDisplay(
 export function getProcessesLimitDisplay(
   license: License,
   policy: Policy | null | undefined,
-  processCount: number = 0,
 ): string {
-  return formatLimitDisplay(
-    processCount,
-    getAttributeLimit(license, policy, "maxProcesses"),
+  return capitalize(
+    formatLimitValue(getAttributeLimit(license, policy, "maxProcesses")),
   )
 }
 

--- a/src/pages/app/license/details.tsx
+++ b/src/pages/app/license/details.tsx
@@ -90,6 +90,8 @@ import {
   getProcessesLimitDisplay,
   getCoresLimitDisplay,
   getMachineMetricCount,
+  getMachineCount,
+  getUserCount,
   getByteUsageLimit,
   getUsesLimitDisplay,
   isLimitOverridden,
@@ -893,8 +895,7 @@ export default function LicenseDetails() {
                                   value={getMachinesLimitDisplay(
                                     license,
                                     policy,
-                                    license.relationships.machines?.data
-                                      ?.length ?? 0,
+                                    getMachineCount(license),
                                   )}
                                   variant={
                                     license.attributes.maxMachines ||
@@ -922,7 +923,6 @@ export default function LicenseDetails() {
                                   value={getProcessesLimitDisplay(
                                     license,
                                     policy,
-                                    0,
                                   )}
                                   variant={
                                     license.attributes.maxProcesses ||
@@ -950,8 +950,7 @@ export default function LicenseDetails() {
                                   value={getUsersLimitDisplay(
                                     license,
                                     policy,
-                                    license.relationships.users?.data?.length ??
-                                      0,
+                                    getUserCount(license),
                                   )}
                                   variant={
                                     license.attributes.maxUsers ||
@@ -1123,7 +1122,7 @@ export default function LicenseDetails() {
                         value={getMachinesLimitDisplay(
                           license,
                           policy,
-                          license.relationships.machines?.data?.length ?? 0,
+                          getMachineCount(license),
                         )}
                         tooltip={LicenseAttributeDescriptions.maxMachines}
                         suffix={
@@ -1134,26 +1133,13 @@ export default function LicenseDetails() {
                         }
                       />
                       <Property.Field
-                        icon={Repeat}
-                        label="processes"
-                        variant="reverse"
-                        value={getProcessesLimitDisplay(license, policy, 0)}
-                        tooltip={LicenseAttributeDescriptions.maxProcesses}
-                        suffix={
-                          isLimitOverridden(
-                            license.attributes.maxProcesses,
-                            policy?.attributes.maxProcesses,
-                          ) && <OverriddenBadge />
-                        }
-                      />
-                      <Property.Field
                         icon={Users}
                         label="users"
                         variant="reverse"
                         value={getUsersLimitDisplay(
                           license,
                           policy,
-                          licenseUsers.length,
+                          getUserCount(license),
                         )}
                         tooltip={LicenseAttributeDescriptions.maxUsers}
                         suffix={
@@ -1173,6 +1159,19 @@ export default function LicenseDetails() {
                           isLimitOverridden(
                             license.attributes.maxUses,
                             policy?.attributes.maxUses,
+                          ) && <OverriddenBadge />
+                        }
+                      />
+                      <Property.Field
+                        icon={Repeat}
+                        label="processes"
+                        variant="reverse"
+                        value={getProcessesLimitDisplay(license, policy)}
+                        tooltip={LicenseAttributeDescriptions.maxProcesses}
+                        suffix={
+                          isLimitOverridden(
+                            license.attributes.maxProcesses,
+                            policy?.attributes.maxProcesses,
                           ) && <OverriddenBadge />
                         }
                       />


### PR DESCRIPTION
Closes #303. License machine and user counts are now backed by `meta.count` so they're displaying correct data. Also fixes license processes to just display the limit, as current count was never available.