### PR TITLE
Fix list state persistence

### DIFF
--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -96,14 +96,6 @@ export default function DataTable<T extends TableResource>({
     },
     manualPagination: true,
     pageCount: -1,
-    onPaginationChange: (updater) => {
-      const current = {
-        pageIndex: table.page - 1,
-        pageSize: table.pageSize,
-      }
-      const next = typeof updater === "function" ? updater(current) : updater
-      table.setPage(next.pageIndex + 1)
-    },
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -35,14 +35,14 @@ import { cn } from "@/lib/utils"
 import { TableColumns, TableResource } from "@/lib/tables"
 
 import { useMobile } from "@/hooks/use-mobile"
-import { DataTableState } from "@/hooks/use-data-table"
+import { PaginationState } from "@/hooks/use-pagination"
 
 import * as Motion from "@/components/motion"
 import * as Skeletons from "@/components/skeletons"
 
 type DataTableProps<T extends TableResource> = {
   data: T[]
-  table: DataTableState
+  pagination: PaginationState
   columns: TableColumns<T>
   onRowClick?: (row: T) => void
   staticColumns?: number
@@ -52,7 +52,7 @@ type DataTableProps<T extends TableResource> = {
 
 export default function DataTable<T extends TableResource>({
   data,
-  table,
+  pagination,
   columns,
   onRowClick,
   staticColumns = 1,
@@ -69,20 +69,20 @@ export default function DataTable<T extends TableResource>({
   const containerRef = useRef<HTMLDivElement>(null) // For measuring available container width and observing resizes (e.g. sidebar toggle)
 
   // Track which pages have already animated so revisiting doesn't animate again
-  const prevPageRef = useRef(table.page)
+  const prevPageRef = useRef(pagination.page)
   const directionRef = useRef<1 | -1>(1)
   const animatedPagesRef = useRef(new Set<number>())
 
-  if (table.page !== prevPageRef.current) {
-    directionRef.current = table.page > prevPageRef.current ? 1 : -1
+  if (pagination.page !== prevPageRef.current) {
+    directionRef.current = pagination.page > prevPageRef.current ? 1 : -1
     animatedPagesRef.current.add(prevPageRef.current)
-    prevPageRef.current = table.page
+    prevPageRef.current = pagination.page
 
     // Reset horizontal scroll when changing pages
     setScrollIndex(0)
   }
 
-  const shouldAnimate = !animatedPagesRef.current.has(table.page)
+  const shouldAnimate = !animatedPagesRef.current.has(pagination.page)
 
   const [columnWidths, setColumnWidths] = useState<number[]>([]) // Widths of each column for calculating scroll offsets
   const headerCellRefs = useRef<(HTMLTableCellElement | null)[]>([]) // For measuring rendered header cell widths to determine column widths
@@ -92,7 +92,10 @@ export default function DataTable<T extends TableResource>({
     columns,
     state: {
       sorting,
-      pagination: { pageIndex: table.page - 1, pageSize: table.pageSize },
+      pagination: {
+        pageIndex: pagination.page - 1,
+        pageSize: pagination.pageSize,
+      },
     },
     manualPagination: true,
     pageCount: -1,
@@ -181,7 +184,7 @@ export default function DataTable<T extends TableResource>({
     return () => {
       observer.disconnect()
     }
-  }, [data, table.page, measureColumns])
+  }, [data, pagination.page, measureColumns])
 
   function getCellStyle(columnIndex: number): React.CSSProperties {
     // Render static columns above scrollable so they don't get visually cut off when scrolling
@@ -223,7 +226,7 @@ export default function DataTable<T extends TableResource>({
             className="relative overflow-hidden"
             style={{ contain: "inline-size" }}
           >
-            <div key={table.page} className="relative w-full">
+            <div key={pagination.page} className="relative w-full">
               <table className="min-w-full border-separate border-spacing-0 text-sm">
                 <TableHeader>
                   {tableInstance.getHeaderGroups().map((group) => (

--- a/src/components/environments/view/list.tsx
+++ b/src/components/environments/view/list.tsx
@@ -3,7 +3,7 @@ import { Environment } from "@/types/environments"
 import { useListEnvironments } from "@/queries/environments"
 
 import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
-import { useDataTable } from "@/hooks/use-data-table"
+import { usePagination } from "@/hooks/use-pagination"
 import { useEnvironmentTableColumns } from "@/hooks/use-environment-table-columns"
 
 import DataTable from "@/components/data-table"
@@ -17,8 +17,8 @@ interface EnvironmentsListProps {
 export default function EnvironmentsList({
   onViewDetails,
 }: EnvironmentsListProps) {
-  const table = useDataTable()
-  const { page, setPage } = table
+  const pagination = usePagination()
+  const { page, setPage } = pagination
   const { cursor, goToPage } = useCursors(page, setPage)
   const columns = useEnvironmentTableColumns()
 
@@ -37,7 +37,7 @@ export default function EnvironmentsList({
     <>
       <DataTable
         data={environments}
-        table={table}
+        pagination={pagination}
         columns={columns}
         isLoading={isLoading}
         onRowClick={onViewDetails}

--- a/src/components/tokens/dialog/internal.tsx
+++ b/src/components/tokens/dialog/internal.tsx
@@ -9,7 +9,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog"
 
-import { useDataTable } from "@/hooks/use-data-table"
+import { usePagination } from "@/hooks/use-pagination"
 import { useCursors, cursorFromLink } from "@/hooks/use-cursors"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 import { useTokenTableColumns } from "@/hooks/use-token-table-columns"
@@ -32,8 +32,8 @@ export default function InternalTokensDialog({
   open,
   onOpenChange,
 }: InternalTokensDialogProps) {
-  const table = useDataTable()
-  const { page, setPage } = table
+  const pagination = usePagination()
+  const { page, setPage } = pagination
   const { cursor, reset, goToPage } = useCursors(page, setPage)
   const columns = useTokenTableColumns()
   const navigateToResource = useResourceNavigate()
@@ -82,7 +82,7 @@ export default function InternalTokensDialog({
         <ScrollArea className="min-h-0 flex-1">
           <DataTable<Token>
             data={tokens}
-            table={table}
+            pagination={pagination}
             columns={columns}
             isLoading={isLoading}
             onRowClick={handleNavigate}

--- a/src/hooks/use-cursors.ts
+++ b/src/hooks/use-cursors.ts
@@ -6,8 +6,7 @@ import {
 } from "@tanstack/react-router"
 
 import { cursorSearch } from "@/lib/pagination"
-
-import { usePageSize, type DataTableState } from "@/hooks/use-data-table"
+import { usePageSize, type PaginationState } from "@/hooks/use-pagination"
 
 export function cursorFromLink(link?: string | null): string | null {
   if (!link) return null
@@ -53,7 +52,7 @@ export function useCursors(page: number, setPage: (page: number) => void) {
   return { cursor, reset, goToPage }
 }
 
-export type CursorSearchState = DataTableState & {
+export type CursorSearchState = PaginationState & {
   cursor: string
   goToPage: (page: number, cursor: string | null) => void
 }

--- a/src/hooks/use-cursors.ts
+++ b/src/hooks/use-cursors.ts
@@ -1,4 +1,13 @@
-import { useState, useCallback } from "react"
+import { useState, useMemo, useCallback } from "react"
+import {
+  type NavigateOptions,
+  useSearch,
+  useNavigate,
+} from "@tanstack/react-router"
+
+import { cursorSearch } from "@/lib/pagination"
+
+import { usePageSize, type DataTableState } from "@/hooks/use-data-table"
 
 export function cursorFromLink(link?: string | null): string | null {
   if (!link) return null
@@ -42,4 +51,51 @@ export function useCursors(page: number, setPage: (page: number) => void) {
   )
 
   return { cursor, reset, goToPage }
+}
+
+export type CursorSearchState = DataTableState & {
+  cursor: string
+  goToPage: (page: number, cursor: string | null) => void
+}
+
+// reads/updates cursor chain out of the route's search params
+export function useCursorSearch(): CursorSearchState {
+  const search = useSearch({ strict: false })
+  const navigate = useNavigate()
+  const pageSize = usePageSize()
+
+  const cursors = useMemo(() => cursorSearch(search).cursors ?? [], [search])
+
+  const page = cursors.length + 1
+  const cursor = cursors[cursors.length - 1] ?? ""
+
+  const setCursors = useCallback(
+    (next: string[]) => {
+      void navigate({
+        search: () => ({
+          ...search,
+          cursors: next.length > 0 ? next : undefined,
+        }),
+      } as NavigateOptions)
+    },
+    [navigate, search],
+  )
+
+  const goToPage = useCallback(
+    (nextPage: number, nextCursor: string | null) => {
+      if (nextPage === page) return
+
+      if (nextPage < page) {
+        setCursors(cursors.slice(0, Math.max(0, nextPage - 1)))
+        return
+      }
+
+      if (!nextCursor) return
+
+      setCursors([...cursors, nextCursor])
+    },
+    [page, cursors, setCursors],
+  )
+
+  return { page, pageSize, cursor, goToPage }
 }

--- a/src/hooks/use-data-table.ts
+++ b/src/hooks/use-data-table.ts
@@ -3,15 +3,22 @@ import { useMobile } from "@/hooks/use-mobile"
 
 export type DataTableState = {
   page: number
-  setPage: (page: number) => void
   pageSize: number
 }
 
-export function useDataTable(): DataTableState {
+export function usePageSize(): number {
   const isMobile = useMobile()
-  const [page, setPage] = useState(1)
 
-  const pageSize = isMobile ? 15 : 20
+  return isMobile ? 15 : 20
+}
+
+// local page state for lists that aren't a route
+// i.e. environments list dialog
+export function useDataTable(): DataTableState & {
+  setPage: (page: number) => void
+} {
+  const [page, setPage] = useState(1)
+  const pageSize = usePageSize()
 
   return { page, setPage, pageSize }
 }

--- a/src/hooks/use-filter-search.ts
+++ b/src/hooks/use-filter-search.ts
@@ -5,12 +5,14 @@ import {
   useNavigate,
 } from "@tanstack/react-router"
 
+import { omitCursorSearch } from "@/lib/pagination"
+
 export function useFilterSearch<T extends Record<string, unknown>>(
   defaults?: Partial<T>,
 ): [T, (next: T) => void] {
   const search = useSearch({ strict: false })
   const navigate = useNavigate()
-  const filters = { ...defaults, ...search } as T
+  const filters = { ...defaults, ...omitCursorSearch(search) } as T
 
   const setFilters = useCallback(
     (next: T) => {

--- a/src/hooks/use-pagination.ts
+++ b/src/hooks/use-pagination.ts
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import { useMobile } from "@/hooks/use-mobile"
 
-export type DataTableState = {
+export type PaginationState = {
   page: number
   pageSize: number
 }
@@ -14,7 +14,7 @@ export function usePageSize(): number {
 
 // local page state for lists that aren't a route
 // i.e. environments list dialog
-export function useDataTable(): DataTableState & {
+export function usePagination(): PaginationState & {
   setPage: (page: number) => void
 } {
   const [page, setPage] = useState(1)

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -23,6 +23,7 @@ export function cursorSearch(search: object): CursorSearch {
 // returns filters from a route's search params
 export function omitCursorSearch(search: object): Record<string, unknown> {
   const { cursors, ...filters } = search as Record<string, unknown>
+  void cursors
 
   return filters
 }

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,0 +1,28 @@
+export type CursorSearch = {
+  cursors?: string[]
+}
+
+const CURSOR_PATTERN =
+  /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i
+
+// returns cursors from a route's search params
+export function cursorSearch(search: object): CursorSearch {
+  const { cursors } = search as { cursors?: unknown }
+  if (!Array.isArray(cursors)) return {}
+
+  const walked: string[] = []
+  for (const cursor of cursors) {
+    if (typeof cursor !== "string" || !CURSOR_PATTERN.test(cursor)) break
+
+    walked.push(cursor)
+  }
+
+  return walked.length > 0 ? { cursors: walked } : {}
+}
+
+// returns filters from a route's search params
+export function omitCursorSearch(search: object): Record<string, unknown> {
+  const { cursors, ...filters } = search as Record<string, unknown>
+
+  return filters
+}

--- a/src/pages/app/arch/list.tsx
+++ b/src/pages/app/arch/list.tsx
@@ -1,8 +1,7 @@
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useArchTableColumns } from "@/hooks/use-arch-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { Arch } from "@/types/arches"
 
 import { useListArches } from "@/queries/arches"
@@ -13,9 +12,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function ArchesList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
-  const { cursor, goToPage } = useCursors(page, setPage)
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useArchTableColumns()
 
   const {

--- a/src/pages/app/arch/list.tsx
+++ b/src/pages/app/arch/list.tsx
@@ -12,8 +12,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function ArchesList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useArchTableColumns()
 
   const {
@@ -34,7 +34,7 @@ export default function ArchesList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Arch>
           data={arches}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={archesLoading}
         />

--- a/src/pages/app/artifact/list.tsx
+++ b/src/pages/app/artifact/list.tsx
@@ -20,8 +20,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function ArtifactsList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useArtifactTableColumns()
 
   const [filters, setFilters] = useFilterSearch<ArtifactFilters>()
@@ -64,7 +64,7 @@ export default function ArtifactsList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Artifact>
           data={artifacts}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={artifactsLoading}
           onRowClick={(artifact) => navigateToResource(artifact)}

--- a/src/pages/app/artifact/list.tsx
+++ b/src/pages/app/artifact/list.tsx
@@ -1,11 +1,10 @@
-import { useState, useCallback } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useArtifactTableColumns } from "@/hooks/use-artifact-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { Artifact } from "@/types/artifacts"
 
@@ -21,20 +20,11 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function ArtifactsList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useArtifactTableColumns()
 
   const [filters, setFilters] = useFilterSearch<ArtifactFilters>()
-  const { cursor, reset, goToPage } = useCursors(page, setPage)
-
-  const handleFiltersChange = useCallback(
-    (next: ArtifactFilters) => {
-      setFilters(next)
-      reset()
-    },
-    [setFilters, reset],
-  )
 
   const {
     data: artifacts,
@@ -68,7 +58,7 @@ export default function ArtifactsList() {
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
-        <Artifacts.FilterBar filters={filters} onChange={handleFiltersChange} />
+        <Artifacts.FilterBar filters={filters} onChange={setFilters} />
       </div>
 
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">

--- a/src/pages/app/channel/list.tsx
+++ b/src/pages/app/channel/list.tsx
@@ -12,8 +12,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function ChannelsList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useChannelTableColumns()
 
   const {
@@ -34,7 +34,7 @@ export default function ChannelsList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Channel>
           data={channels}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={channelsLoading}
         />

--- a/src/pages/app/channel/list.tsx
+++ b/src/pages/app/channel/list.tsx
@@ -1,8 +1,7 @@
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useChannelTableColumns } from "@/hooks/use-channel-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { Channel } from "@/types/channels"
 
 import { useListChannels } from "@/queries/channels"
@@ -13,9 +12,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function ChannelsList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
-  const { cursor, goToPage } = useCursors(page, setPage)
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useChannelTableColumns()
 
   const {

--- a/src/pages/app/component/list.tsx
+++ b/src/pages/app/component/list.tsx
@@ -1,11 +1,10 @@
-import { useState, useCallback } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useComponentTableColumns } from "@/hooks/use-component-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { Component } from "@/types/components"
 
@@ -21,20 +20,11 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function ComponentsList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useComponentTableColumns()
 
   const [filters, setFilters] = useFilterSearch<ComponentFilters>()
-  const { cursor, reset, goToPage } = useCursors(page, setPage)
-
-  const handleFiltersChange = useCallback(
-    (next: ComponentFilters) => {
-      setFilters(next)
-      reset()
-    },
-    [setFilters, reset],
-  )
 
   const {
     data: components,
@@ -67,10 +57,7 @@ export default function ComponentsList() {
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
-        <Components.FilterBar
-          filters={filters}
-          onChange={handleFiltersChange}
-        />
+        <Components.FilterBar filters={filters} onChange={setFilters} />
       </div>
 
       <Components.Form.Create open={open} onOpenChange={setOpen} />

--- a/src/pages/app/component/list.tsx
+++ b/src/pages/app/component/list.tsx
@@ -20,8 +20,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function ComponentsList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useComponentTableColumns()
 
   const [filters, setFilters] = useFilterSearch<ComponentFilters>()
@@ -65,7 +65,7 @@ export default function ComponentsList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Component>
           data={components}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={componentsLoading}
           onRowClick={(component) => navigateToResource(component)}

--- a/src/pages/app/engine/list.tsx
+++ b/src/pages/app/engine/list.tsx
@@ -12,8 +12,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function EnginesList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useEngineTableColumns()
 
   const {
@@ -34,7 +34,7 @@ export default function EnginesList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Engine>
           data={engines}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={enginesLoading}
         />

--- a/src/pages/app/engine/list.tsx
+++ b/src/pages/app/engine/list.tsx
@@ -1,8 +1,7 @@
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useEngineTableColumns } from "@/hooks/use-engine-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { Engine } from "@/types/engines"
 
 import { useListEngines } from "@/queries/engines"
@@ -13,9 +12,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function EnginesList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
-  const { cursor, goToPage } = useCursors(page, setPage)
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useEngineTableColumns()
 
   const {

--- a/src/pages/app/entitlement/list.tsx
+++ b/src/pages/app/entitlement/list.tsx
@@ -19,8 +19,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function EntitlementsList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useEntitlementTableColumns()
 
   const {
@@ -56,7 +56,7 @@ export default function EntitlementsList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Entitlement>
           data={entitlements}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={entitlementsLoading}
           onRowClick={(entitlement) => navigateToResource(entitlement)}

--- a/src/pages/app/entitlement/list.tsx
+++ b/src/pages/app/entitlement/list.tsx
@@ -3,9 +3,8 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useEntitlementTableColumns } from "@/hooks/use-entitlement-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { Entitlement } from "@/types/entitlements"
 
 import { useListEntitlements } from "@/queries/entitlements"
@@ -20,9 +19,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function EntitlementsList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
-  const { cursor, goToPage } = useCursors(page, setPage)
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useEntitlementTableColumns()
 
   const {

--- a/src/pages/app/event-log/list.tsx
+++ b/src/pages/app/event-log/list.tsx
@@ -10,9 +10,8 @@ import {
   TableCell,
 } from "@/components/ui/table"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useEdition } from "@/hooks/use-edition"
-import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { useEventLogTableColumns } from "@/hooks/use-event-log-table-columns"
 
@@ -132,21 +131,12 @@ function EventLogTableSkeleton() {
 }
 
 export default function EventLogList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const navigate = useNavigate()
   const { isEE } = useEdition()
 
   const [filters, setFilters] = useFilterSearch<EventLogFilters>()
-  const { cursor, reset, goToPage } = useCursors(page, setPage)
-
-  const handleFiltersChange = useCallback(
-    (next: EventLogFilters) => {
-      setFilters(next)
-      reset()
-    },
-    [setFilters, reset],
-  )
 
   const columns = useEventLogTableColumns()
 
@@ -194,7 +184,7 @@ export default function EventLogList() {
   const content = (
     <>
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
-        <EventLogs.FilterBar filters={filters} onChange={handleFiltersChange} />
+        <EventLogs.FilterBar filters={filters} onChange={setFilters} />
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden">

--- a/src/pages/app/event-log/list.tsx
+++ b/src/pages/app/event-log/list.tsx
@@ -131,8 +131,8 @@ function EventLogTableSkeleton() {
 }
 
 export default function EventLogList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const navigate = useNavigate()
   const { isEE } = useEdition()
 
@@ -168,7 +168,7 @@ export default function EventLogList() {
     <ScrollArea className="h-full overflow-auto">
       <DataTable<EventLog>
         data={eventLogs}
-        table={table}
+        pagination={pagination}
         columns={columns}
         isLoading={loading}
         onRowClick={(eventLog) =>

--- a/src/pages/app/group/list.tsx
+++ b/src/pages/app/group/list.tsx
@@ -3,9 +3,8 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useGroupTableColumns } from "@/hooks/use-group-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { Group } from "@/types/groups"
 
 import { useListGroups } from "@/queries/groups"
@@ -20,9 +19,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function GroupsList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
-  const { cursor, goToPage } = useCursors(page, setPage)
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useGroupTableColumns()
 
   const {

--- a/src/pages/app/group/list.tsx
+++ b/src/pages/app/group/list.tsx
@@ -19,8 +19,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function GroupsList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useGroupTableColumns()
 
   const {
@@ -56,7 +56,7 @@ export default function GroupsList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Group>
           data={groups}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={groupsLoading}
           onRowClick={(group) => navigateToResource(group)}

--- a/src/pages/app/license/list.tsx
+++ b/src/pages/app/license/list.tsx
@@ -1,10 +1,9 @@
-import { useState, useCallback } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useLicenseTableColumns } from "@/hooks/use-license-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { License } from "@/types/licenses"
 
@@ -21,20 +20,11 @@ import PageFooter from "@/components/page-footer"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
 export default function LicensesList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useLicenseTableColumns()
 
   const [filters, setFilters] = useFilterSearch<LicenseFilters>()
-  const { cursor, reset, goToPage } = useCursors(page, setPage)
-
-  const handleFiltersChange = useCallback(
-    (next: LicenseFilters) => {
-      setFilters(next)
-      reset()
-    },
-    [setFilters, reset],
-  )
 
   const {
     data: licenses,
@@ -67,7 +57,7 @@ export default function LicensesList() {
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
-        <Licenses.FilterBar filters={filters} onChange={handleFiltersChange} />
+        <Licenses.FilterBar filters={filters} onChange={setFilters} />
       </div>
 
       <Licenses.Form.Create open={open} onOpenChange={setOpen} />

--- a/src/pages/app/license/list.tsx
+++ b/src/pages/app/license/list.tsx
@@ -20,8 +20,8 @@ import PageFooter from "@/components/page-footer"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
 export default function LicensesList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useLicenseTableColumns()
 
   const [filters, setFilters] = useFilterSearch<LicenseFilters>()
@@ -65,7 +65,7 @@ export default function LicensesList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<License>
           data={licenses}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={licensesLoading}
           onRowClick={(license) => navigateToResource(license)}

--- a/src/pages/app/machine/list.tsx
+++ b/src/pages/app/machine/list.tsx
@@ -20,8 +20,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function MachinesList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useMachineTableColumns()
 
   const [filters, setFilters] = useFilterSearch<MachineFilters>()
@@ -65,7 +65,7 @@ export default function MachinesList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Machine>
           data={machines}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={machinesLoading}
           onRowClick={(machine) => navigateToResource(machine)}

--- a/src/pages/app/machine/list.tsx
+++ b/src/pages/app/machine/list.tsx
@@ -1,11 +1,10 @@
-import { useState, useCallback } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useMachineTableColumns } from "@/hooks/use-machine-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { Machine } from "@/types/machines"
 
@@ -21,20 +20,11 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function MachinesList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useMachineTableColumns()
 
   const [filters, setFilters] = useFilterSearch<MachineFilters>()
-  const { cursor, reset, goToPage } = useCursors(page, setPage)
-
-  const handleFiltersChange = useCallback(
-    (next: MachineFilters) => {
-      setFilters(next)
-      reset()
-    },
-    [setFilters, reset],
-  )
 
   const {
     data: machines,
@@ -67,7 +57,7 @@ export default function MachinesList() {
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
-        <Machines.FilterBar filters={filters} onChange={handleFiltersChange} />
+        <Machines.FilterBar filters={filters} onChange={setFilters} />
       </div>
 
       <Machines.Form.Create open={open} onOpenChange={setOpen} />

--- a/src/pages/app/package/list.tsx
+++ b/src/pages/app/package/list.tsx
@@ -1,11 +1,10 @@
-import { useState, useCallback } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { usePackageTableColumns } from "@/hooks/use-package-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { Package } from "@/types/packages"
 
@@ -21,20 +20,11 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function PackagesList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = usePackageTableColumns()
 
   const [filters, setFilters] = useFilterSearch<PackageFilters>()
-  const { cursor, reset, goToPage } = useCursors(page, setPage)
-
-  const handleFiltersChange = useCallback(
-    (next: PackageFilters) => {
-      setFilters(next)
-      reset()
-    },
-    [setFilters, reset],
-  )
 
   const {
     data: packages,
@@ -68,7 +58,7 @@ export default function PackagesList() {
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
-        <Packages.FilterBar filters={filters} onChange={handleFiltersChange} />
+        <Packages.FilterBar filters={filters} onChange={setFilters} />
       </div>
 
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">

--- a/src/pages/app/package/list.tsx
+++ b/src/pages/app/package/list.tsx
@@ -20,8 +20,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function PackagesList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = usePackageTableColumns()
 
   const [filters, setFilters] = useFilterSearch<PackageFilters>()
@@ -64,7 +64,7 @@ export default function PackagesList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Package>
           data={packages}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={packagesLoading}
           onRowClick={(pkg) => navigateToResource(pkg)}

--- a/src/pages/app/platform/list.tsx
+++ b/src/pages/app/platform/list.tsx
@@ -12,8 +12,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function PlatformsList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = usePlatformTableColumns()
 
   const {
@@ -34,7 +34,7 @@ export default function PlatformsList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Platform>
           data={platforms}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={platformsLoading}
         />

--- a/src/pages/app/platform/list.tsx
+++ b/src/pages/app/platform/list.tsx
@@ -1,8 +1,7 @@
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { usePlatformTableColumns } from "@/hooks/use-platform-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { Platform } from "@/types/platforms"
 
 import { useListPlatforms } from "@/queries/platforms"
@@ -13,9 +12,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function PlatformsList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
-  const { cursor, goToPage } = useCursors(page, setPage)
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = usePlatformTableColumns()
 
   const {

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -1,11 +1,10 @@
-import { useState, useCallback } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { usePolicyTableColumns } from "@/hooks/use-policy-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { Policy } from "@/types/policies"
 
@@ -21,20 +20,11 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function PoliciesList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = usePolicyTableColumns()
 
   const [filters, setFilters] = useFilterSearch<PolicyFilters>()
-  const { cursor, reset, goToPage } = useCursors(page, setPage)
-
-  const handleFiltersChange = useCallback(
-    (next: PolicyFilters) => {
-      setFilters(next)
-      reset()
-    },
-    [setFilters, reset],
-  )
 
   const {
     data: policies,
@@ -69,7 +59,7 @@ export default function PoliciesList() {
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
-        <Policies.FilterBar filters={filters} onChange={handleFiltersChange} />
+        <Policies.FilterBar filters={filters} onChange={setFilters} />
       </div>
 
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">

--- a/src/pages/app/policy/list.tsx
+++ b/src/pages/app/policy/list.tsx
@@ -20,8 +20,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function PoliciesList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = usePolicyTableColumns()
 
   const [filters, setFilters] = useFilterSearch<PolicyFilters>()
@@ -65,7 +65,7 @@ export default function PoliciesList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Policy>
           data={policies}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={policiesLoading}
           onRowClick={(policy) => navigateToResource(policy)}

--- a/src/pages/app/process/list.tsx
+++ b/src/pages/app/process/list.tsx
@@ -1,11 +1,10 @@
-import { useState, useCallback } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useProcessTableColumns } from "@/hooks/use-process-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { Process } from "@/types/processes"
 
@@ -21,20 +20,11 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function ProcessesList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useProcessTableColumns()
 
   const [filters, setFilters] = useFilterSearch<ProcessFilters>()
-  const { cursor, reset, goToPage } = useCursors(page, setPage)
-
-  const handleFiltersChange = useCallback(
-    (next: ProcessFilters) => {
-      setFilters(next)
-      reset()
-    },
-    [setFilters, reset],
-  )
 
   const {
     data: processes,
@@ -67,7 +57,7 @@ export default function ProcessesList() {
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
-        <Processes.FilterBar filters={filters} onChange={handleFiltersChange} />
+        <Processes.FilterBar filters={filters} onChange={setFilters} />
       </div>
 
       <Processes.Form.Create open={open} onOpenChange={setOpen} />

--- a/src/pages/app/process/list.tsx
+++ b/src/pages/app/process/list.tsx
@@ -20,8 +20,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function ProcessesList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useProcessTableColumns()
 
   const [filters, setFilters] = useFilterSearch<ProcessFilters>()
@@ -65,7 +65,7 @@ export default function ProcessesList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Process>
           data={processes}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={processesLoading}
           onRowClick={(process) => navigateToResource(process)}

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -19,8 +19,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function ProductsList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useProductTableColumns()
 
   const {
@@ -56,7 +56,7 @@ export default function ProductsList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Product>
           data={products}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={productsLoading}
           onRowClick={(product) => navigateToResource(product)}

--- a/src/pages/app/product/list.tsx
+++ b/src/pages/app/product/list.tsx
@@ -3,9 +3,8 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useProductTableColumns } from "@/hooks/use-product-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { Product } from "@/types/products"
 
 import { useListProducts } from "@/queries/products"
@@ -20,9 +19,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function ProductsList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
-  const { cursor, goToPage } = useCursors(page, setPage)
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useProductTableColumns()
 
   const {

--- a/src/pages/app/release/list.tsx
+++ b/src/pages/app/release/list.tsx
@@ -20,8 +20,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function ReleasesList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useReleaseTableColumns()
 
   const [filters, setFilters] = useFilterSearch<ReleaseFilters>()
@@ -64,7 +64,7 @@ export default function ReleasesList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Release>
           data={releases}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={releasesLoading}
           onRowClick={(release) => navigateToResource(release)}

--- a/src/pages/app/release/list.tsx
+++ b/src/pages/app/release/list.tsx
@@ -1,11 +1,10 @@
-import { useState, useCallback } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useReleaseTableColumns } from "@/hooks/use-release-table-columns"
-import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { Release } from "@/types/releases"
 
@@ -21,20 +20,11 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function ReleasesList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useReleaseTableColumns()
 
   const [filters, setFilters] = useFilterSearch<ReleaseFilters>()
-  const { cursor, reset, goToPage } = useCursors(page, setPage)
-
-  const handleFiltersChange = useCallback(
-    (next: ReleaseFilters) => {
-      setFilters(next)
-      reset()
-    },
-    [setFilters, reset],
-  )
 
   const {
     data: releases,
@@ -68,7 +58,7 @@ export default function ReleasesList() {
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
-        <Releases.FilterBar filters={filters} onChange={handleFiltersChange} />
+        <Releases.FilterBar filters={filters} onChange={setFilters} />
       </div>
 
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">

--- a/src/pages/app/request-log/list.tsx
+++ b/src/pages/app/request-log/list.tsx
@@ -3,9 +3,8 @@ import { useNavigate } from "@tanstack/react-router"
 
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useEdition } from "@/hooks/use-edition"
-import { useDataTable } from "@/hooks/use-data-table"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { useRequestLogTableColumns } from "@/hooks/use-request-log-table-columns"
 
@@ -25,21 +24,12 @@ import PageHeader from "@/components/page-header"
 import Pagination from "@/components/pagination"
 
 export default function RequestLogList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const navigate = useNavigate()
   const { isEE } = useEdition()
 
   const [filters, setFilters] = useFilterSearch<RequestLogFilters>()
-  const { cursor, reset, goToPage } = useCursors(page, setPage)
-
-  const handleFiltersChange = useCallback(
-    (next: RequestLogFilters) => {
-      setFilters(next)
-      reset()
-    },
-    [setFilters, reset],
-  )
 
   const columns = useRequestLogTableColumns()
 
@@ -87,10 +77,7 @@ export default function RequestLogList() {
   const content = (
     <>
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
-        <RequestLogs.FilterBar
-          filters={filters}
-          onChange={handleFiltersChange}
-        />
+        <RequestLogs.FilterBar filters={filters} onChange={setFilters} />
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden">

--- a/src/pages/app/request-log/list.tsx
+++ b/src/pages/app/request-log/list.tsx
@@ -24,8 +24,8 @@ import PageHeader from "@/components/page-header"
 import Pagination from "@/components/pagination"
 
 export default function RequestLogList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const navigate = useNavigate()
   const { isEE } = useEdition()
 
@@ -61,7 +61,7 @@ export default function RequestLogList() {
     <ScrollArea className="h-full overflow-auto">
       <DataTable<RequestLog>
         data={requestLogs}
-        table={table}
+        pagination={pagination}
         columns={columns}
         isLoading={loading}
         onRowClick={(requestLog) =>

--- a/src/pages/app/team/list.tsx
+++ b/src/pages/app/team/list.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react"
+import { useState, useMemo } from "react"
 import { useLocation, useNavigate } from "@tanstack/react-router"
 
 import { Badge } from "@/components/ui/badge"
@@ -10,8 +10,7 @@ import { useListUsers } from "@/queries/users"
 import { useGetAccount, useGetAccountPlan } from "@/queries/accounts"
 
 import { useMobile } from "@/hooks/use-mobile"
-import { useDataTable } from "@/hooks/use-data-table"
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useFilterSearch } from "@/hooks/use-filter-search"
 import { usePermissions } from "@/hooks/use-permissions"
 import { useTeamTableColumns } from "@/hooks/use-team-table-columns"
@@ -29,21 +28,12 @@ import Pagination from "@/components/pagination"
 export default function TeamPage() {
   const isMobile = useMobile()
 
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useTeamTableColumns()
   const { can } = usePermissions()
 
   const [filters, setFilters] = useFilterSearch<UserFilters>()
-  const { cursor, reset, goToPage } = useCursors(page, setPage)
-
-  const handleFiltersChange = useCallback(
-    (next: UserFilters) => {
-      setFilters(next)
-      reset()
-    },
-    [setFilters, reset],
-  )
 
   // NB(cazden) API requires 'admin.read' whenever an admin appears in the response,
   // remove it from the request if current user can't read admins to avoid 403.
@@ -128,7 +118,7 @@ export default function TeamPage() {
       )}
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-3 md:p-2.5 md:px-4">
-        <Users.TeamFilterBar filters={filters} onChange={handleFiltersChange} />
+        <Users.TeamFilterBar filters={filters} onChange={setFilters} />
       </div>
 
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">

--- a/src/pages/app/team/list.tsx
+++ b/src/pages/app/team/list.tsx
@@ -28,8 +28,8 @@ import Pagination from "@/components/pagination"
 export default function TeamPage() {
   const isMobile = useMobile()
 
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useTeamTableColumns()
   const { can } = usePermissions()
 
@@ -124,7 +124,7 @@ export default function TeamPage() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<User>
           data={users}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={usersLoading}
           onRowClick={(user) =>

--- a/src/pages/app/token/list.tsx
+++ b/src/pages/app/token/list.tsx
@@ -1,10 +1,10 @@
-import { useState, useCallback } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { useDataTable } from "@/hooks/use-data-table"
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
+import { useFilterSearch } from "@/hooks/use-filter-search"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 import { useTokenTableColumns } from "@/hooks/use-token-table-columns"
 
@@ -20,16 +20,14 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function TokensList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useTokenTableColumns()
   const navigateToResource = useResourceNavigate()
 
-  // pre-filter to customer-related tokens, e.g. user, license
-  const [filters, setFilters] = useState<TokenFilters>({
+  const [filters, setFilters] = useFilterSearch<TokenFilters>({
     bearerRoles: [...SubjectTokenRoles],
   })
-  const { cursor, reset, goToPage } = useCursors(page, setPage)
 
   const [createOpen, setCreateOpen] = useState(false)
 
@@ -38,14 +36,6 @@ export default function TokensList() {
     links,
     isLoading,
   } = useListTokens({ cursor, pageSize, filters })
-
-  const handleFiltersChange = useCallback(
-    (next: TokenFilters) => {
-      setFilters(next)
-      reset()
-    },
-    [reset],
-  )
 
   const nextCursor = cursorFromLink(links?.next)
 
@@ -64,7 +54,7 @@ export default function TokensList() {
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
-        <Tokens.FilterBar filters={filters} onChange={handleFiltersChange} />
+        <Tokens.FilterBar filters={filters} onChange={setFilters} />
       </div>
 
       <Tokens.Form.Create open={createOpen} onOpenChange={setCreateOpen} />

--- a/src/pages/app/token/list.tsx
+++ b/src/pages/app/token/list.tsx
@@ -20,8 +20,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function TokensList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useTokenTableColumns()
   const navigateToResource = useResourceNavigate()
 
@@ -62,7 +62,7 @@ export default function TokensList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<Token>
           data={tokens}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={isLoading}
           onRowClick={(token) => navigateToResource(token)}

--- a/src/pages/app/user/list.tsx
+++ b/src/pages/app/user/list.tsx
@@ -20,8 +20,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function UsersList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useUserTableColumns()
 
   const [filters, setFilters] = useFilterSearch<UserFilters>({
@@ -67,7 +67,7 @@ export default function UsersList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<User>
           data={users}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={usersLoading}
           onRowClick={(user) => navigateToResource(user)}

--- a/src/pages/app/user/list.tsx
+++ b/src/pages/app/user/list.tsx
@@ -1,12 +1,11 @@
-import { useState, useCallback } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useUserTableColumns } from "@/hooks/use-user-table-columns"
 import { useFilterSearch } from "@/hooks/use-filter-search"
-import { useDataTable } from "@/hooks/use-data-table"
 import { User, UserRole, type UserFilters } from "@/types/users"
 
 import { useListUsers } from "@/queries/users"
@@ -21,22 +20,13 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function UsersList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useUserTableColumns()
 
   const [filters, setFilters] = useFilterSearch<UserFilters>({
     roles: [UserRole.User],
   })
-  const { cursor, reset, goToPage } = useCursors(page, setPage)
-
-  const handleFiltersChange = useCallback(
-    (next: UserFilters) => {
-      setFilters(next)
-      reset()
-    },
-    [setFilters, reset],
-  )
 
   const {
     data: users,
@@ -69,7 +59,7 @@ export default function UsersList() {
       </PageHeader>
 
       <div className="min-w-0 overflow-hidden border-b border-accent px-2 pt-2 pb-2.5 md:px-4">
-        <Users.FilterBar filters={filters} onChange={handleFiltersChange} />
+        <Users.FilterBar filters={filters} onChange={setFilters} />
       </div>
 
       <Users.Form.Create open={open} onOpenChange={setOpen} />

--- a/src/pages/app/webhook-endpoint/list.tsx
+++ b/src/pages/app/webhook-endpoint/list.tsx
@@ -7,8 +7,7 @@ import { WebhookEndpoint } from "@/types/webhook-endpoints"
 
 import { useListWebhookEndpoints } from "@/queries/webhook-endpoints"
 
-import { useDataTable } from "@/hooks/use-data-table"
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 import { useWebhookEndpointTableColumns } from "@/hooks/use-webhook-endpoint-table-columns"
 
@@ -20,9 +19,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function WebhookEndpointsList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
-  const { cursor, goToPage } = useCursors(page, setPage)
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useWebhookEndpointTableColumns()
 
   const {

--- a/src/pages/app/webhook-endpoint/list.tsx
+++ b/src/pages/app/webhook-endpoint/list.tsx
@@ -19,8 +19,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function WebhookEndpointsList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useWebhookEndpointTableColumns()
 
   const {
@@ -49,7 +49,7 @@ export default function WebhookEndpointsList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<WebhookEndpoint>
           data={webhookEndpoints}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={isLoading}
           onRowClick={(webhookEndpoint) => navigateToResource(webhookEndpoint)}

--- a/src/pages/app/webhook-event/list.tsx
+++ b/src/pages/app/webhook-event/list.tsx
@@ -4,8 +4,7 @@ import { WebhookEvent } from "@/types/webhook-events"
 
 import { useListWebhookEvents } from "@/queries/webhook-events"
 
-import { useDataTable } from "@/hooks/use-data-table"
-import { cursorFromLink, useCursors } from "@/hooks/use-cursors"
+import { cursorFromLink, useCursorSearch } from "@/hooks/use-cursors"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 import { useWebhookEventTableColumns } from "@/hooks/use-webhook-event-table-columns"
 
@@ -15,9 +14,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function WebhookEventsList() {
-  const table = useDataTable()
-  const { page, pageSize, setPage } = table
-  const { cursor, goToPage } = useCursors(page, setPage)
+  const table = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = table
   const columns = useWebhookEventTableColumns()
 
   const {

--- a/src/pages/app/webhook-event/list.tsx
+++ b/src/pages/app/webhook-event/list.tsx
@@ -14,8 +14,8 @@ import PageHeader from "@/components/page-header"
 import PageFooter from "@/components/page-footer"
 
 export default function WebhookEventsList() {
-  const table = useCursorSearch()
-  const { page, pageSize, cursor, goToPage } = table
+  const pagination = useCursorSearch()
+  const { page, pageSize, cursor, goToPage } = pagination
   const columns = useWebhookEventTableColumns()
 
   const {
@@ -35,7 +35,7 @@ export default function WebhookEventsList() {
       <ScrollArea className="h-[calc(100vh-7rem)] overflow-auto">
         <DataTable<WebhookEvent>
           data={webhookEvents}
-          table={table}
+          pagination={pagination}
           columns={columns}
           isLoading={isLoading}
           onRowClick={(webhookEvent) => navigateToResource(webhookEvent)}

--- a/src/routes/$accountId/app.artifacts.tsx
+++ b/src/routes/$accountId/app.artifacts.tsx
@@ -2,10 +2,13 @@ import { createFileRoute } from "@tanstack/react-router"
 import { type ArtifactFilters } from "@/types/artifacts"
 import * as Page from "@/pages/index"
 import { requirePermission } from "@/lib/permissions"
+import { cursorSearch, type CursorSearch } from "@/lib/pagination"
 import { titleHead } from "@/lib/document-title"
 
-function validateSearch(search: Record<string, unknown>): ArtifactFilters {
-  const filters: ArtifactFilters = {}
+function validateSearch(
+  search: Record<string, unknown>,
+): ArtifactFilters & CursorSearch {
+  const filters: ArtifactFilters & CursorSearch = cursorSearch(search)
 
   if (typeof search.status === "string") filters.status = search.status
   if (typeof search.product === "string") filters.product = search.product

--- a/src/routes/$accountId/app.components.tsx
+++ b/src/routes/$accountId/app.components.tsx
@@ -2,10 +2,13 @@ import { createFileRoute } from "@tanstack/react-router"
 import { type ComponentFilters } from "@/queries/components"
 import * as Page from "@/pages/index"
 import { requirePermission } from "@/lib/permissions"
+import { cursorSearch, type CursorSearch } from "@/lib/pagination"
 import { titleHead } from "@/lib/document-title"
 
-function validateSearch(search: Record<string, unknown>): ComponentFilters {
-  const filters: ComponentFilters = {}
+function validateSearch(
+  search: Record<string, unknown>,
+): ComponentFilters & CursorSearch {
+  const filters: ComponentFilters & CursorSearch = cursorSearch(search)
 
   if (typeof search.machine === "string") filters.machine = search.machine
   if (typeof search.license === "string") filters.license = search.license

--- a/src/routes/$accountId/app.event-logs.tsx
+++ b/src/routes/$accountId/app.event-logs.tsx
@@ -5,6 +5,7 @@ import { type EventLogResourceFilter } from "@/types/event-logs"
 
 import { titleHead } from "@/lib/document-title"
 import { expandEventLogEventFilters } from "@/lib/event-logs"
+import { cursorSearch, type CursorSearch } from "@/lib/pagination"
 import { requirePermission } from "@/lib/permissions"
 
 import * as Page from "@/pages/index"
@@ -27,8 +28,10 @@ function parseResourceFilter(
   return undefined
 }
 
-function validateSearch(search: Record<string, unknown>): EventLogFilters {
-  const filters: EventLogFilters = {}
+function validateSearch(
+  search: Record<string, unknown>,
+): EventLogFilters & CursorSearch {
+  const filters: EventLogFilters & CursorSearch = cursorSearch(search)
 
   if (Array.isArray(search.events)) {
     const events = search.events.filter(

--- a/src/routes/$accountId/app.licenses.tsx
+++ b/src/routes/$accountId/app.licenses.tsx
@@ -2,14 +2,17 @@ import { createFileRoute } from "@tanstack/react-router"
 import { type LicenseFilters } from "@/queries/licenses"
 import * as Page from "@/pages/index"
 import { requirePermission } from "@/lib/permissions"
+import { cursorSearch, type CursorSearch } from "@/lib/pagination"
 import { titleHead } from "@/lib/document-title"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-function validateSearch(search: Record<string, unknown>): LicenseFilters {
-  const filters: LicenseFilters = {}
+function validateSearch(
+  search: Record<string, unknown>,
+): LicenseFilters & CursorSearch {
+  const filters: LicenseFilters & CursorSearch = cursorSearch(search)
 
   if (typeof search.status === "string") filters.status = search.status
   if (typeof search.product === "string") filters.product = search.product

--- a/src/routes/$accountId/app.machines.tsx
+++ b/src/routes/$accountId/app.machines.tsx
@@ -2,14 +2,17 @@ import { createFileRoute } from "@tanstack/react-router"
 import { type MachineFilters } from "@/queries/machines"
 import * as Page from "@/pages/index"
 import { requirePermission } from "@/lib/permissions"
+import { cursorSearch, type CursorSearch } from "@/lib/pagination"
 import { titleHead } from "@/lib/document-title"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-function validateSearch(search: Record<string, unknown>): MachineFilters {
-  const filters: MachineFilters = {}
+function validateSearch(
+  search: Record<string, unknown>,
+): MachineFilters & CursorSearch {
+  const filters: MachineFilters & CursorSearch = cursorSearch(search)
 
   if (typeof search.status === "string") filters.status = search.status
   if (typeof search.fingerprint === "string")

--- a/src/routes/$accountId/app.policies.tsx
+++ b/src/routes/$accountId/app.policies.tsx
@@ -2,10 +2,13 @@ import { createFileRoute } from "@tanstack/react-router"
 import { type PolicyFilters } from "@/queries/policies"
 import * as Page from "@/pages/index"
 import { titleHead } from "@/lib/document-title"
+import { cursorSearch, type CursorSearch } from "@/lib/pagination"
 import { requirePermission } from "@/lib/permissions"
 
-function validateSearch(search: Record<string, unknown>): PolicyFilters {
-  const filters: PolicyFilters = {}
+function validateSearch(
+  search: Record<string, unknown>,
+): PolicyFilters & CursorSearch {
+  const filters: PolicyFilters & CursorSearch = cursorSearch(search)
 
   if (typeof search.product === "string") filters.product = search.product
 

--- a/src/routes/$accountId/app.processes.tsx
+++ b/src/routes/$accountId/app.processes.tsx
@@ -2,10 +2,13 @@ import { createFileRoute } from "@tanstack/react-router"
 import { type ProcessFilters } from "@/queries/processes"
 import * as Page from "@/pages/index"
 import { requirePermission } from "@/lib/permissions"
+import { cursorSearch, type CursorSearch } from "@/lib/pagination"
 import { titleHead } from "@/lib/document-title"
 
-function validateSearch(search: Record<string, unknown>): ProcessFilters {
-  const filters: ProcessFilters = {}
+function validateSearch(
+  search: Record<string, unknown>,
+): ProcessFilters & CursorSearch {
+  const filters: ProcessFilters & CursorSearch = cursorSearch(search)
 
   if (typeof search.machine === "string") filters.machine = search.machine
   if (typeof search.license === "string") filters.license = search.license

--- a/src/routes/$accountId/app.releases.tsx
+++ b/src/routes/$accountId/app.releases.tsx
@@ -2,10 +2,13 @@ import { createFileRoute } from "@tanstack/react-router"
 import { type ReleaseFilters } from "@/types/releases"
 import * as Page from "@/pages/index"
 import { requirePermission } from "@/lib/permissions"
+import { cursorSearch, type CursorSearch } from "@/lib/pagination"
 import { titleHead } from "@/lib/document-title"
 
-function validateSearch(search: Record<string, unknown>): ReleaseFilters {
-  const filters: ReleaseFilters = {}
+function validateSearch(
+  search: Record<string, unknown>,
+): ReleaseFilters & CursorSearch {
+  const filters: ReleaseFilters & CursorSearch = cursorSearch(search)
 
   if (typeof search.status === "string") filters.status = search.status
   if (typeof search.channel === "string") filters.channel = search.channel

--- a/src/routes/$accountId/app.request-logs.tsx
+++ b/src/routes/$accountId/app.request-logs.tsx
@@ -4,6 +4,7 @@ import { type RequestLogFilters } from "@/queries/request-logs"
 import { type RequestLogResourceFilter } from "@/types/request-logs"
 
 import { titleHead } from "@/lib/document-title"
+import { cursorSearch, type CursorSearch } from "@/lib/pagination"
 import { requirePermission } from "@/lib/permissions"
 
 import * as Page from "@/pages/index"
@@ -26,8 +27,10 @@ function parseResourceFilter(
   return undefined
 }
 
-function validateSearch(search: Record<string, unknown>): RequestLogFilters {
-  const filters: RequestLogFilters = {}
+function validateSearch(
+  search: Record<string, unknown>,
+): RequestLogFilters & CursorSearch {
+  const filters: RequestLogFilters & CursorSearch = cursorSearch(search)
 
   if (typeof search.method === "string") filters.method = search.method
   if (typeof search.status === "string") filters.status = search.status

--- a/src/routes/$accountId/app.team.tsx
+++ b/src/routes/$accountId/app.team.tsx
@@ -2,14 +2,17 @@ import { createFileRoute } from "@tanstack/react-router"
 import { type UserFilters } from "@/types/users"
 import * as Page from "@/pages/index"
 import { requireAllPermissions } from "@/lib/permissions"
+import { cursorSearch, type CursorSearch } from "@/lib/pagination"
 import { titleHead } from "@/lib/document-title"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-function validateSearch(search: Record<string, unknown>): UserFilters {
-  const filters: UserFilters = {}
+function validateSearch(
+  search: Record<string, unknown>,
+): UserFilters & CursorSearch {
+  const filters: UserFilters & CursorSearch = cursorSearch(search)
 
   if (typeof search.status === "string") filters.status = search.status
   if (Array.isArray(search.roles)) filters.roles = search.roles as string[]

--- a/src/routes/$accountId/app.tokens.tsx
+++ b/src/routes/$accountId/app.tokens.tsx
@@ -2,11 +2,19 @@ import { createFileRoute } from "@tanstack/react-router"
 
 import * as Page from "@/pages/index"
 import { titleHead } from "@/lib/document-title"
+import { cursorSearch, type CursorSearch } from "@/lib/pagination"
 import { requirePermission } from "@/lib/permissions"
-import { TokenBearerType, type TokenFilters } from "@/types/tokens"
+import {
+  TokenBearerType,
+  TokenRole,
+  AllTokenRoles,
+  type TokenFilters,
+} from "@/types/tokens"
 
-function validateSearch(search: Record<string, unknown>): TokenFilters {
-  const filters: TokenFilters = {}
+function validateSearch(
+  search: Record<string, unknown>,
+): TokenFilters & CursorSearch {
+  const filters: TokenFilters & CursorSearch = cursorSearch(search)
 
   if (
     typeof search.bearerType === "string" &&
@@ -15,6 +23,14 @@ function validateSearch(search: Record<string, unknown>): TokenFilters {
     filters.bearerType = search.bearerType as TokenBearerType
   }
   if (typeof search.bearerId === "string") filters.bearerId = search.bearerId
+  if (Array.isArray(search.bearerRoles)) {
+    const bearerRoles = search.bearerRoles.filter(
+      (role): role is TokenRole =>
+        typeof role === "string" &&
+        (AllTokenRoles as readonly string[]).includes(role),
+    )
+    if (bearerRoles.length > 0) filters.bearerRoles = bearerRoles
+  }
   if (typeof search.environment === "string") {
     filters.environment = search.environment
   }

--- a/src/routes/$accountId/app.users.tsx
+++ b/src/routes/$accountId/app.users.tsx
@@ -2,14 +2,17 @@ import { createFileRoute } from "@tanstack/react-router"
 import { type UserFilters } from "@/queries/users"
 import * as Page from "@/pages/index"
 import { requirePermission } from "@/lib/permissions"
+import { cursorSearch, type CursorSearch } from "@/lib/pagination"
 import { titleHead } from "@/lib/document-title"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-function validateSearch(search: Record<string, unknown>): UserFilters {
-  const filters: UserFilters = {}
+function validateSearch(
+  search: Record<string, unknown>,
+): UserFilters & CursorSearch {
+  const filters: UserFilters & CursorSearch = cursorSearch(search)
 
   if (typeof search.status === "string") filters.status = search.status
   if (typeof search.assigned === "boolean") filters.assigned = search.assigned


### PR DESCRIPTION
Closes #320, closes #321.

Paginating persists the cursor to the URL, so subsequently clicking into a resource and hitting back returns you to the page you were on instead of the first.

<img width="900" src="https://github.com/user-attachments/assets/810e490a-58df-4231-bfe2-e2e4f6b72686" />

Also fixes token list filters, as they were kept in local state, so they now use `useFilterSearch` like the other lists.
