### PR TITLE
Fix numeric inputs accepting non-numeric values

### DIFF
--- a/src/components/artifacts/form/fields.tsx
+++ b/src/components/artifacts/form/fields.tsx
@@ -28,6 +28,7 @@ import { type FieldVariant } from "@/components/forms/field"
 
 import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
+import NumberInput from "@/components/number-input"
 import MetadataInput from "@/components/metadata-input"
 
 type Descriptions = typeof ArtifactFormFieldDescriptions
@@ -307,10 +308,8 @@ function FilesizeField({
             optional
           >
             <FormControl>
-              <Input
+              <NumberInput
                 {...field}
-                value={field.value ?? ""}
-                type="number"
                 placeholder="e.g. 3097"
                 autoFocus={autoFocus}
                 autoComplete="off"

--- a/src/components/byte-size-input.tsx
+++ b/src/components/byte-size-input.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react"
 
-import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import {
   Popover,
@@ -17,7 +16,13 @@ import {
   formatByteUnitValue,
 } from "@/lib/bytes"
 
-interface ByteSizeInputProps {
+import NumberInput from "@/components/number-input"
+
+interface ByteSizeInputProps
+  extends Pick<
+    React.ComponentProps<"input">,
+    "id" | "aria-invalid" | "aria-describedby" | "ref"
+  > {
   value?: number | null
   onChange: (bytes: number | null) => void
   defaultUnit?: ByteUnitKey
@@ -35,6 +40,7 @@ export default function ByteSizeInput({
   placeholderBytes,
   autoFocus,
   className,
+  ...inputProps
 }: ByteSizeInputProps): React.ReactElement {
   const [unit, setUnit] = useState<ByteUnit>(() =>
     selectByteUnit(value, defaultUnit),
@@ -42,14 +48,12 @@ export default function ByteSizeInput({
   const [unitsOpen, setUnitsOpen] = useState(false)
 
   const apply = (n: number | null, u: ByteUnit) => {
-    if (n == null || n <= 0) onChange(null)
+    if (n != null && Number.isNaN(n)) onChange(NaN)
+    else if (n == null || n <= 0) onChange(null)
     else onChange(Math.round(n * u.bytes))
   }
 
-  const onNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const raw = e.currentTarget.value
-    const next = raw === "" ? null : Number(raw)
-
+  const onNumberChange = (next: number | null) => {
     apply(next, unit)
   }
 
@@ -58,7 +62,12 @@ export default function ByteSizeInput({
     setUnitsOpen(false)
   }
 
-  const valueInUnit = formatByteUnitValue(value, unit)
+  const valueInUnit =
+    value == null
+      ? null
+      : Number.isNaN(value)
+        ? NaN
+        : Number((value / unit.bytes).toFixed(2))
   const placeholderInUnit =
     placeholderBytes === undefined
       ? placeholder
@@ -68,10 +77,9 @@ export default function ByteSizeInput({
 
   return (
     <div className={cn("flex items-stretch", className)}>
-      <Input
-        type="number"
-        min={unit.bytes === 1 ? 1 : 0.01}
-        step={unit.bytes === 1 ? 1 : "any"}
+      <NumberInput
+        {...inputProps}
+        decimal={unit.bytes !== 1}
         value={valueInUnit}
         placeholder={placeholderInUnit}
         onChange={onNumberChange}

--- a/src/components/duration-input.tsx
+++ b/src/components/duration-input.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo, useRef } from "react"
 import * as PopoverPrimitive from "@radix-ui/react-popover"
 
-import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import {
@@ -26,6 +25,8 @@ import {
 import { cn } from "@/lib/utils"
 
 import { useMobile } from "@/hooks/use-mobile"
+
+import NumberInput from "@/components/number-input"
 
 type Unit = { key: string; label: string; seconds: number | null }
 
@@ -110,7 +111,11 @@ function selectUnit(
   return positive ?? allowed[0]
 }
 
-interface DurationInputProps {
+interface DurationInputProps
+  extends Pick<
+    React.ComponentProps<"input">,
+    "id" | "aria-invalid" | "aria-describedby"
+  > {
   value?: number | null
   onChange: (seconds: number | null) => void
   units?: Array<Unit["key"]>
@@ -130,6 +135,7 @@ export default function DurationInput({
   autoFocus,
   disabledTooltip,
   className,
+  ...inputProps
 }: DurationInputProps): React.ReactElement {
   const availableUnits = useMemo(() => {
     if (!units || units.length === 0) return DEFAULT_UNITS
@@ -153,8 +159,16 @@ export default function DurationInput({
       ? Math.max(1, Math.round(value / unit.seconds))
       : null
 
+  const inputValue =
+    typeof value === "number" && Number.isNaN(value)
+      ? NaN
+      : unit.seconds == null || num == null
+        ? null
+        : num
+
   const apply = (n: number | null, u: Unit) => {
-    if (n == null || u.seconds == null) onChange(null)
+    if (n != null && Number.isNaN(n)) onChange(NaN)
+    else if (n == null || u.seconds == null) onChange(null)
     else onChange(n > 0 ? n * u.seconds : null)
   }
 
@@ -165,12 +179,11 @@ export default function DurationInput({
     onChange(seconds)
   }
 
-  const onNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const raw = e.currentTarget.value
-    const next = raw === "" ? null : Number(raw)
+  const onNumberChange = (next: number | null) => {
+    const isNaNValue = next != null && Number.isNaN(next)
 
-    // Switch to a default unit if current unit is unlimited
-    if (unit.seconds == null && next != null) {
+    // switch to a default unit if current unit is unlimited
+    if (!isNaNValue && unit.seconds == null && next != null) {
       const defaultUnit =
         availableUnits.find((u) => u.key === "days") ??
         availableUnits.find((u) => u.seconds != null) ??
@@ -194,8 +207,6 @@ export default function DurationInput({
     }
   }
 
-  const isUnlimited = unit.seconds == null
-
   const content = (
     <div className={cn("flex items-stretch", className)}>
       <Popover
@@ -205,12 +216,10 @@ export default function DurationInput({
         modal={true}
       >
         <PopoverPrimitive.Anchor asChild>
-          <Input
+          <NumberInput
+            {...inputProps}
             ref={inputRef}
-            type="number"
-            min={1}
-            step={1}
-            value={isUnlimited || num == null ? "" : num}
+            value={inputValue}
             onFocus={() => setPresetsOpen(true)}
             onChange={onNumberChange}
             disabled={disabled}

--- a/src/components/groups/form/fields.tsx
+++ b/src/components/groups/form/fields.tsx
@@ -18,6 +18,7 @@ import {
 import { type FieldVariant } from "@/components/forms/field"
 
 import * as Forms from "@/components/forms"
+import NumberInput from "@/components/number-input"
 import MetadataInput from "@/components/metadata-input"
 
 type Descriptions = typeof GroupFormFieldDescriptions
@@ -194,17 +195,10 @@ function MaxUsersField({
             optional
           >
             <FormControl>
-              <Input
-                type="number"
-                min={1}
+              <NumberInput
                 placeholder="e.g. 10"
                 {...field}
-                value={field.value ?? ""}
                 autoFocus={autoFocus}
-                onChange={(e) => {
-                  const value = e.target.value
-                  field.onChange(value === "" ? null : Number(value))
-                }}
               />
             </FormControl>
           </Forms.Field.Header>
@@ -239,17 +233,10 @@ function MaxLicensesField({
             optional
           >
             <FormControl>
-              <Input
-                type="number"
-                min={1}
+              <NumberInput
                 placeholder="e.g. 100"
                 {...field}
-                value={field.value ?? ""}
                 autoFocus={autoFocus}
-                onChange={(e) => {
-                  const value = e.target.value
-                  field.onChange(value === "" ? null : Number(value))
-                }}
               />
             </FormControl>
           </Forms.Field.Header>
@@ -284,17 +271,10 @@ function MaxMachinesField({
             optional
           >
             <FormControl>
-              <Input
-                type="number"
-                min={1}
+              <NumberInput
                 placeholder="e.g. 50"
                 {...field}
-                value={field.value ?? ""}
                 autoFocus={autoFocus}
-                onChange={(e) => {
-                  const value = e.target.value
-                  field.onChange(value === "" ? null : Number(value))
-                }}
               />
             </FormControl>
           </Forms.Field.Header>

--- a/src/components/licenses/form/fields.tsx
+++ b/src/components/licenses/form/fields.tsx
@@ -43,6 +43,7 @@ import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
 import * as Calendars from "@/components/calendars"
 import MultiSelect from "@/components/multi-select"
+import NumberInput from "@/components/number-input"
 import MetadataInput from "@/components/metadata-input"
 import ByteSizeInput from "@/components/byte-size-input"
 
@@ -565,22 +566,14 @@ function MaxMachinesField({
             tooltip={descriptions.maxMachines}
           >
             <FormControl>
-              <Input
+              <NumberInput
                 {...field}
-                type="number"
-                min={1}
                 placeholder={
                   selectedPolicy
                     ? getLimitPlaceholder(selectedPolicy.attributes.maxMachines)
                     : "Inherit from policy"
                 }
-                value={field.value ?? ""}
                 autoFocus={autoFocus}
-                onChange={(e) =>
-                  field.onChange(
-                    e.target.value ? parseInt(e.target.value) : null,
-                  )
-                }
                 disabled={selectedPolicy?.attributes.floating === false}
                 disabledTooltip={
                   LicenseDisabledFormFieldDescriptions.maxMachines
@@ -621,10 +614,8 @@ function MaxProcessesField({
             tooltip={descriptions.maxProcesses}
           >
             <FormControl>
-              <Input
+              <NumberInput
                 {...field}
-                type="number"
-                min={1}
                 placeholder={
                   selectedPolicy
                     ? getLimitPlaceholder(
@@ -632,13 +623,7 @@ function MaxProcessesField({
                       )
                     : "Inherit from policy"
                 }
-                value={field.value ?? ""}
                 autoFocus={autoFocus}
-                onChange={(e) =>
-                  field.onChange(
-                    e.target.value ? parseInt(e.target.value) : null,
-                  )
-                }
               />
             </FormControl>
           </Forms.Field.Header>
@@ -675,22 +660,14 @@ function MaxUsersField({
             tooltip={descriptions.maxUsers}
           >
             <FormControl>
-              <Input
+              <NumberInput
                 {...field}
-                type="number"
-                min={1}
                 placeholder={
                   selectedPolicy
                     ? getLimitPlaceholder(selectedPolicy.attributes.maxUsers)
                     : "Inherit from policy"
                 }
-                value={field.value ?? ""}
                 autoFocus={autoFocus}
-                onChange={(e) =>
-                  field.onChange(
-                    e.target.value ? parseInt(e.target.value) : null,
-                  )
-                }
               />
             </FormControl>
           </Forms.Field.Header>
@@ -727,22 +704,14 @@ function MaxCoresField({
             tooltip={descriptions.maxCores}
           >
             <FormControl>
-              <Input
+              <NumberInput
                 {...field}
-                type="number"
-                min={1}
                 placeholder={
                   selectedPolicy
                     ? getLimitPlaceholder(selectedPolicy.attributes.maxCores)
                     : "Inherit from policy"
                 }
-                value={field.value ?? ""}
                 autoFocus={autoFocus}
-                onChange={(e) =>
-                  field.onChange(
-                    e.target.value ? parseInt(e.target.value) : null,
-                  )
-                }
               />
             </FormControl>
           </Forms.Field.Header>
@@ -864,22 +833,14 @@ function MaxUsesField({
             tooltip={descriptions.maxUses}
           >
             <FormControl>
-              <Input
+              <NumberInput
                 {...field}
-                type="number"
-                min={1}
                 placeholder={
                   selectedPolicy
                     ? getLimitPlaceholder(selectedPolicy.attributes.maxUses)
                     : "Inherit from policy"
                 }
-                value={field.value ?? ""}
                 autoFocus={autoFocus}
-                onChange={(e) =>
-                  field.onChange(
-                    e.target.value ? parseInt(e.target.value) : null,
-                  )
-                }
               />
             </FormControl>
           </Forms.Field.Header>

--- a/src/components/machines/form/fields.tsx
+++ b/src/components/machines/form/fields.tsx
@@ -23,6 +23,7 @@ import { type FieldVariant } from "@/components/forms/field"
 
 import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
+import NumberInput from "@/components/number-input"
 import MetadataInput from "@/components/metadata-input"
 import ByteSizeInput from "@/components/byte-size-input"
 
@@ -468,17 +469,10 @@ function CoresField({
             optional
           >
             <FormControl>
-              <Input
-                type="number"
-                min={1}
+              <NumberInput
                 placeholder="e.g. 4"
                 {...field}
-                value={field.value ?? ""}
                 autoFocus={autoFocus}
-                onChange={(e) => {
-                  const value = e.target.value
-                  field.onChange(value === "" ? null : Number(value))
-                }}
               />
             </FormControl>
           </Forms.Field.Header>

--- a/src/components/number-input.tsx
+++ b/src/components/number-input.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+
+import { Input } from "@/components/ui/input"
+
+// convert a number or null into a raw string
+function toRawString(value: number | null | undefined): string {
+  return value == null || Number.isNaN(value) ? "" : String(value)
+}
+
+// parse a raw string into a number or null
+function parseRaw(raw: string): number | null {
+  const trimmed = raw.trim()
+  return trimmed === "" ? null : Number(trimmed)
+}
+
+type NumberInputProps = Omit<
+  React.ComponentProps<typeof Input>,
+  "type" | "value" | "onChange" | "inputMode"
+> & {
+  value?: number | null
+  onChange?: (value: number | null) => void
+  decimal?: boolean
+}
+
+export default function NumberInput({
+  value = null,
+  onChange,
+  decimal = false,
+  ...props
+}: NumberInputProps) {
+  const [raw, setRaw] = React.useState(() => toRawString(value))
+
+  const incomingIsNaN = typeof value === "number" && Number.isNaN(value)
+  if (!incomingIsNaN && !Object.is(parseRaw(raw), value)) {
+    setRaw(toRawString(value))
+  }
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const next = event.target.value
+    setRaw(next)
+    onChange?.(parseRaw(next))
+  }
+
+  return (
+    <Input
+      {...props}
+      type="text"
+      inputMode={decimal ? "decimal" : "numeric"}
+      value={raw}
+      onChange={handleChange}
+    />
+  )
+}

--- a/src/components/policies/form/fields.tsx
+++ b/src/components/policies/form/fields.tsx
@@ -60,6 +60,7 @@ import { type FieldVariant } from "@/components/forms/field"
 
 import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
+import NumberInput from "@/components/number-input"
 import MetadataInput from "@/components/metadata-input"
 import NullableSelect from "@/components/nullable-select"
 import DurationInput from "@/components/duration-input"
@@ -1523,12 +1524,9 @@ function MaxMachinesField({
             tooltip={descriptions.maxMachines}
           >
             <FormControl>
-              <Input
-                type="number"
-                min={1}
+              <NumberInput
                 placeholder="e.g. 1"
                 {...field}
-                value={field.value ?? ""}
                 autoFocus={autoFocus}
               />
             </FormControl>
@@ -2305,12 +2303,9 @@ function MaxProcessesField({
             tooltip={descriptions.maxProcesses}
           >
             <FormControl>
-              <Input
-                type="number"
-                min={1}
+              <NumberInput
                 placeholder="e.g. 1"
                 {...field}
-                value={field.value ?? ""}
                 autoFocus={autoFocus}
               />
             </FormControl>
@@ -2359,12 +2354,9 @@ function MaxUsersField({
             tooltip={descriptions.maxUsers}
           >
             <FormControl>
-              <Input
-                type="number"
-                min={1}
+              <NumberInput
                 placeholder="e.g. 1"
                 {...field}
-                value={field.value ?? ""}
                 autoFocus={autoFocus}
               />
             </FormControl>
@@ -2413,12 +2405,9 @@ function MaxUsesField({
             tooltip={descriptions.maxUses}
           >
             <FormControl>
-              <Input
-                type="number"
-                min={1}
+              <NumberInput
                 placeholder="e.g. 1"
                 {...field}
-                value={field.value ?? ""}
                 autoFocus={autoFocus}
               />
             </FormControl>
@@ -2467,12 +2456,9 @@ function MaxCoresField({
             tooltip={descriptions.maxCores}
           >
             <FormControl>
-              <Input
-                type="number"
-                min={1}
+              <NumberInput
                 placeholder="e.g. 1"
                 {...field}
-                value={field.value ?? ""}
                 autoFocus={autoFocus}
               />
             </FormControl>
@@ -2702,15 +2688,7 @@ function CheckInIntervalCountField({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span tabIndex={0}>
-                      <Input
-                        type="number"
-                        min={1}
-                        max={365}
-                        placeholder="1 - 365"
-                        {...field}
-                        value={field.value ?? ""}
-                        disabled
-                      />
+                      <NumberInput placeholder="1 - 365" {...field} disabled />
                     </span>
                   </TooltipTrigger>
                   <TooltipContent className="max-w-80 bg-background-4 text-pretty text-content-muted">
@@ -2718,13 +2696,9 @@ function CheckInIntervalCountField({
                   </TooltipContent>
                 </Tooltip>
               ) : (
-                <Input
-                  type="number"
-                  min={1}
-                  max={365}
+                <NumberInput
                   placeholder="1 - 365"
                   {...field}
-                  value={field.value ?? ""}
                   autoFocus={autoFocus}
                 />
               )}

--- a/src/components/policies/form/fields.tsx
+++ b/src/components/policies/form/fields.tsx
@@ -885,17 +885,12 @@ function DurationField({
               <DurationInput
                 value={field.value}
                 onChange={(value) => {
+                  field.onChange(value)
                   if (mode === PolicyMode.Create && value === null) {
-                    form.reset({
-                      ...form.getValues(),
-                      duration: value,
-                      expirationStrategy: undefined,
-                      expirationBasis: undefined,
-                      renewalBasis: undefined,
-                      transferStrategy: undefined,
-                    })
-                  } else {
-                    field.onChange(value)
+                    form.resetField("expirationStrategy")
+                    form.resetField("expirationBasis")
+                    form.resetField("renewalBasis")
+                    form.resetField("transferStrategy")
                   }
                 }}
                 units={["unlimited", "days", "weeks", "months", "years"]}
@@ -1200,17 +1195,12 @@ function RequireHeartbeatField({
               }
               onValueChange={(value) => {
                 const newValue = value === "" ? undefined : value === "true"
+                field.onChange(newValue)
                 if (mode === PolicyMode.Create && !newValue) {
-                  form.reset({
-                    ...form.getValues(),
-                    requireHeartbeat: newValue,
-                    heartbeatDuration: undefined,
-                    heartbeatCullStrategy: undefined,
-                    heartbeatBasis: undefined,
-                    heartbeatResurrectionStrategy: undefined,
-                  })
-                } else {
-                  field.onChange(newValue)
+                  form.resetField("heartbeatDuration")
+                  form.resetField("heartbeatCullStrategy")
+                  form.resetField("heartbeatBasis")
+                  form.resetField("heartbeatResurrectionStrategy")
                 }
               }}
             >
@@ -2614,14 +2604,9 @@ function CheckInIntervalField({
             <NullableSelect<CheckInInterval>
               value={field.value}
               onChange={(value) => {
+                field.onChange(value)
                 if (mode === PolicyMode.Create && value === null) {
-                  form.reset({
-                    ...form.getValues(),
-                    checkInInterval: value,
-                    checkInIntervalCount: undefined,
-                  })
-                } else {
-                  field.onChange(value)
+                  form.resetField("checkInIntervalCount")
                 }
               }}
               invalid={!!fieldState.error}

--- a/src/components/tokens/form/fields.tsx
+++ b/src/components/tokens/form/fields.tsx
@@ -57,6 +57,7 @@ import * as Forms from "@/components/forms"
 import * as Search from "@/components/search"
 import * as Calendars from "@/components/calendars"
 import MultiSelect from "@/components/multi-select"
+import NumberInput from "@/components/number-input"
 import { CardSelector, CardOption } from "@/components/card-selector"
 
 const BEARER_KIND_ICONS: Record<TokenBearerKind, ReactNode> = {
@@ -495,17 +496,7 @@ function MaxActivationsField({
             tooltip={TokenFormFieldDescriptions.maxActivations}
           >
             <FormControl>
-              <Input
-                type="number"
-                min={0}
-                value={field.value ?? ""}
-                placeholder="Unlimited"
-                onChange={(e) =>
-                  field.onChange(
-                    e.target.value ? parseInt(e.target.value) : null,
-                  )
-                }
-              />
+              <NumberInput {...field} placeholder="Unlimited" />
             </FormControl>
           </Forms.Field.Header>
           <FormMessage />
@@ -535,17 +526,7 @@ function MaxDeactivationsField({
             tooltip={TokenFormFieldDescriptions.maxDeactivations}
           >
             <FormControl>
-              <Input
-                type="number"
-                min={0}
-                value={field.value ?? ""}
-                placeholder="Unlimited"
-                onChange={(e) =>
-                  field.onChange(
-                    e.target.value ? parseInt(e.target.value) : null,
-                  )
-                }
-              />
+              <NumberInput {...field} placeholder="Unlimited" />
             </FormControl>
           </Forms.Field.Header>
           <FormMessage />

--- a/src/schemas/artifacts.ts
+++ b/src/schemas/artifacts.ts
@@ -2,12 +2,13 @@ import { FieldPath } from "react-hook-form"
 import { z } from "zod"
 
 import { CombineFormValues } from "@/types/forms"
+import { CoercedNumberSchema } from "@/schemas/numbers"
 import { MetadataPairsSchema } from "@/schemas/metadata"
 
 const BaseShape = z.object({
   filename: z.string().trim().min(1, "Filename is required"),
   filetype: z.string().trim().nullable().optional(),
-  filesize: z.coerce.number().int().min(0).nullable().optional(),
+  filesize: CoercedNumberSchema.int().min(0).nullable().optional(),
   platform: z.string().trim().nullable().optional(),
   arch: z.string().trim().nullable().optional(),
   signature: z.string().trim().nullable().optional(),
@@ -22,7 +23,7 @@ const ReleaseShape = z.object({
 const CreateShape = BaseShape.merge(ReleaseShape)
 
 const UpdateShape = z.object({
-  filesize: z.coerce.number().int().min(0).nullable().optional(),
+  filesize: CoercedNumberSchema.int().min(0).nullable().optional(),
   signature: z.string().trim().nullable().optional(),
   checksum: z.string().trim().nullable().optional(),
   metadata: MetadataPairsSchema.optional(),

--- a/src/schemas/groups.ts
+++ b/src/schemas/groups.ts
@@ -2,13 +2,15 @@ import { FieldPath } from "react-hook-form"
 import { z } from "zod"
 
 import { CombineFormValues } from "@/types/forms"
+
+import { NumberSchema } from "@/schemas/numbers"
 import { MetadataPairsSchema } from "@/schemas/metadata"
 
 const BaseShape = z.object({
   name: z.string().trim().min(1, "Name is required"),
-  maxUsers: z.number().int().positive().nullable().optional(),
-  maxLicenses: z.number().int().positive().nullable().optional(),
-  maxMachines: z.number().int().positive().nullable().optional(),
+  maxUsers: NumberSchema.int().positive().nullable().optional(),
+  maxLicenses: NumberSchema.int().positive().nullable().optional(),
+  maxMachines: NumberSchema.int().positive().nullable().optional(),
   metadata: MetadataPairsSchema.optional(),
 })
 

--- a/src/schemas/licenses.ts
+++ b/src/schemas/licenses.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 
 import { SigningAlgorithm } from "@/types/files"
 import { CombineFormValues } from "@/types/forms"
+import { NumberSchema } from "@/schemas/numbers"
 import { MetadataPairsSchema } from "@/schemas/metadata"
 
 const BaseShape = z.object({
@@ -15,13 +16,13 @@ const BaseShape = z.object({
   expiry: z.string().nullable().optional(),
   suspended: z.boolean().optional().nullable().default(null),
   protected: z.boolean().optional().nullable().default(null),
-  maxMachines: z.number().int().positive().nullable().optional(),
-  maxProcesses: z.number().int().positive().nullable().optional(),
-  maxUsers: z.number().int().positive().nullable().optional(),
-  maxCores: z.number().int().positive().nullable().optional(),
-  maxMemory: z.number().int().positive().nullable().optional(),
-  maxDisk: z.number().int().positive().nullable().optional(),
-  maxUses: z.number().int().positive().nullable().optional(),
+  maxMachines: NumberSchema.int().positive().nullable().optional(),
+  maxProcesses: NumberSchema.int().positive().nullable().optional(),
+  maxUsers: NumberSchema.int().positive().nullable().optional(),
+  maxCores: NumberSchema.int().positive().nullable().optional(),
+  maxMemory: NumberSchema.int().positive().nullable().optional(),
+  maxDisk: NumberSchema.int().positive().nullable().optional(),
+  maxUses: NumberSchema.int().positive().nullable().optional(),
   permissions: z.array(z.string()).nullable().optional(),
   metadata: MetadataPairsSchema.optional(),
   ownerId: z.string().nullable().optional(),
@@ -96,7 +97,7 @@ const CheckOutShape = z.object({
   includeEnabled: z.boolean().default(false),
   include: z.array(z.string()).default([]),
   ttlEnabled: z.boolean().default(false),
-  ttl: z.number().nullable().default(null),
+  ttl: NumberSchema.nullable().default(null),
   encryptEnabled: z.boolean().default(false),
   algorithm: z.string().default(SigningAlgorithm.Ed25519),
 })

--- a/src/schemas/machines.ts
+++ b/src/schemas/machines.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 
 import { SigningAlgorithm } from "@/types/files"
 import { CombineFormValues } from "@/types/forms"
+import { NumberSchema } from "@/schemas/numbers"
 import { MetadataPairsSchema } from "@/schemas/metadata"
 
 const BaseShape = z.object({
@@ -10,9 +11,9 @@ const BaseShape = z.object({
   ip: z.string().trim().nullable().optional(),
   hostname: z.string().trim().nullable().optional(),
   platform: z.string().trim().nullable().optional(),
-  cores: z.number().int().positive().nullable().optional(),
-  memory: z.number().int().positive().nullable().optional(),
-  disk: z.number().int().positive().nullable().optional(),
+  cores: NumberSchema.int().positive().nullable().optional(),
+  memory: NumberSchema.int().positive().nullable().optional(),
+  disk: NumberSchema.int().positive().nullable().optional(),
   metadata: MetadataPairsSchema.optional(),
   groupId: z.string().nullable().optional(),
   ownerId: z.string().nullable().optional(),
@@ -62,7 +63,7 @@ const CheckOutShape = z.object({
   includeEnabled: z.boolean().default(false),
   include: z.array(z.string()).default([]),
   ttlEnabled: z.boolean().default(false),
-  ttl: z.number().nullable().default(null),
+  ttl: NumberSchema.nullable().default(null),
   encryptEnabled: z.boolean().default(false),
   algorithm: z.string().default(SigningAlgorithm.Ed25519),
 })

--- a/src/schemas/numbers.ts
+++ b/src/schemas/numbers.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const NumberSchema = z.number({ invalid_type_error: "Must be a number" })
+export const CoercedNumberSchema = z.coerce.number({
+  invalid_type_error: "Must be a number",
+})

--- a/src/schemas/policies.ts
+++ b/src/schemas/policies.ts
@@ -26,6 +26,7 @@ import {
   AccessTemplates,
   MeteredTemplates,
 } from "@/types/policies"
+import { CoercedNumberSchema } from "@/schemas/numbers"
 import { MetadataPairsSchema, recordToMetadataPairs } from "@/schemas/metadata"
 
 // NB(ezekg) zod schemas have _def.typeName at runtime but ZodTypeDef
@@ -84,10 +85,10 @@ export const BaseShape = z.object({
     .nonnegative()
     .nullish()
     .transform((value) => (value == null ? value : value === 0 ? null : value)),
-  maxUses: z.coerce.number().int().positive().nullish(),
-  maxCores: z.coerce.number().int().positive().nullish(),
-  maxMemory: z.coerce.number().int().positive().nullish(),
-  maxDisk: z.coerce.number().int().positive().nullish(),
+  maxUses: CoercedNumberSchema.int().positive().nullish(),
+  maxCores: CoercedNumberSchema.int().positive().nullish(),
+  maxMemory: CoercedNumberSchema.int().positive().nullish(),
+  maxDisk: CoercedNumberSchema.int().positive().nullish(),
   protected: z.boolean().default(true),
 
   requireHeartbeat: z.boolean().default(false),
@@ -386,7 +387,7 @@ export type TemplateFormValues = z.input<typeof TemplateSchema>
 export type TemplateValues = z.output<typeof TemplateSchema>
 
 export const TimedShape = z.object({
-  duration: z.coerce.number().int().positive().nullish().default(1209600),
+  duration: CoercedNumberSchema.int().positive().nullish().default(1209600),
   renewalBasis: z
     .nativeEnum(RenewalBasis)
     .nullish()
@@ -447,7 +448,7 @@ export const PerpetualFallbackShape = z.object({
 export const NodeLockedShape = z.object({
   requireFingerprintScope: z.boolean().default(true),
   floating: z.boolean().default(true),
-  maxMachines: z.coerce.number().int().min(1).optional().default(1),
+  maxMachines: CoercedNumberSchema.int().min(1).optional().default(1),
 })
 
 export const NodeLockedRules = <TInput, TOutput extends BaseValues>(

--- a/src/schemas/tokens.ts
+++ b/src/schemas/tokens.ts
@@ -3,14 +3,15 @@ import { z } from "zod"
 
 import { CombineFormValues } from "@/types/forms"
 import { TokenBearerKind } from "@/types/tokens"
+import { NumberSchema } from "@/schemas/numbers"
 
 const BaseShape = z.object({
   bearerKind: z.nativeEnum(TokenBearerKind),
   bearerId: z.string().trim().nullable().optional(),
   name: z.string().trim().nullable().optional(),
   expiry: z.string().nullable().optional(),
-  maxActivations: z.number().int().nullable().optional(),
-  maxDeactivations: z.number().int().nullable().optional(),
+  maxActivations: NumberSchema.int().nullable().optional(),
+  maxDeactivations: NumberSchema.int().nullable().optional(),
   permissions: z.array(z.string()).nullable().optional(),
 })
 


### PR DESCRIPTION
Closes #174. Also exposed a bug when working with Policy `duration` where we could break the input and prevent the user from being able to validate and finish policy creation. This occurred in a couple other policy fields as well, such as `requireHeartbeat` and `checkInInterval`, which was caused by resetting the form when the field's value met certain conditions (which we were using to e.g. reset `requireHeartbeat`s related fields to their default values when it was `false`). Fixed to just reset the fields now instead of the form, so this also closes #314.

`asdasda` has no power here:
<img width="700" src="https://github.com/user-attachments/assets/0aad41d1-ac7b-4610-a1fc-f7a118898d22" />
