### PR TITLE
Add duration tooltip for displaying raw seconds

### DIFF
--- a/src/components/attribute/value.tsx
+++ b/src/components/attribute/value.tsx
@@ -1,12 +1,12 @@
-import { formatDuration } from "date-fns"
-
 import TooltipBadge from "@/components/tooltip-badge"
+import { DurationPopover } from "@/components/duration"
 import { TimestampPopover } from "@/components/timestamp"
 
 import { truncateKey } from "@/lib/licenses"
-import { cn, capitalize, secondsToParts, labelize } from "@/lib/utils"
+import { cn, capitalize, labelize } from "@/lib/utils"
 import { formatByteSize, formatRawByteSize } from "@/lib/bytes"
 import { formatRelativeTime, formatUtcDate } from "@/lib/timestamps"
+import { toSeconds, formatCompactDurationLabel } from "@/lib/temporal"
 
 import { useMobile } from "@/hooks/use-mobile"
 
@@ -96,15 +96,42 @@ export default function AttributeValue({
     )
   }
 
+  if (type === "duration") {
+    const numeric =
+      typeof raw === "number"
+        ? raw
+        : typeof raw === "string"
+          ? Number(raw)
+          : null
+    const seconds = toSeconds(numeric)
+
+    if (seconds == null) {
+      return (
+        <TooltipBadge
+          value={emptyLabel}
+          variant="disabled"
+          tooltip={tooltip}
+          className={className}
+        />
+      )
+    }
+
+    return (
+      <TooltipBadge
+        value={formatCompactDurationLabel(seconds)}
+        variant={forceDisabled ? "disabled" : undefined}
+        interactive
+        content={<DurationPopover value={seconds} tooltip={tooltip} />}
+        contentClassName="w-80 max-w-none bg-popover p-3"
+        className={className}
+      />
+    )
+  }
+
   let value: string
   let hoverValue: string | undefined
 
   switch (type) {
-    case "duration": {
-      const parts = secondsToParts(Number(raw))
-      value = parts == null ? "Not set" : formatDuration(parts, { zero: false })
-      break
-    }
     case "boolean": {
       const bool = Boolean(raw)
       value = isUnset ? emptyLabel : bool ? "Enabled" : "Disabled"

--- a/src/components/duration.tsx
+++ b/src/components/duration.tsx
@@ -1,0 +1,48 @@
+import { Copy } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+
+import { copyToClipboard } from "@/lib/clipboard"
+import { secondsLabel, formatFullDurationLabel } from "@/lib/temporal"
+
+export function DurationPopover({
+  value,
+  tooltip,
+}: {
+  value: number
+  tooltip?: React.ReactNode
+}) {
+  const raw = String(value)
+
+  return (
+    <div className="flex flex-col text-xs">
+      {tooltip && (
+        <>
+          <p className="text-pretty text-content-loud">{tooltip}</p>
+          <Separator className="mt-3 mb-2.5" />
+        </>
+      )}
+      <div className="flex items-center justify-between">
+        <span className="min-w-0 flex-1 truncate text-content-muted">
+          <span className="font-mono">{raw}</span> {secondsLabel(value)}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          title="Copy duration in seconds"
+          onClick={async (e) => {
+            e.stopPropagation() // prevent click from propagating, e.g. selecting a table row
+            await copyToClipboard(raw)
+          }}
+          className="-my-1 -mr-1 size-6 shrink-0"
+        >
+          <Copy className="size-3.5" />
+        </Button>
+      </div>
+      <span className="min-w-0 text-pretty text-content-normal">
+        {formatFullDurationLabel(value)}
+      </span>
+    </div>
+  )
+}

--- a/src/components/timestamp.tsx
+++ b/src/components/timestamp.tsx
@@ -156,7 +156,7 @@ export function TimestampPopover({
       {tooltip && (
         <>
           <p className="text-pretty text-content-loud">{tooltip}</p>
-          <Separator className="my-2" />
+          <Separator className="my-2.5" />
         </>
       )}
       <div className="flex items-center justify-between">

--- a/src/lib/machines.ts
+++ b/src/lib/machines.ts
@@ -16,7 +16,7 @@ export const machineAttributeTypeSchema: Record<
   disk: "bytes",
   requireHeartbeat: "boolean",
   heartbeatStatus: "string",
-  heartbeatDuration: "number",
+  heartbeatDuration: "duration",
   lastHeartbeat: "date",
   nextHeartbeat: "date",
   lastCheckOut: "date",

--- a/src/lib/processes.ts
+++ b/src/lib/processes.ts
@@ -10,5 +10,5 @@ export const processAttributeTypeSchema: Record<
   status: "string",
   lastHeartbeat: "date",
   nextHeartbeat: "date",
-  interval: "number",
+  interval: "duration",
 }

--- a/src/lib/temporal.ts
+++ b/src/lib/temporal.ts
@@ -1,4 +1,4 @@
-import type { Duration } from "date-fns"
+import { formatDuration, type Duration } from "date-fns"
 
 export const SECONDS_PER_MINUTE = 60
 export const SECONDS_PER_HOUR = 3600
@@ -40,4 +40,117 @@ export function parseISODuration(isoDuration: string): Duration {
 
     return obj
   }, {})
+}
+
+type DurationFormatOptions = {
+  emptyLabel?: string
+}
+
+const DURATION_UNITS: [keyof Duration, number][] = [
+  ["years", SECONDS_PER_YEAR],
+  ["months", SECONDS_PER_MONTH],
+  ["weeks", SECONDS_PER_WEEK],
+  ["days", SECONDS_PER_DAY],
+  ["hours", SECONDS_PER_HOUR],
+  ["minutes", SECONDS_PER_MINUTE],
+  ["seconds", 1],
+]
+
+const EXACT_UNITS = DURATION_UNITS.filter(
+  ([unit]) => unit !== "years" && unit !== "months",
+)
+
+// convert a number of seconds into a whole number of seconds
+export function toSeconds(total?: number | null): number | null {
+  if (total == null || !Number.isFinite(total)) return null
+
+  const seconds = Math.floor(total)
+
+  return seconds > 0 ? seconds : null
+}
+
+// break a number of seconds down into its component units
+// e.g. 1234567 seconds would return { days: 14, hours: 6, minutes: 56, seconds: 7 }
+function decompose(
+  seconds: number,
+  units: [keyof Duration, number][],
+): Duration {
+  let remaining = seconds
+  const parts: Duration = {}
+
+  for (const [unit, size] of units) {
+    const count = Math.trunc(remaining / size)
+    if (count > 0) {
+      parts[unit] = count
+      remaining -= count * size
+    }
+  }
+
+  return parts
+}
+
+// find the index of the smallest unit that has a non-zero value,
+// e.g. { days: 1, hours: 2, minutes: 3 } would return 2 for minutes
+function smallestUnitIndex(parts: Duration): number {
+  for (let i = DURATION_UNITS.length - 1; i >= 0; i--) {
+    if (parts[DURATION_UNITS[i][0]]) return i
+  }
+
+  return -1
+}
+
+function secondsToParts(seconds: number): Duration {
+  // when the value is a whole number of a single unit, show just
+  // that unit so it reads back the way it was entered, e.g. 1 year
+  for (const [unit, size] of DURATION_UNITS) {
+    if (size > 1 && seconds % size === 0) {
+      const part: Duration = {}
+      part[unit] = seconds / size
+      return part
+    }
+  }
+
+  // otherwise break it down across units
+  return decompose(seconds, DURATION_UNITS)
+}
+
+function secondsToFullParts(seconds: number): Duration {
+  const calendar = decompose(seconds, DURATION_UNITS)
+  const exact = decompose(seconds, EXACT_UNITS)
+
+  // keep years and months unless dropping them reads more clearly,
+  // e.g. 1 year, 2 months, 3 days vs 14 months, 3 days
+  return smallestUnitIndex(exact) < smallestUnitIndex(calendar)
+    ? exact
+    : calendar
+}
+
+// compact duration, e.g. 2 weeks
+export function formatCompactDurationLabel(
+  total?: number | null,
+  { emptyLabel = "--" }: DurationFormatOptions = {},
+): string {
+  const seconds = toSeconds(total)
+  if (seconds == null) return emptyLabel
+
+  return formatDuration(secondsToParts(seconds), { zero: false })
+}
+
+// full duration, e.g. 1 year, 2 months, 3 days, 4 hours, 5 minutes, 6 seconds
+export function formatFullDurationLabel(
+  total?: number | null,
+  { emptyLabel = "--" }: DurationFormatOptions = {},
+): string {
+  const seconds = toSeconds(total)
+  if (seconds == null) return emptyLabel
+
+  return formatDuration(secondsToFullParts(seconds), {
+    zero: false,
+    delimiter: ", ",
+  })
+}
+
+// seconds pluralization, e.g. 1 second vs 2 seconds
+export function secondsLabel(seconds: number): string {
+  return seconds === 1 ? "second" : "seconds"
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,15 +1,5 @@
 import { clsx, type ClassValue } from "clsx"
-import type { Duration } from "date-fns"
 import { twMerge } from "tailwind-merge"
-
-import {
-  SECONDS_PER_MINUTE,
-  SECONDS_PER_HOUR,
-  SECONDS_PER_DAY,
-  SECONDS_PER_WEEK,
-  SECONDS_PER_MONTH,
-  SECONDS_PER_YEAR,
-} from "@/lib/temporal"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -109,44 +99,6 @@ export function capitalize(s: string): string {
 export function labelize(value?: string | null, map?: Record<string, string>) {
   if (!value) return "--"
   return (map && map[value]) || titleCase(value)
-}
-
-const DURATION_UNITS: [keyof Duration, number][] = [
-  ["years", SECONDS_PER_YEAR],
-  ["months", SECONDS_PER_MONTH],
-  ["weeks", SECONDS_PER_WEEK],
-  ["days", SECONDS_PER_DAY],
-  ["hours", SECONDS_PER_HOUR],
-  ["minutes", SECONDS_PER_MINUTE],
-  ["seconds", 1],
-]
-
-export function secondsToParts(total?: number | null): Duration | null {
-  if (total == null || total === 0) return null
-
-  const seconds = Math.max(0, Math.floor(total))
-
-  // when the value is a whole number of a single unit, show just
-  // that unit so it reads back the way it was entered, e.g. 1 year
-  for (const [unit, size] of DURATION_UNITS) {
-    if (size > 1 && seconds % size === 0) {
-      const part: Duration = {}
-      part[unit] = seconds / size
-      return part
-    }
-  }
-
-  // otherwise break it down across units
-  let remaining = seconds
-  const parts: Duration = {}
-  for (const [unit, size] of DURATION_UNITS) {
-    const count = Math.trunc(remaining / size)
-    if (count > 0) {
-      parts[unit] = count
-      remaining -= count * size
-    }
-  }
-  return parts
 }
 
 export function splitLastWord(s: string): { head: string; tail: string } {

--- a/src/pages/app/process/details.tsx
+++ b/src/pages/app/process/details.tsx
@@ -314,7 +314,7 @@ export default function ProcessDetails() {
                         variant="none"
                         value={
                           <Attribute.Value
-                            type="number"
+                            type="duration"
                             value={process.attributes.interval}
                             tooltip={ProcessAttributeDescriptions.interval}
                           />


### PR DESCRIPTION
Closes #298, closes #36.

Adds a duration tooltip to policy duration, machine heartbeat duration, and process interval.

<img width="500" src="https://github.com/user-attachments/assets/bbc37866-3a0b-4527-b56a-aedd9a1866e8" />
<img width="500" src="https://github.com/user-attachments/assets/78fac2c2-639b-468b-ae12-4a13e465f7d9" />
<img width="500" src="https://github.com/user-attachments/assets/182ddd0e-b8fd-4143-9a91-6cd6ead28c0f" />
