### PR TITLE
Fix email dasherizing when entered during account step

### DIFF
--- a/src/components/auth/form/account.tsx
+++ b/src/components/auth/form/account.tsx
@@ -22,9 +22,15 @@ export default function AccountForm() {
   })
 
   function onSubmit({ slug }: Schemas.Auth.AccountValues) {
+    const value = form.getValues("slug").trim()
+    const email = Schemas.Auth.LoginSchema.safeParse({ email: value }).success
+      ? value
+      : undefined
+
     void navigate({
       to: "/$accountId/auth/login",
       params: { accountId: slug },
+      search: { email },
     })
   }
 

--- a/src/components/auth/form/login.tsx
+++ b/src/components/auth/form/login.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useNavigate, Link } from "@tanstack/react-router"
+import { useNavigate, useSearch, Link } from "@tanstack/react-router"
+
 import { Undo2 } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
@@ -13,8 +14,8 @@ import * as Schemas from "@/schemas"
 import { AuthErrorCode, type AuthData } from "@/types/auth"
 
 import { useSlide } from "@/hooks/use-slide"
-import { useSession } from "@/hooks/use-session"
 import { useMobile } from "@/hooks/use-mobile"
+import { useSession } from "@/hooks/use-session"
 
 import { cn } from "@/lib/utils"
 import { toast } from "@/lib/toast"
@@ -47,9 +48,13 @@ export default function LoginForm() {
   const navigate = useNavigate()
   const session = useSession()
 
+  const { email: emailFromParams } = useSearch({
+    from: "/$accountId/auth/login",
+  })
+
   const [step, direction, setStep] = useSlide<Step>(STEP_ORDER, "email")
 
-  const [email, setEmail] = useState("")
+  const [email, setEmail] = useState(emailFromParams ?? "")
   const [password, setPassword] = useState("")
   const [remember, setRemember] = useState(false)
   const [ssoRedirectUrl, setSsoRedirectUrl] = useState<string | null>(null)
@@ -101,6 +106,7 @@ export default function LoginForm() {
       ) : (
         <EmailStep
           key="email"
+          email={email}
           onPasswordRequired={(value) => {
             setEmail(value)
             setStep("password")
@@ -118,10 +124,12 @@ export default function LoginForm() {
 }
 
 function EmailStep({
+  email,
   onPasswordRequired,
   onSsoRequired,
   onBack,
 }: {
+  email: string
   onPasswordRequired: (email: string) => void
   onSsoRequired: (email: string, redirectUrl: string) => void
   onBack: () => void
@@ -140,7 +148,7 @@ function EmailStep({
   const form = useForm<Schemas.Auth.LoginValues>({
     resolver: zodResolver(Schemas.Auth.LoginSchema),
     mode: "onChange",
-    defaultValues: { email: "" },
+    defaultValues: { email },
   })
 
   async function onSubmit({ email }: Schemas.Auth.LoginValues) {

--- a/src/routes/$accountId/auth.login.tsx
+++ b/src/routes/$accountId/auth.login.tsx
@@ -4,5 +4,8 @@ import { titleHead } from "@/lib/document-title"
 
 export const Route = createFileRoute("/$accountId/auth/login")({
   head: titleHead("Sign in"),
+  validateSearch: (search: Record<string, unknown>): { email?: string } => ({
+    email: typeof search.email === "string" ? search.email : undefined,
+  }),
   component: () => <Auth.Form.Login />,
 })

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -18,7 +18,7 @@ export const AccountSchema = z.object({
     .string()
     .trim()
     .min(1, "Please enter your account.")
-    .transform(dasherize)
+    .transform((value) => dasherize(value.split("@")[1] || value))
     .pipe(z.string().regex(/^[-A-Za-z0-9]+$/, "Please enter a valid account.")),
 })
 export type AccountValues = z.output<typeof AccountSchema>


### PR DESCRIPTION
Closes #339. Strips the user portion of an email entered on the account step down to its domain so it dasherizes properly, and uses the entered email from the account step to pre-fill the email field in the subsequent login step.