### PR TITLE
Add Fathom event tracking to onboarding wizard

### DIFF
--- a/src/components/onboarding/dialog/validation.tsx
+++ b/src/components/onboarding/dialog/validation.tsx
@@ -23,6 +23,7 @@ import { useEnvironment } from "@/hooks/use-environment"
 import { type QuickstartEnvironment } from "@/hooks/use-quickstart-environment"
 
 import * as keygen from "@/keygen"
+import * as fathom from "@/fathom"
 
 import { cn } from "@/lib/utils"
 import { DOCS_URL, DOCS_API_URL } from "@/lib/url"
@@ -107,6 +108,7 @@ export default function ValidationDialog({
 
   const openRef = useRef(open)
   const autoRanRef = useRef(false)
+  const trackedValidRef = useRef(false)
   const terminalRef = useRef<TerminalHandle>(null)
 
   useEffect(() => {
@@ -129,6 +131,11 @@ export default function ValidationDialog({
           validateKey.mutateAsync({ key: validationKey }),
           new Promise((resolve) => setTimeout(resolve, delayMs)),
         ])
+
+        if (result.meta.valid && !trackedValidRef.current) {
+          trackedValidRef.current = true
+          fathom.track("onboarding: validate completed")
+        }
 
         if (openRef.current) {
           setValidation(result)

--- a/src/components/onboarding/form/environment.tsx
+++ b/src/components/onboarding/form/environment.tsx
@@ -9,6 +9,8 @@ import { IsolationStrategy } from "@/types/environments"
 
 import { useCreateEnvironment } from "@/queries/environments"
 
+import * as fathom from "@/fathom"
+
 import { toast } from "@/lib/toast"
 
 import * as Forms from "@/components/forms"
@@ -46,6 +48,7 @@ export default function EnvironmentOnboardingForm({
         message: "Environment created",
         variant: "success",
       })
+      fathom.track("onboarding: environment completed")
     },
     [createEnvironment],
   )

--- a/src/components/onboarding/form/invite.tsx
+++ b/src/components/onboarding/form/invite.tsx
@@ -9,6 +9,8 @@ import { useCreateUser, useForgotPassword } from "@/queries/users"
 
 import { usePermissions } from "@/hooks/use-permissions"
 
+import * as fathom from "@/fathom"
+
 import { toast } from "@/lib/toast"
 import { settleInviteUsers } from "@/lib/users"
 import { permissionsForRole } from "@/lib/permissions"
@@ -69,6 +71,7 @@ export default function InviteOnboardingForm({
         message: invited.length === 1 ? "Invite sent" : "Invites sent",
         variant: "success",
       })
+      fathom.track("onboarding: invite completed")
     },
     [form, createUser, resetPassword],
   )

--- a/src/components/onboarding/form/license.tsx
+++ b/src/components/onboarding/form/license.tsx
@@ -6,6 +6,8 @@ import * as Schemas from "@/schemas"
 
 import { useCreateLicense } from "@/queries/licenses"
 
+import * as fathom from "@/fathom"
+
 import { toast } from "@/lib/toast"
 
 import * as Forms from "@/components/forms"
@@ -42,6 +44,7 @@ export default function LicenseOnboardingForm({
     async (values: Schemas.Licenses.CreateValues) => {
       await createLicense.mutateAsync(values)
       toast({ message: "License created", variant: "success" })
+      fathom.track("onboarding: license completed")
     },
     [createLicense],
   )

--- a/src/components/onboarding/form/policy.tsx
+++ b/src/components/onboarding/form/policy.tsx
@@ -6,6 +6,8 @@ import * as Schemas from "@/schemas"
 
 import { useCreatePolicy } from "@/queries/policies"
 
+import * as fathom from "@/fathom"
+
 import { toast } from "@/lib/toast"
 
 import * as Forms from "@/components/forms"
@@ -45,6 +47,7 @@ export default function PolicyOnboardingForm({
     async (values: Schemas.Policies.CreateValues) => {
       await createPolicy.mutateAsync(values)
       toast({ message: "Policy created", variant: "success" })
+      fathom.track("onboarding: policy completed")
     },
     [createPolicy],
   )

--- a/src/components/onboarding/form/product.tsx
+++ b/src/components/onboarding/form/product.tsx
@@ -7,6 +7,8 @@ import { DistributionStrategy } from "@/types/products"
 
 import { useCreateProduct } from "@/queries/products"
 
+import * as fathom from "@/fathom"
+
 import { toast } from "@/lib/toast"
 
 import * as Forms from "@/components/forms"
@@ -47,6 +49,7 @@ export default function ProductOnboardingForm({
     async (values: Schemas.Products.CreateValues) => {
       await createProduct.mutateAsync(values)
       toast({ message: "Product created", variant: "success" })
+      fathom.track("onboarding: product completed")
     },
     [createProduct],
   )

--- a/src/fathom/index.ts
+++ b/src/fathom/index.ts
@@ -1,1 +1,2 @@
 export { default as init } from "./init"
+export { default as track } from "./track"

--- a/src/fathom/track.ts
+++ b/src/fathom/track.ts
@@ -1,0 +1,12 @@
+import * as Fathom from "fathom-client"
+import * as keygen from "@/keygen"
+
+export default function track(event: string): void {
+  const { siteId } = keygen.config.fathom
+
+  if (!siteId) {
+    return
+  }
+
+  Fathom.trackEvent(event)
+}

--- a/src/pages/app/learn.tsx
+++ b/src/pages/app/learn.tsx
@@ -18,6 +18,7 @@ import {
 import { CircleCheckBig, ExternalLink, RotateCw, Undo2 } from "lucide-react"
 
 import * as keygen from "@/keygen"
+import * as fathom from "@/fathom"
 
 import { InternalRoles } from "@/types/users"
 
@@ -91,6 +92,11 @@ export default function Learn() {
     open: openDialog === dialog,
     onOpenChange: (open: boolean) => setOpenDialog(open ? dialog : null),
   })
+
+  const openStep = (step: OnboardingStep) => {
+    fathom.track(`onboarding: ${step} opened`)
+    setOpenDialog(step)
+  }
 
   const canProbeTeammates = can("admin.read")
   const canProbeEnvironments = isEE && can("environment.read")
@@ -201,8 +207,10 @@ export default function Learn() {
     new Set(),
   )
 
-  const skipStep = (step: OnboardingStep) =>
+  const skipStep = (step: OnboardingStep) => {
+    fathom.track(`onboarding: ${step} skipped`)
     setSkippedSteps((prev) => new Set(prev).add(step))
+  }
 
   const unskipStep = (step: OnboardingStep) =>
     setSkippedSteps((prev) => {
@@ -278,7 +286,7 @@ export default function Learn() {
                 state={stepState("invite")}
                 actionLabel="Invite Teammates"
                 disabledTooltip={permissionTooltip("invite")}
-                onAction={() => setOpenDialog("invite")}
+                onAction={() => openStep("invite")}
                 onSkip={() => skipStep("invite")}
                 onUndoSkip={() => unskipStep("invite")}
               />
@@ -290,7 +298,7 @@ export default function Learn() {
                   state={stepState("environment")}
                   actionLabel="New Environment"
                   disabledTooltip={permissionTooltip("environment")}
-                  onAction={() => setOpenDialog("environment")}
+                  onAction={() => openStep("environment")}
                   onSkip={() => skipStep("environment")}
                   onUndoSkip={() => unskipStep("environment")}
                 />
@@ -302,7 +310,7 @@ export default function Learn() {
                 state={stepState("product")}
                 actionLabel="New Product"
                 disabledTooltip={permissionTooltip("product")}
-                onAction={() => setOpenDialog("product")}
+                onAction={() => openStep("product")}
               />
 
               <OnboardingCard
@@ -311,7 +319,7 @@ export default function Learn() {
                 state={stepState("policy")}
                 actionLabel="New Policy"
                 disabledTooltip={permissionTooltip("policy")}
-                onAction={() => setOpenDialog("policy")}
+                onAction={() => openStep("policy")}
               />
 
               <OnboardingCard
@@ -320,7 +328,7 @@ export default function Learn() {
                 state={stepState("license")}
                 actionLabel="New License"
                 disabledTooltip={permissionTooltip("license")}
-                onAction={() => setOpenDialog("license")}
+                onAction={() => openStep("license")}
               />
 
               <OnboardingCard
@@ -330,7 +338,7 @@ export default function Learn() {
                 actionLabel="Validate License"
                 onAction={() => {
                   validationListener.arm()
-                  setOpenDialog("validate")
+                  openStep("validate")
                 }}
                 onRefresh={
                   validationListener.refreshable


### PR DESCRIPTION
This will add event analytics to our Fathom dashboard for opening, skipping and 
completing any step in our onboarding wizard flow. If sending events for opening the steps seems like it'd create too much noise, I can remove that, but also easy to do in a follow-up if you want to see how it does.