### PR TITLE
Add license permission fields

### DIFF
--- a/src/components/collapsible-card.tsx
+++ b/src/components/collapsible-card.tsx
@@ -1,4 +1,4 @@
-import { useState, Fragment, Children } from "react"
+import { useState, Fragment, Children, isValidElement } from "react"
 import { motion, AnimatePresence } from "motion/react"
 
 import { cn } from "@/lib/utils"
@@ -8,9 +8,9 @@ import {
   CollapsibleTrigger,
   CollapsibleContent,
 } from "@/components/ui/collapsible"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Separator } from "@/components/ui/separator"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
 import { ChevronDown, ChevronUp } from "lucide-react"
 
@@ -33,6 +33,13 @@ export default function CollapsibleCard({
 }: CollapsibleCardProps) {
   const [open, setOpen] = useState(defaultOpen)
   const [transitioned, setTransitioned] = useState(!defaultOpen)
+
+  const items: React.ReactNode[] = []
+  Children.forEach(children, (child) => {
+    if (isValidElement(child)) {
+      items.push(child)
+    }
+  })
 
   return (
     <Card
@@ -89,10 +96,10 @@ export default function CollapsibleCard({
                 >
                   <ScrollArea orientation="horizontal">
                     <CardContent className={cn("p-4", contentClass)}>
-                      {Children.map(children, (child, index) => (
+                      {items.map((child, index) => (
                         <Fragment key={index}>
                           {child}
-                          {index < Children.count(children) - 1 && (
+                          {index < items.length - 1 && (
                             <Separator className="my-4" />
                           )}
                         </Fragment>

--- a/src/components/forms/section/card.tsx
+++ b/src/components/forms/section/card.tsx
@@ -1,4 +1,4 @@
-import { Children } from "react"
+import { Children, Fragment, isValidElement } from "react"
 import { cn } from "@/lib/utils"
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -15,19 +15,24 @@ export default function FormsSectionCard({
   children,
   className,
 }: FormsSectionCardProps): React.ReactElement {
+  const items: React.ReactNode[] = []
+  Children.forEach(children, (child) => {
+    if (isValidElement(child)) {
+      items.push(child)
+    }
+  })
+
   return (
     <Card className={cn("m-4 rounded-sm bg-background pt-0", className)}>
       <CardHeader className="h-9 rounded-t-sm border-b border-accent bg-background-1 px-4 py-1">
         <CardTitle className="text-content-loud">{title}</CardTitle>
       </CardHeader>
       <CardContent className="p-4">
-        {Children.map(children, (child, index) => (
-          <>
+        {items.map((child, index) => (
+          <Fragment key={index}>
             {child}
-            {index < Children.count(children) - 1 && (
-              <Separator className="my-6" />
-            )}
-          </>
+            {index < items.length - 1 && <Separator className="my-6" />}
+          </Fragment>
         ))}
       </CardContent>
     </Card>

--- a/src/components/licenses/form/create.tsx
+++ b/src/components/licenses/form/create.tsx
@@ -51,6 +51,7 @@ export default function CreateLicenseForm({
       maxDisk: null,
       maxUses: null,
       ownerId: null,
+      permissions: null,
       metadata: [],
       entitlements: { attach: [], create: [] },
       users: { attach: [] },
@@ -264,7 +265,7 @@ export default function CreateLicenseForm({
 
           <Forms.Section.Step
             crumb="Additional configuration"
-            fields={["protected", "suspended", "metadata"]}
+            fields={["protected", "suspended", "permissions", "metadata"]}
           >
             <Forms.Section.Card title="Additional configuration">
               <Forms.Section.Columns>
@@ -283,6 +284,11 @@ export default function CreateLicenseForm({
                   />
                 </Forms.Section.Column>
               </Forms.Section.Columns>
+              <Licenses.Form.Fields
+                schema="create"
+                include={["permissions"]}
+                fieldVariant="stacking"
+              />
               <Licenses.Form.Fields
                 schema="create"
                 include={["metadata"]}

--- a/src/components/licenses/form/create.tsx
+++ b/src/components/licenses/form/create.tsx
@@ -16,6 +16,7 @@ import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 import { toast } from "@/lib/toast"
 import { settleCreateEntitlements } from "@/lib/entitlements"
 
+import * as keygen from "@/keygen"
 import * as Forms from "@/components/forms"
 import * as Licenses from "@/components/licenses"
 import DocumentationLink from "@/components/documentation-link"
@@ -263,9 +264,26 @@ export default function CreateLicenseForm({
             <DocumentationLink page="licenses" />
           </Forms.Section.Step>
 
+          {!keygen.config.isCE && (
+            <Forms.Section.Step
+              crumb="License permissions"
+              fields={["permissions"]}
+            >
+              <Forms.Section.Card title="License permissions">
+                <Licenses.Form.Fields
+                  schema="create"
+                  include={["permissions"]}
+                  fieldVariant="stacking"
+                />
+              </Forms.Section.Card>
+
+              <DocumentationLink page="licenses" />
+            </Forms.Section.Step>
+          )}
+
           <Forms.Section.Step
             crumb="Additional configuration"
-            fields={["protected", "suspended", "permissions", "metadata"]}
+            fields={["protected", "suspended", "metadata"]}
           >
             <Forms.Section.Card title="Additional configuration">
               <Forms.Section.Columns>
@@ -284,11 +302,7 @@ export default function CreateLicenseForm({
                   />
                 </Forms.Section.Column>
               </Forms.Section.Columns>
-              <Licenses.Form.Fields
-                schema="create"
-                include={["permissions"]}
-                fieldVariant="stacking"
-              />
+
               <Licenses.Form.Fields
                 schema="create"
                 include={["metadata"]}

--- a/src/components/licenses/form/edit.tsx
+++ b/src/components/licenses/form/edit.tsx
@@ -25,6 +25,7 @@ import { useCreateEntitlement } from "@/queries/entitlements"
 import { toast } from "@/lib/toast"
 import { settleCreateEntitlements } from "@/lib/entitlements"
 
+import * as keygen from "@/keygen"
 import * as Forms from "@/components/forms"
 import * as Licenses from "@/components/licenses"
 
@@ -233,13 +234,15 @@ export default function EditLicenseForm({
           <Separator className="my-8" />
 
           <Forms.Section.Columns>
-            <Forms.Section.Column>
-              <Licenses.Form.Fields
-                schema="edit"
-                include={["permissions"]}
-                fieldVariant="stacking"
-              />
-            </Forms.Section.Column>
+            {!keygen.config.isCE && (
+              <Forms.Section.Column>
+                <Licenses.Form.Fields
+                  schema="edit"
+                  include={["permissions"]}
+                  fieldVariant="stacking"
+                />
+              </Forms.Section.Column>
+            )}
             <Forms.Section.Column>
               <Licenses.Form.Fields
                 schema="edit"

--- a/src/components/licenses/form/edit.tsx
+++ b/src/components/licenses/form/edit.tsx
@@ -83,6 +83,7 @@ export default function EditLicenseForm({
           maxDisk: license.attributes.maxDisk ?? null,
           maxUses: license.attributes.maxUses ?? null,
           ownerId: currentOwnerId,
+          permissions: license.attributes.permissions ?? null,
           metadata: recordToMetadataPairs(license.attributes.metadata),
           entitlements: {
             attach: licenseEntitlements.map((e) => e.id),
@@ -231,11 +232,22 @@ export default function EditLicenseForm({
 
           <Separator className="my-8" />
 
-          <Licenses.Form.Fields
-            schema="edit"
-            include={["metadata"]}
-            fieldVariant="stacking"
-          />
+          <Forms.Section.Columns>
+            <Forms.Section.Column>
+              <Licenses.Form.Fields
+                schema="edit"
+                include={["permissions"]}
+                fieldVariant="stacking"
+              />
+            </Forms.Section.Column>
+            <Forms.Section.Column>
+              <Licenses.Form.Fields
+                schema="edit"
+                include={["metadata"]}
+                fieldVariant="stacking"
+              />
+            </Forms.Section.Column>
+          </Forms.Section.Columns>
 
           <Separator className="my-8" />
 

--- a/src/components/licenses/form/fields.tsx
+++ b/src/components/licenses/form/fields.tsx
@@ -34,6 +34,7 @@ import {
   LicenseCreateFormFieldDescriptions,
   LicenseEditFormFieldDescriptions,
   LicenseDisabledFormFieldDescriptions,
+  LicensePermissions,
 } from "@/types/licenses"
 import { Policy } from "@/types/policies"
 import { type FieldVariant } from "@/components/forms/field"
@@ -41,6 +42,7 @@ import { type FieldVariant } from "@/components/forms/field"
 import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
 import * as Calendars from "@/components/calendars"
+import MultiSelect from "@/components/multi-select"
 import MetadataInput from "@/components/metadata-input"
 import ByteSizeInput from "@/components/byte-size-input"
 
@@ -71,6 +73,7 @@ const INCLUDE_DEFAULT_FIELDS: Schemas.Licenses.FieldNames[] = [
   "ownerId",
   "suspended",
   "protected",
+  "permissions",
   "metadata",
   "entitlements.attach",
   "entitlements.create",
@@ -243,6 +246,16 @@ export default function LicensesFormFields({
               <AttachUsersField
                 key="users.attach"
                 autoFocus={autoFocus === "users.attach"}
+                fieldVariant={fieldVariant}
+                descriptions={descriptions}
+              />
+            )
+          case "permissions":
+            return (
+              <PermissionsField
+                key="permissions"
+                schema={schema}
+                autoFocus={autoFocus === "permissions"}
                 fieldVariant={fieldVariant}
                 descriptions={descriptions}
               />
@@ -945,6 +958,55 @@ function ProtectedField({
               />
             </FormControl>
           </Forms.Field.Header>
+        </FormItem>
+      )}
+    />
+  )
+}
+
+function PermissionsField({
+  schema,
+  autoFocus,
+  fieldVariant = "row",
+  descriptions,
+}: {
+  schema?: "create" | "edit"
+  autoFocus?: boolean
+  fieldVariant?: FieldVariant
+  descriptions: Descriptions
+}) {
+  const form = useFormContext<Schemas.Licenses.BaseValues>()
+
+  return (
+    <FormField
+      control={form.control}
+      name="permissions"
+      render={({ field }) => (
+        <FormItem>
+          <Forms.Field.Header
+            label="Permissions"
+            variant={fieldVariant}
+            optional
+            tooltip={descriptions.permissions}
+          >
+            <MultiSelect
+              value={field.value}
+              onChange={field.onChange}
+              options={LicensePermissions.map((p) => ({
+                label: p,
+                value: p,
+              }))}
+              includeNone
+              includeWildcard
+              placeholder={
+                schema === "create"
+                  ? "Leave blank to use defaults"
+                  : "Select permissions..."
+              }
+              autoFocus={autoFocus}
+            />
+          </Forms.Field.Header>
+          <FormMessage />
         </FormItem>
       )}
     />

--- a/src/components/products/form/create.tsx
+++ b/src/components/products/form/create.tsx
@@ -4,6 +4,8 @@ import { zodResolver } from "@hookform/resolvers/zod"
 
 import { Award, Lock, Unlock } from "lucide-react"
 
+import * as keygen from "@/keygen"
+
 import * as Schemas from "@/schemas"
 import { DistributionStrategy } from "@/types/products"
 
@@ -107,15 +109,8 @@ export default function CreateProductForm({
           </Forms.Section.Step>
 
           <Forms.Section.Step
-            crumb="Product attributes"
-            fields={[
-              "name",
-              "code",
-              "url",
-              "platforms",
-              "permissions",
-              "metadata",
-            ]}
+            crumb="Attributes"
+            fields={["name", "code", "url", "platforms"]}
           >
             <Forms.Field.Title>
               <Products.Form.Fields
@@ -138,12 +133,38 @@ export default function CreateProductForm({
                 <Forms.Section.Column>
                   <Products.Form.Fields
                     schema="create"
-                    include={["permissions", "platforms"]}
+                    include={["platforms"]}
                     fieldVariant="stacking"
                   />
                 </Forms.Section.Column>
               </Forms.Section.Columns>
+            </Forms.Section.Card>
 
+            <DocumentationLink page="products" />
+          </Forms.Section.Step>
+
+          {!keygen.config.isCE && (
+            <Forms.Section.Step
+              crumb="Product permissions"
+              fields={["permissions"]}
+            >
+              <Forms.Section.Card title="Product permissions">
+                <Products.Form.Fields
+                  schema="create"
+                  include={["permissions"]}
+                  fieldVariant="stacking"
+                />
+              </Forms.Section.Card>
+
+              <DocumentationLink page="products" />
+            </Forms.Section.Step>
+          )}
+
+          <Forms.Section.Step
+            crumb="Additional configuration"
+            fields={["metadata"]}
+          >
+            <Forms.Section.Card title="Additional configuration">
               <Products.Form.Fields
                 schema="create"
                 include={["metadata"]}

--- a/src/components/products/form/edit.tsx
+++ b/src/components/products/form/edit.tsx
@@ -13,6 +13,7 @@ import { useGetProduct, useUpdateProduct } from "@/queries/products"
 import { toast } from "@/lib/toast"
 import { recordToMetadataPairs } from "@/schemas/metadata"
 
+import * as keygen from "@/keygen"
 import * as Forms from "@/components/forms"
 import * as Products from "@/components/products"
 
@@ -67,7 +68,6 @@ export default function EditProductForm({
           errorMessage="Failed to update product"
           isPending={updateProduct.isPending}
           submitLabel="Update"
-          className="md:h-[70vh]!"
         >
           <Forms.Section.Columns title="Attributes">
             <Forms.Section.Column>
@@ -86,13 +86,17 @@ export default function EditProductForm({
             </Forms.Section.Column>
           </Forms.Section.Columns>
 
-          <Separator className="my-8" />
+          {!keygen.config.isCE && (
+            <>
+              <Separator className="my-8" />
 
-          <Products.Form.Fields
-            schema="edit"
-            include={["permissions"]}
-            fieldVariant="stacking"
-          />
+              <Products.Form.Fields
+                schema="edit"
+                include={["permissions"]}
+                fieldVariant="stacking"
+              />
+            </>
+          )}
 
           <Separator className="my-8" />
 

--- a/src/components/sidebar/panel.tsx
+++ b/src/components/sidebar/panel.tsx
@@ -79,6 +79,7 @@ type ViewRoute = {
   label: string
   params: Record<string, unknown>
   requires?: readonly Permission[]
+  ee?: boolean
 }
 
 type View = {
@@ -281,6 +282,7 @@ const VIEWS: View[] = [
         label: "Permissions",
         params: { accountId: keygen.config.id },
         requires: ["account.update"],
+        ee: true,
       },
       {
         to: "/$accountId/app/developers",
@@ -318,8 +320,10 @@ function useActiveView(): View {
 function useVisibleViews(): View[] {
   const { canAll } = usePermissions()
 
-  const isRouteVisible = (route: ViewRoute): boolean =>
-    route.requires == null || canAll(route.requires)
+  const isRouteVisible = (route: ViewRoute): boolean => {
+    if (route.ee && keygen.config.isCE) return false
+    return route.requires == null || canAll(route.requires)
+  }
 
   const filtered = VIEWS.map((view) => ({
     ...view,

--- a/src/components/tokens/form/create.tsx
+++ b/src/components/tokens/form/create.tsx
@@ -11,6 +11,7 @@ import { useCreateToken } from "@/queries/tokens"
 
 import { toast } from "@/lib/toast"
 
+import * as keygen from "@/keygen"
 import * as Forms from "@/components/forms"
 import * as Tokens from "@/components/tokens"
 import { BadgeGroup, BadgeGroupItem } from "@/components/badge-group"
@@ -130,9 +131,19 @@ export default function CreateTokenForm({
                     />
                   </Forms.Section.Column>
                 </Forms.Section.Columns>
-                <Tokens.Form.Fields include={["permissions"]} />
               </Forms.Section.Card>
             </Forms.Section.Step>
+
+            {!keygen.config.isCE && (
+              <Forms.Section.Step
+                crumb="Token permissions"
+                fields={["permissions"]}
+              >
+                <Forms.Section.Card title="Token permissions">
+                  <Tokens.Form.Fields include={["permissions"]} />
+                </Forms.Section.Card>
+              </Forms.Section.Step>
+            )}
           </Forms.Layout.Wizard>
         </Forms.Container.Dialog>
       </Forms.Provider>

--- a/src/components/tokens/form/fields.tsx
+++ b/src/components/tokens/form/fields.tsx
@@ -153,9 +153,9 @@ export default function TokensFormFields({
               />
             )
           case "permissions":
-            return !keygen.config.isCE ? (
+            return (
               <PermissionsField key="permissions" fieldVariant={fieldVariant} />
-            ) : null
+            )
           default:
             return null
         }

--- a/src/components/users/form/create.tsx
+++ b/src/components/users/form/create.tsx
@@ -10,6 +10,7 @@ import { useCreateUser, useChangeUserGroup } from "@/queries/users"
 
 import { toast } from "@/lib/toast"
 
+import * as keygen from "@/keygen"
 import * as Forms from "@/components/forms"
 import * as Users from "@/components/users"
 import DocumentationLink from "@/components/documentation-link"
@@ -73,8 +74,8 @@ export default function CreateUserForm({
           errorMessage="Failed to create user"
         >
           <Forms.Section.Step
-            crumb="General attributes"
-            fields={["email", "password", "permissions"]}
+            crumb="Account attributes"
+            fields={["email", "password"]}
           >
             <Forms.Field.Title>
               <Users.Form.Fields
@@ -85,33 +86,22 @@ export default function CreateUserForm({
               />
             </Forms.Field.Title>
 
-            <Forms.Section.Card title="General attributes">
-              <Forms.Section.Columns>
-                <Forms.Section.Column>
-                  <Users.Form.Fields
-                    schema="create"
-                    include={["password"]}
-                    fieldVariant="stacking"
-                  />
-                </Forms.Section.Column>
-                <Forms.Section.Column>
-                  <Users.Form.Fields
-                    schema="create"
-                    include={["permissions"]}
-                    fieldVariant="stacking"
-                  />
-                </Forms.Section.Column>
-              </Forms.Section.Columns>
+            <Forms.Section.Card title="Account attributes">
+              <Users.Form.Fields
+                schema="create"
+                include={["password"]}
+                fieldVariant="stacking"
+              />
             </Forms.Section.Card>
 
             <DocumentationLink page="users" />
           </Forms.Section.Step>
 
           <Forms.Section.Step
-            crumb="Profile configuration"
+            crumb="Profile attributes"
             fields={["firstName", "lastName", "role"]}
           >
-            <Forms.Section.Card title="Profile configuration">
+            <Forms.Section.Card title="Profile attributes">
               <Forms.Section.Columns>
                 <Forms.Section.Column>
                   <Users.Form.Fields
@@ -132,6 +122,23 @@ export default function CreateUserForm({
 
             <DocumentationLink page="users" />
           </Forms.Section.Step>
+
+          {!keygen.config.isCE && (
+            <Forms.Section.Step
+              crumb="User permissions"
+              fields={["permissions"]}
+            >
+              <Forms.Section.Card title="User permissions">
+                <Users.Form.Fields
+                  schema="create"
+                  include={["permissions"]}
+                  fieldVariant="stacking"
+                />
+              </Forms.Section.Card>
+
+              <DocumentationLink page="users" />
+            </Forms.Section.Step>
+          )}
 
           <Forms.Section.Step
             crumb="Additional configuration"

--- a/src/components/users/form/edit.tsx
+++ b/src/components/users/form/edit.tsx
@@ -4,6 +4,8 @@ import { zodResolver } from "@hookform/resolvers/zod"
 
 import { Separator } from "@/components/ui/separator"
 
+import * as keygen from "@/keygen"
+
 import * as Schemas from "@/schemas"
 import { UserRole, InternalRoles } from "@/types/users"
 
@@ -91,15 +93,23 @@ export default function EditUserForm({
             <Forms.Section.Column>
               <Users.Form.Fields
                 schema="edit"
-                include={[
-                  "password",
-                  isInternal ? "internalPermissions" : "permissions",
-                  "role",
-                ]}
+                include={["password", "role"]}
                 fieldVariant="stacking"
               />
             </Forms.Section.Column>
           </Forms.Section.Columns>
+
+          {!keygen.config.isCE && (
+            <>
+              <Separator className="my-8" />
+
+              <Users.Form.Fields
+                schema="edit"
+                include={[isInternal ? "internalPermissions" : "permissions"]}
+                fieldVariant="stacking"
+              />
+            </>
+          )}
 
           <Separator className="my-8" />
 

--- a/src/components/users/form/invite.tsx
+++ b/src/components/users/form/invite.tsx
@@ -11,6 +11,7 @@ import { toast } from "@/lib/toast"
 
 import * as Schemas from "@/schemas"
 
+import * as keygen from "@/keygen"
 import * as Users from "@/components/users"
 import * as Forms from "@/components/forms"
 
@@ -73,13 +74,17 @@ export default function InviteUserForm({
             </Forms.Section.Column>
           </Forms.Section.Columns>
 
-          <Separator dashed className="my-8" />
+          {!keygen.config.isCE && (
+            <>
+              <Separator dashed className="my-8" />
 
-          <Users.Form.Fields
-            schema="invite"
-            include={["internalPermissions"]}
-            fieldVariant="stacking"
-          />
+              <Users.Form.Fields
+                schema="invite"
+                include={["internalPermissions"]}
+                fieldVariant="stacking"
+              />
+            </>
+          )}
         </Forms.Layout.Sheet>
       </Forms.Container.Dialog>
     </Forms.Provider>

--- a/src/keygen/licenses/create.ts
+++ b/src/keygen/licenses/create.ts
@@ -11,7 +11,8 @@ config.validate()
 export default async function create(
   values: Schemas.Licenses.CreateValues,
 ): Promise<LicenseResponse> {
-  const { policyId, ownerId, entitlements, users, ...attributes } = values
+  const { policyId, ownerId, entitlements, users, permissions, ...attributes } =
+    values
   void ownerId
   void entitlements
   void users
@@ -25,7 +26,10 @@ export default async function create(
   const body = {
     data: {
       type: "licenses",
-      attributes: compact(attributes),
+      attributes: compact({
+        ...attributes,
+        permissions: !config.isCE ? permissions : undefined,
+      }),
       relationships,
     },
   }

--- a/src/keygen/licenses/update.ts
+++ b/src/keygen/licenses/update.ts
@@ -16,7 +16,7 @@ export default async function update({
   id,
   values,
 }: UpdateProps): Promise<LicenseResponse> {
-  const { ownerId, entitlements, users, ...attributes } = values
+  const { ownerId, entitlements, users, permissions, ...attributes } = values
   void ownerId
   void entitlements
   void users
@@ -24,7 +24,10 @@ export default async function update({
   const body = {
     data: {
       type: "licenses",
-      attributes,
+      attributes: {
+        ...attributes,
+        ...(permissions != null ? { permissions } : {}),
+      },
     },
   }
 

--- a/src/keygen/licenses/update.ts
+++ b/src/keygen/licenses/update.ts
@@ -26,7 +26,7 @@ export default async function update({
       type: "licenses",
       attributes: {
         ...attributes,
-        ...(permissions != null ? { permissions } : {}),
+        ...(!config.isCE && permissions != null ? { permissions } : {}),
       },
     },
   }

--- a/src/keygen/products/create.ts
+++ b/src/keygen/products/create.ts
@@ -14,10 +14,15 @@ interface CreateProps {
 export default async function create({
   values,
 }: CreateProps): Promise<ProductResponse> {
+  const { permissions, ...rest } = values
+
   const body = {
     data: {
       type: "products",
-      attributes: compact(values),
+      attributes: compact({
+        ...rest,
+        permissions: !config.isCE ? permissions : undefined,
+      }),
     },
   }
 

--- a/src/keygen/products/update.ts
+++ b/src/keygen/products/update.ts
@@ -16,10 +16,15 @@ export default async function update({
   id,
   values,
 }: UpdateProps): Promise<ProductResponse> {
+  const { permissions, ...rest } = values
+
   const body = {
     data: {
       type: "products",
-      attributes: compact(values),
+      attributes: compact({
+        ...rest,
+        permissions: !config.isCE ? permissions : undefined,
+      }),
     },
   }
 

--- a/src/keygen/users/create.ts
+++ b/src/keygen/users/create.ts
@@ -11,13 +11,16 @@ config.validate()
 export default async function create(
   values: Schemas.Users.CreateValues,
 ): Promise<UserResponse> {
-  const { groupId, ...attributes } = values
+  const { groupId, permissions, ...attributes } = values
   void groupId
 
   const body = {
     data: {
       type: "users",
-      attributes: compact(attributes),
+      attributes: compact({
+        ...attributes,
+        permissions: !config.isCE ? permissions : undefined,
+      }),
     },
   }
 

--- a/src/keygen/users/update.ts
+++ b/src/keygen/users/update.ts
@@ -18,13 +18,16 @@ export default async function update({
   values,
   root,
 }: UpdateProps): Promise<UserResponse> {
-  const { groupId, ...attributes } = values
+  const { groupId, permissions, ...attributes } = values
   void groupId
 
   const body = {
     data: {
       type: "users",
-      attributes,
+      attributes: {
+        ...attributes,
+        ...(permissions != null ? { permissions } : {}),
+      },
     },
   }
 

--- a/src/keygen/users/update.ts
+++ b/src/keygen/users/update.ts
@@ -26,7 +26,7 @@ export default async function update({
       type: "users",
       attributes: {
         ...attributes,
-        ...(permissions != null ? { permissions } : {}),
+        ...(!config.isCE && permissions != null ? { permissions } : {}),
       },
     },
   }

--- a/src/lib/licenses.ts
+++ b/src/lib/licenses.ts
@@ -7,7 +7,10 @@ import { capitalize } from "@/lib/utils"
 import { AttributeType } from "@/components/attribute/value"
 
 export const licenseAttributeTypeSchema: Record<
-  keyof Omit<License["attributes"], "metadata" | "created" | "updated">,
+  keyof Omit<
+    License["attributes"],
+    "metadata" | "permissions" | "created" | "updated"
+  >,
   AttributeType
 > = {
   name: "string",

--- a/src/pages/app/license/details.tsx
+++ b/src/pages/app/license/details.tsx
@@ -656,27 +656,29 @@ export default function LicenseDetails() {
                       />
                     </div>
                   </div>
-                  <CollapsibleMenu title="Permissions" defaultOpen={false}>
-                    {license.attributes.permissions != null &&
-                    license.attributes.permissions.length > 0 ? (
-                      <div className="flex max-w-full flex-wrap gap-2">
-                        {license.attributes.permissions.map(
-                          (permission, index) => (
-                            <Badge
-                              key={index}
-                              className="text-sm text-content-muted"
-                            >
-                              {permission}
-                            </Badge>
-                          ),
-                        )}
-                      </div>
-                    ) : (
-                      <p className="text-sm text-content-muted">
-                        No permissions defined.
-                      </p>
-                    )}
-                  </CollapsibleMenu>
+                  {!keygen.config.isCE && (
+                    <CollapsibleMenu title="Permissions" defaultOpen={false}>
+                      {license.attributes.permissions != null &&
+                      license.attributes.permissions.length > 0 ? (
+                        <div className="flex max-w-full flex-wrap gap-2">
+                          {license.attributes.permissions.map(
+                            (permission, index) => (
+                              <Badge
+                                key={index}
+                                className="text-sm text-content-muted"
+                              >
+                                {permission}
+                              </Badge>
+                            ),
+                          )}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-content-muted">
+                          No permissions defined.
+                        </p>
+                      )}
+                    </CollapsibleMenu>
+                  )}
                 </CollapsibleCard>
 
                 <CollapsibleCard

--- a/src/pages/app/license/details.tsx
+++ b/src/pages/app/license/details.tsx
@@ -656,6 +656,27 @@ export default function LicenseDetails() {
                       />
                     </div>
                   </div>
+                  <CollapsibleMenu title="Permissions" defaultOpen={false}>
+                    {license.attributes.permissions != null &&
+                    license.attributes.permissions.length > 0 ? (
+                      <div className="flex max-w-full flex-wrap gap-2">
+                        {license.attributes.permissions.map(
+                          (permission, index) => (
+                            <Badge
+                              key={index}
+                              className="text-sm text-content-muted"
+                            >
+                              {permission}
+                            </Badge>
+                          ),
+                        )}
+                      </div>
+                    ) : (
+                      <p className="text-sm text-content-muted">
+                        No permissions defined.
+                      </p>
+                    )}
+                  </CollapsibleMenu>
                 </CollapsibleCard>
 
                 <CollapsibleCard

--- a/src/pages/app/product/details.tsx
+++ b/src/pages/app/product/details.tsx
@@ -297,27 +297,29 @@ export default function ProductDetails() {
                       />
                     </div>
                   </div>
-                  <CollapsibleMenu title="Permissions" defaultOpen={false}>
-                    {product.attributes.permissions != null &&
-                    product.attributes.permissions.length > 0 ? (
-                      <div className="flex max-w-full flex-wrap gap-2">
-                        {product.attributes.permissions.map(
-                          (permission, index) => (
-                            <Badge
-                              key={index}
-                              className="text-sm text-content-muted"
-                            >
-                              {permission}
-                            </Badge>
-                          ),
-                        )}
-                      </div>
-                    ) : (
-                      <p className="text-sm text-content-muted">
-                        No permissions defined.
-                      </p>
-                    )}
-                  </CollapsibleMenu>
+                  {!keygen.config.isCE && (
+                    <CollapsibleMenu title="Permissions" defaultOpen={false}>
+                      {product.attributes.permissions != null &&
+                      product.attributes.permissions.length > 0 ? (
+                        <div className="flex max-w-full flex-wrap gap-2">
+                          {product.attributes.permissions.map(
+                            (permission, index) => (
+                              <Badge
+                                key={index}
+                                className="text-sm text-content-muted"
+                              >
+                                {permission}
+                              </Badge>
+                            ),
+                          )}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-content-muted">
+                          No permissions defined.
+                        </p>
+                      )}
+                    </CollapsibleMenu>
+                  )}
                 </CollapsibleCard>
 
                 <CollapsibleCard title="Relationships">

--- a/src/pages/app/team/details.tsx
+++ b/src/pages/app/team/details.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react"
 import { useParams } from "@tanstack/react-router"
 
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Separator } from "@/components/ui/separator"
@@ -344,6 +345,27 @@ export default function TeamDetails() {
                       />
                     </div>
                   </div>
+                  <CollapsibleMenu title="Permissions" defaultOpen={false}>
+                    {user.attributes.permissions != null &&
+                    user.attributes.permissions.length > 0 ? (
+                      <div className="flex max-w-full flex-wrap gap-2">
+                        {user.attributes.permissions.map(
+                          (permission, index) => (
+                            <Badge
+                              key={index}
+                              className="text-sm text-content-muted"
+                            >
+                              {permission}
+                            </Badge>
+                          ),
+                        )}
+                      </div>
+                    ) : (
+                      <p className="text-sm text-content-muted">
+                        No permissions defined.
+                      </p>
+                    )}
+                  </CollapsibleMenu>
                 </CollapsibleCard>
 
                 <CollapsibleCard title="Relationships">

--- a/src/pages/app/team/details.tsx
+++ b/src/pages/app/team/details.tsx
@@ -59,6 +59,7 @@ import { useBreadcrumbBackNavigate } from "@/hooks/use-breadcrumb-back-navigate"
 import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
 
+import * as keygen from "@/keygen"
 import * as Users from "@/components/users"
 import * as Property from "@/components/property"
 import * as Attribute from "@/components/attribute"
@@ -345,27 +346,29 @@ export default function TeamDetails() {
                       />
                     </div>
                   </div>
-                  <CollapsibleMenu title="Permissions" defaultOpen={false}>
-                    {user.attributes.permissions != null &&
-                    user.attributes.permissions.length > 0 ? (
-                      <div className="flex max-w-full flex-wrap gap-2">
-                        {user.attributes.permissions.map(
-                          (permission, index) => (
-                            <Badge
-                              key={index}
-                              className="text-sm text-content-muted"
-                            >
-                              {permission}
-                            </Badge>
-                          ),
-                        )}
-                      </div>
-                    ) : (
-                      <p className="text-sm text-content-muted">
-                        No permissions defined.
-                      </p>
-                    )}
-                  </CollapsibleMenu>
+                  {!keygen.config.isCE && (
+                    <CollapsibleMenu title="Permissions" defaultOpen={false}>
+                      {user.attributes.permissions != null &&
+                      user.attributes.permissions.length > 0 ? (
+                        <div className="flex max-w-full flex-wrap gap-2">
+                          {user.attributes.permissions.map(
+                            (permission, index) => (
+                              <Badge
+                                key={index}
+                                className="text-sm text-content-muted"
+                              >
+                                {permission}
+                              </Badge>
+                            ),
+                          )}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-content-muted">
+                          No permissions defined.
+                        </p>
+                      )}
+                    </CollapsibleMenu>
+                  )}
                 </CollapsibleCard>
 
                 <CollapsibleCard title="Relationships">

--- a/src/pages/app/token/details.tsx
+++ b/src/pages/app/token/details.tsx
@@ -48,6 +48,7 @@ import { toast } from "@/lib/toast"
 import { copyToClipboard } from "@/lib/clipboard"
 import { revokeTokenDescription } from "@/lib/tokens"
 
+import * as keygen from "@/keygen"
 import * as Tokens from "@/components/tokens"
 import * as Property from "@/components/property"
 import * as Attribute from "@/components/attribute"
@@ -352,27 +353,29 @@ export default function TokenDetails() {
                       )}
                     </div>
                   </div>
-                  <CollapsibleMenu title="Permissions" defaultOpen={false}>
-                    {token.attributes.permissions != null &&
-                    token.attributes.permissions.length > 0 ? (
-                      <div className="flex max-w-full flex-wrap gap-2">
-                        {token.attributes.permissions.map(
-                          (permission, index) => (
-                            <Badge
-                              key={index}
-                              className="text-sm text-content-muted"
-                            >
-                              {permission}
-                            </Badge>
-                          ),
-                        )}
-                      </div>
-                    ) : (
-                      <p className="text-sm text-content-muted">
-                        No permissions defined.
-                      </p>
-                    )}
-                  </CollapsibleMenu>
+                  {!keygen.config.isCE && (
+                    <CollapsibleMenu title="Permissions" defaultOpen={false}>
+                      {token.attributes.permissions != null &&
+                      token.attributes.permissions.length > 0 ? (
+                        <div className="flex max-w-full flex-wrap gap-2">
+                          {token.attributes.permissions.map(
+                            (permission, index) => (
+                              <Badge
+                                key={index}
+                                className="text-sm text-content-muted"
+                              >
+                                {permission}
+                              </Badge>
+                            ),
+                          )}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-content-muted">
+                          No permissions defined.
+                        </p>
+                      )}
+                    </CollapsibleMenu>
+                  )}
                 </CollapsibleCard>
 
                 <CollapsibleCard title="Relationships">

--- a/src/pages/app/user/details.tsx
+++ b/src/pages/app/user/details.tsx
@@ -451,6 +451,27 @@ export default function UserDetails() {
                       />
                     </div>
                   </div>
+                  <CollapsibleMenu title="Permissions" defaultOpen={false}>
+                    {user.attributes.permissions != null &&
+                    user.attributes.permissions.length > 0 ? (
+                      <div className="flex max-w-full flex-wrap gap-2">
+                        {user.attributes.permissions.map(
+                          (permission, index) => (
+                            <Badge
+                              key={index}
+                              className="text-sm text-content-muted"
+                            >
+                              {permission}
+                            </Badge>
+                          ),
+                        )}
+                      </div>
+                    ) : (
+                      <p className="text-sm text-content-muted">
+                        No permissions defined.
+                      </p>
+                    )}
+                  </CollapsibleMenu>
                 </CollapsibleCard>
 
                 <CollapsibleCard

--- a/src/pages/app/user/details.tsx
+++ b/src/pages/app/user/details.tsx
@@ -451,27 +451,29 @@ export default function UserDetails() {
                       />
                     </div>
                   </div>
-                  <CollapsibleMenu title="Permissions" defaultOpen={false}>
-                    {user.attributes.permissions != null &&
-                    user.attributes.permissions.length > 0 ? (
-                      <div className="flex max-w-full flex-wrap gap-2">
-                        {user.attributes.permissions.map(
-                          (permission, index) => (
-                            <Badge
-                              key={index}
-                              className="text-sm text-content-muted"
-                            >
-                              {permission}
-                            </Badge>
-                          ),
-                        )}
-                      </div>
-                    ) : (
-                      <p className="text-sm text-content-muted">
-                        No permissions defined.
-                      </p>
-                    )}
-                  </CollapsibleMenu>
+                  {!keygen.config.isCE && (
+                    <CollapsibleMenu title="Permissions" defaultOpen={false}>
+                      {user.attributes.permissions != null &&
+                      user.attributes.permissions.length > 0 ? (
+                        <div className="flex max-w-full flex-wrap gap-2">
+                          {user.attributes.permissions.map(
+                            (permission, index) => (
+                              <Badge
+                                key={index}
+                                className="text-sm text-content-muted"
+                              >
+                                {permission}
+                              </Badge>
+                            ),
+                          )}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-content-muted">
+                          No permissions defined.
+                        </p>
+                      )}
+                    </CollapsibleMenu>
+                  )}
                 </CollapsibleCard>
 
                 <CollapsibleCard

--- a/src/routes/$accountId/app.permissions.tsx
+++ b/src/routes/$accountId/app.permissions.tsx
@@ -1,10 +1,21 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, redirect } from "@tanstack/react-router"
 
+import * as keygen from "@/keygen"
 import * as Page from "@/pages/index"
 import { requirePermission } from "@/lib/permissions"
 
 export const Route = createFileRoute("/$accountId/app/permissions")({
   component: () => <Page.App.Settings.Permissions />,
-  beforeLoad: ({ context }) =>
-    requirePermission(context.queryClient, "account.update"),
+  beforeLoad: ({ context }) => {
+    if (keygen.config.isCE) {
+      redirect({
+        to: "/$accountId/app/general",
+        params: { accountId: keygen.config.id },
+        replace: true,
+        throw: true,
+      })
+    }
+
+    return requirePermission(context.queryClient, "account.update")
+  },
 })

--- a/src/schemas/licenses.ts
+++ b/src/schemas/licenses.ts
@@ -22,6 +22,7 @@ const BaseShape = z.object({
   maxMemory: z.number().int().positive().nullable().optional(),
   maxDisk: z.number().int().positive().nullable().optional(),
   maxUses: z.number().int().positive().nullable().optional(),
+  permissions: z.array(z.string()).nullable().optional(),
   metadata: MetadataPairsSchema.optional(),
   ownerId: z.string().nullable().optional(),
   entitlements: z

--- a/src/types/licenses.ts
+++ b/src/types/licenses.ts
@@ -48,6 +48,7 @@ export type LicenseAttributes = {
   lastCheckOut: string | null
   lastCheckIn: string | null
   nextCheckIn: string | null
+  permissions: string[] | null
   metadata: Record<string, unknown>
   created: string
   updated: string
@@ -66,6 +67,7 @@ export interface LicenseInput {
   maxMemory?: number | null
   maxDisk?: number | null
   maxUses?: number | null
+  permissions?: string[] | null
   metadata?: Record<string, unknown>
 }
 
@@ -126,6 +128,7 @@ export const LicenseAttributeDescriptions: Readonly<
   lastCheckIn: "The time at which the license was last checked-in.",
   nextCheckIn:
     "The time at which the license must be checked-in by to remain valid.",
+  permissions: "The permissions for the license.",
   metadata:
     "Store arbitrary key/value data on the license for book keeping purposes, entitlements, etc.",
 } as const


### PR DESCRIPTION
Closes #142. Addresses a few issues with permissions and adds permissions config to licenses.

Licenses now includes a permissions form field, and permission sections have been added to the License, User and Team details pages. Additionally, this fixes a problem in CE that allowed users to attempt to modify and make API requests with permission attributes, which is an EE-exclusive feature, so the API would reject.

All forms that include permissions (products, licenses, users, invite teammate, and tokens) now have their permissions form field separated into its own step that requires EE to be viewable. Eventually we'll add a CTA so the steps are still viewable in CE (#306).

NB: moving the permission form fields into separate steps was necessary because step validation is performed per-step submit, so if we conditionally included the form field in a step with other fields, that would dirty validation because the step would be expecting permissions and wouldn't have access to the field in CE. Isn't really an issue today because permissions are always optional, but could be an issue if we ever required permissions in the same step with other fields.

<img width="700" src="https://github.com/user-attachments/assets/94a6ca84-3397-4b0e-a03a-3806907b2460" />
<img width="700" src="https://github.com/user-attachments/assets/0fe73c37-0f73-41fb-bd39-bc2f85390dec" />
<img width="700" src="https://github.com/user-attachments/assets/f7b4deae-e457-4792-b5e6-05cbaba90a80" />

