### PR TITLE
Fix policy template tooltips

### DIFF
--- a/src/components/card-selector.tsx
+++ b/src/components/card-selector.tsx
@@ -152,7 +152,7 @@ export function CardSelector<T>({
                         <PopoverTrigger onClick={(e) => e.stopPropagation()}>
                           <Info className="size-5 text-content-subdued" />
                         </PopoverTrigger>
-                        <PopoverContent className="ml-2 max-w-64 bg-background-4 text-content-muted">
+                        <PopoverContent className="ml-2 max-w-64 bg-background-4 text-pretty text-content-muted">
                           {option.tooltip}
                         </PopoverContent>
                       </Popover>
@@ -161,7 +161,7 @@ export function CardSelector<T>({
                         <TooltipTrigger asChild>
                           <Info className="size-4 pt-0.5 text-content-subdued" />
                         </TooltipTrigger>
-                        <TooltipContent className="max-w-64 bg-background-4 text-content-muted">
+                        <TooltipContent className="max-w-64 bg-background-4 text-pretty text-content-muted">
                           {option.tooltip}
                         </TooltipContent>
                       </Tooltip>

--- a/src/components/policies/form/create.tsx
+++ b/src/components/policies/form/create.tsx
@@ -38,12 +38,14 @@ import {
 } from "lucide-react"
 
 import * as Schemas from "@/schemas"
+import { PolicyTemplateSelection } from "@/schemas/policies"
 import {
   TimingTemplates,
   AccessTemplates,
   MeteredTemplates,
-  PolicyTemplateSelection,
-} from "@/schemas/policies"
+  PolicyTemplateLabels,
+  PolicyTemplateDescriptions,
+} from "@/types/policies"
 
 import { toast } from "@/lib/toast"
 import { settleCreateEntitlements } from "@/lib/entitlements"
@@ -284,63 +286,63 @@ function TemplatesSelectionForm({
   const timingOptions: CardOption<TimingTemplates>[] = [
     {
       value: TimingTemplates.Perpetual,
-      label: "Perpetual",
+      label: PolicyTemplateLabels[TimingTemplates.Perpetual],
       icon: <InfinityIcon className="size-6 text-content-subdued md:size-5" />,
-      tooltip: "TODO",
+      tooltip: PolicyTemplateDescriptions[TimingTemplates.Perpetual],
     },
     {
       value: TimingTemplates.Timed,
-      label: "Timed",
+      label: PolicyTemplateLabels[TimingTemplates.Timed],
       icon: <Clock className="size-6 text-content-subdued md:size-5" />,
-      tooltip: "TODO",
+      tooltip: PolicyTemplateDescriptions[TimingTemplates.Timed],
     },
     {
       value: TimingTemplates.PerpetualFallback,
-      label: "Perpetual-fallback",
+      label: PolicyTemplateLabels[TimingTemplates.PerpetualFallback],
       icon: <ClockFading className="size-6 text-content-subdued md:size-5" />,
-      tooltip: "TODO",
+      tooltip: PolicyTemplateDescriptions[TimingTemplates.PerpetualFallback],
     },
   ]
 
   const accessOptions: CardOption<AccessTemplates>[] = [
     {
       value: AccessTemplates.NodeLocked,
-      label: "Node-locked",
+      label: PolicyTemplateLabels[AccessTemplates.NodeLocked],
       icon: <Hexagon className="size-6 text-content-subdued md:size-5" />,
-      tooltip: "TODO",
+      tooltip: PolicyTemplateDescriptions[AccessTemplates.NodeLocked],
     },
     {
       value: AccessTemplates.UserLocked,
-      label: "User-locked",
+      label: PolicyTemplateLabels[AccessTemplates.UserLocked],
       icon: <User className="size-6 text-content-subdued md:size-5" />,
-      tooltip: "TODO",
+      tooltip: PolicyTemplateDescriptions[AccessTemplates.UserLocked],
     },
   ]
 
   const meteredOptions: CardOption<MeteredTemplates>[] = [
     {
       value: MeteredTemplates.ProcessBased,
-      label: "Process-based",
+      label: PolicyTemplateLabels[MeteredTemplates.ProcessBased],
       icon: <Cpu className="size-6 text-content-subdued md:size-5" />,
-      tooltip: "TODO",
+      tooltip: PolicyTemplateDescriptions[MeteredTemplates.ProcessBased],
     },
     {
       value: MeteredTemplates.LeaseBased,
-      label: "Lease-based",
+      label: PolicyTemplateLabels[MeteredTemplates.LeaseBased],
       icon: <Activity className="size-6 text-content-subdued md:size-5" />,
-      tooltip: "TODO",
+      tooltip: PolicyTemplateDescriptions[MeteredTemplates.LeaseBased],
     },
     {
       value: MeteredTemplates.FeatureBased,
-      label: "Feature-based",
+      label: PolicyTemplateLabels[MeteredTemplates.FeatureBased],
       icon: <Binary className="size-6 text-content-subdued md:size-5" />,
-      tooltip: "TODO",
+      tooltip: PolicyTemplateDescriptions[MeteredTemplates.FeatureBased],
     },
     {
       value: MeteredTemplates.UsageBased,
-      label: "Usage-based",
+      label: PolicyTemplateLabels[MeteredTemplates.UsageBased],
       icon: <Hash className="size-6 text-content-subdued md:size-5" />,
-      tooltip: "TODO",
+      tooltip: PolicyTemplateDescriptions[MeteredTemplates.UsageBased],
     },
   ]
 

--- a/src/lib/policies.tsx
+++ b/src/lib/policies.tsx
@@ -1,7 +1,14 @@
 import { AttributeType } from "@/components/attribute/value"
 
 import { Entitlement } from "@/types/entitlements"
-import { Policy, ExpirationStrategy } from "@/types/policies"
+import {
+  Policy,
+  PolicyTemplate,
+  TimingTemplates,
+  AccessTemplates,
+  MeteredTemplates,
+  ExpirationStrategy,
+} from "@/types/policies"
 
 export function isPerpetual(policy: Policy): boolean {
   return policy.attributes.duration == null || policy.attributes.duration === 0
@@ -56,6 +63,27 @@ export function isUsageBased(policy: Policy): boolean {
   const maxUses = policy.attributes.maxUses
 
   return typeof maxUses === "number" && maxUses > 0
+}
+
+export function getPolicyTemplates(
+  policy: Policy,
+  entitlements: Entitlement[],
+): PolicyTemplate[] {
+  const templates: PolicyTemplate[] = []
+
+  if (isPerpetual(policy)) templates.push(TimingTemplates.Perpetual)
+  if (isTimed(policy)) templates.push(TimingTemplates.Timed)
+  if (isPerpetualFallback(policy))
+    templates.push(TimingTemplates.PerpetualFallback)
+  if (isNodeLocked(policy)) templates.push(AccessTemplates.NodeLocked)
+  if (isUserLocked(policy)) templates.push(AccessTemplates.UserLocked)
+  if (isProcessBased(policy)) templates.push(MeteredTemplates.ProcessBased)
+  if (isLeaseBased(policy)) templates.push(MeteredTemplates.LeaseBased)
+  if (isFeatureBased(entitlements))
+    templates.push(MeteredTemplates.FeatureBased)
+  if (isUsageBased(policy)) templates.push(MeteredTemplates.UsageBased)
+
+  return templates
 }
 
 export const policyAttributeTypeSchema: Record<

--- a/src/pages/app/policy/details.tsx
+++ b/src/pages/app/policy/details.tsx
@@ -32,19 +32,26 @@ import {
 import {
   Box,
   Cpu,
+  Hash,
+  User,
   Logs,
   Copy,
   Menu,
   Clock,
   Users,
+  Binary,
   Repeat,
+  Hexagon,
   GitFork,
   Monitor,
+  Activity,
   HardDrive,
+  ClockFading,
   MemoryStick,
   SquarePen,
   SquarePlus,
   EllipsisVertical,
+  Infinity as InfinityIcon,
 } from "lucide-react"
 
 import { useGetProduct } from "@/queries/products"
@@ -64,17 +71,20 @@ import { copyToClipboard } from "@/lib/clipboard"
 import { formatByteSize, formatRawByteSize } from "@/lib/bytes"
 
 import {
-  isPerpetual,
   isTimed,
-  isPerpetualFallback,
   isNodeLocked,
-  isUserLocked,
-  isProcessBased,
   isLeaseBased,
-  isFeatureBased,
-  isUsageBased,
+  getPolicyTemplates,
 } from "@/lib/policies"
-import { PolicyAttributeDescriptions } from "@/types/policies"
+import {
+  PolicyAttributeDescriptions,
+  PolicyTemplateLabels,
+  PolicyTemplateDescriptions,
+  TimingTemplates,
+  AccessTemplates,
+  MeteredTemplates,
+  type PolicyTemplate,
+} from "@/types/policies"
 
 import * as keygen from "@/keygen"
 import * as Policies from "@/components/policies"
@@ -92,6 +102,18 @@ import ConfirmationModal from "@/components/confirmation-modal"
 import TooltipBadge from "@/components/tooltip-badge"
 import CollapsibleCard from "@/components/collapsible-card"
 import CollapsibleMenu from "@/components/collapsible-menu"
+
+const PolicyTemplateIcons: Record<PolicyTemplate, React.ReactNode> = {
+  [TimingTemplates.Perpetual]: <InfinityIcon className="size-3" />,
+  [TimingTemplates.Timed]: <Clock className="size-3" />,
+  [TimingTemplates.PerpetualFallback]: <ClockFading className="size-3" />,
+  [AccessTemplates.NodeLocked]: <Hexagon className="size-3" />,
+  [AccessTemplates.UserLocked]: <User className="size-3" />,
+  [MeteredTemplates.ProcessBased]: <Cpu className="size-3" />,
+  [MeteredTemplates.LeaseBased]: <Activity className="size-3" />,
+  [MeteredTemplates.FeatureBased]: <Binary className="size-3" />,
+  [MeteredTemplates.UsageBased]: <Hash className="size-3" />,
+}
 
 export default function PolicyDetails() {
   const { id } = useParams({ from: "/$accountId/app/policies/$id" })
@@ -260,60 +282,16 @@ export default function PolicyDetails() {
             <div className="px-4 py-6 md:px-10 md:py-8">
               <BackButton className="mb-8" />
               <div className="mb-2 flex flex-wrap gap-2">
-                {isPerpetual(policy) && (
-                  <Badge variant="secondary">
-                    <Clock className="inline size-4" />
-                    Perpetual
-                  </Badge>
-                )}
-                {isTimed(policy) && (
-                  <Badge variant="secondary">
-                    <Clock className="inline size-4" />
-                    Timed
-                  </Badge>
-                )}
-                {isPerpetualFallback(policy) && (
-                  <Badge variant="secondary">
-                    <Clock className="inline size-4" />
-                    Perpetual-fallback
-                  </Badge>
-                )}
-                {isNodeLocked(policy) && (
-                  <Badge variant="secondary">
-                    <Clock className="inline size-4" />
-                    Node-locked
-                  </Badge>
-                )}
-                {isUserLocked(policy) && (
-                  <Badge variant="secondary">
-                    <Clock className="inline size-4" />
-                    User-locked
-                  </Badge>
-                )}
-                {isProcessBased(policy) && (
-                  <Badge variant="secondary">
-                    <Clock className="inline size-4" />
-                    Process-based
-                  </Badge>
-                )}
-                {isLeaseBased(policy) && (
-                  <Badge variant="secondary">
-                    <Clock className="inline size-4" />
-                    Lease-based
-                  </Badge>
-                )}
-                {isFeatureBased(entitlements) && (
-                  <Badge variant="secondary">
-                    <Clock className="inline size-4" />
-                    Feature-based
-                  </Badge>
-                )}
-                {isUsageBased(policy) && (
-                  <Badge variant="secondary">
-                    <Clock className="inline size-4" />
-                    Usage-based
-                  </Badge>
-                )}
+                {getPolicyTemplates(policy, entitlements).map((template) => (
+                  <TooltipBadge
+                    key={template}
+                    icon={PolicyTemplateIcons[template]}
+                    value={PolicyTemplateLabels[template]}
+                    variant="secondary"
+                    tooltip={PolicyTemplateDescriptions[template]}
+                    className="px-1 text-xs"
+                  />
+                ))}
               </div>
               <div className="flex flex-col gap-3 md:flex-row md:items-center">
                 <h1 className="font-owners-wide text-2xl font-medium">

--- a/src/schemas/policies.ts
+++ b/src/schemas/policies.ts
@@ -22,6 +22,9 @@ import {
   HeartbeatBasis,
   HeartbeatCullStrategy,
   HeartbeatResurrectionStrategy,
+  TimingTemplates,
+  AccessTemplates,
+  MeteredTemplates,
 } from "@/types/policies"
 import { MetadataPairsSchema, recordToMetadataPairs } from "@/schemas/metadata"
 
@@ -370,22 +373,6 @@ export type FieldNames = Exclude<
   FieldPath<AllValues>,
   "encrypted" | "entitlements" | "product.id"
 >
-
-export enum TimingTemplates {
-  Perpetual = "PERPETUAL",
-  Timed = "TIMED",
-  PerpetualFallback = "PERPETUAL_FALLBACK",
-}
-export enum AccessTemplates {
-  NodeLocked = "NODE_LOCKED",
-  UserLocked = "USER_LOCKED",
-}
-export enum MeteredTemplates {
-  ProcessBased = "PROCESS_BASED",
-  LeaseBased = "LEASE_BASED",
-  FeatureBased = "FEATURE_BASED",
-  UsageBased = "USAGE_BASED",
-}
 
 export const TemplateSchema = z.object({
   timing: z.nativeEnum(TimingTemplates).nullable().optional(),

--- a/src/types/policies.ts
+++ b/src/types/policies.ts
@@ -473,3 +473,59 @@ export const PolicyOptionLabels = {
     [Scheme.Rsa2048Pkcs1Sign]: "RSA 2048 PKCS1",
   },
 } as const
+
+export enum TimingTemplates {
+  Perpetual = "PERPETUAL",
+  Timed = "TIMED",
+  PerpetualFallback = "PERPETUAL_FALLBACK",
+}
+export enum AccessTemplates {
+  NodeLocked = "NODE_LOCKED",
+  UserLocked = "USER_LOCKED",
+}
+export enum MeteredTemplates {
+  ProcessBased = "PROCESS_BASED",
+  LeaseBased = "LEASE_BASED",
+  FeatureBased = "FEATURE_BASED",
+  UsageBased = "USAGE_BASED",
+}
+
+export type PolicyTemplate =
+  | TimingTemplates
+  | AccessTemplates
+  | MeteredTemplates
+
+export const PolicyTemplateLabels: Readonly<Record<PolicyTemplate, string>> = {
+  [TimingTemplates.Perpetual]: "Perpetual",
+  [TimingTemplates.Timed]: "Timed",
+  [TimingTemplates.PerpetualFallback]: "Perpetual-fallback",
+  [AccessTemplates.NodeLocked]: "Node-locked",
+  [AccessTemplates.UserLocked]: "User-locked",
+  [MeteredTemplates.ProcessBased]: "Process-based",
+  [MeteredTemplates.LeaseBased]: "Lease-based",
+  [MeteredTemplates.FeatureBased]: "Feature-based",
+  [MeteredTemplates.UsageBased]: "Usage-based",
+} as const
+
+export const PolicyTemplateDescriptions: Readonly<
+  Record<PolicyTemplate, string>
+> = {
+  [TimingTemplates.Perpetual]:
+    "Licenses that implement this policy never expire.",
+  [TimingTemplates.Timed]:
+    "Licenses that implement this policy expire after their duration elapses.",
+  [TimingTemplates.PerpetualFallback]:
+    "A timed policy whose licenses keep passing validation after expiry, but can only access releases published before they expired.",
+  [AccessTemplates.NodeLocked]:
+    "Licenses that implement this policy are locked to a limited number of machines.",
+  [AccessTemplates.UserLocked]:
+    "Licenses that implement this policy are locked to a limited number of users.",
+  [MeteredTemplates.ProcessBased]:
+    "Licenses that implement this policy track a limited number of concurrent machine processes.",
+  [MeteredTemplates.LeaseBased]:
+    "Machines must start and maintain a heartbeat to remain valid under this policy.",
+  [MeteredTemplates.FeatureBased]:
+    "Access under this policy is gated by the entitlements attached to it.",
+  [MeteredTemplates.UsageBased]:
+    "Licenses that implement this policy are limited by a maximum number of recorded uses.",
+} as const


### PR DESCRIPTION
Closes #42, closes #300. Fixes policy tooltips by adding hoverable badges on the details page, to be consistent with other pages, and replaces the `TODO` template descriptions in the policy templates form.

<img width="500" src="https://github.com/user-attachments/assets/0eba56ea-68b6-4bf2-9ef7-dfd9c65a54f4" />
<img width="500" src="https://github.com/user-attachments/assets/13a39cd1-96ae-4b7f-8872-0d7d966517e8" />
