### PR TITLE
Fix errors reported to BetterStack as objects

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,12 @@
 import { StrictMode } from "react"
 import ReactDOM from "react-dom/client"
 import * as Sentry from "@sentry/react"
-import { RouterProvider, createRouter } from "@tanstack/react-router"
+import {
+  RouterProvider,
+  createRouter,
+  isNotFound,
+  isRedirect,
+} from "@tanstack/react-router"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { routeTree } from "./routeTree.gen"
 import * as sentry from "@/sentry"
@@ -38,7 +43,12 @@ declare module "@tanstack/react-router" {
 const rootElement = document.getElementById("root")!
 
 if (!rootElement.innerHTML) {
-  const root = ReactDOM.createRoot(rootElement)
+  const root = ReactDOM.createRoot(rootElement, {
+    onCaughtError: (error) => {
+      if (isNotFound(error) || isRedirect(error)) return
+      console.error(error)
+    },
+  })
 
   root.render(
     <StrictMode>


### PR DESCRIPTION
Introduced in #311. `404` errors were surfacing in BetterStack as `[object Object]`. This fixes that by having `onCaughtError` ignore TanStack's `notFound` errors, which Sentry was forwarding to us.