### PR TITLE
Add re-ordering to favorites

### DIFF
--- a/src/components/palette/command-row.tsx
+++ b/src/components/palette/command-row.tsx
@@ -12,6 +12,7 @@ export interface CommandRowProps {
   selectedValue: string
   onSelect: () => void
   value?: string
+  dragHandle?: React.ReactNode
 }
 
 export default function CommandRow({
@@ -19,6 +20,7 @@ export default function CommandRow({
   selectedValue,
   onSelect,
   value,
+  dragHandle,
 }: CommandRowProps) {
   const favorites = useFavoriteCommands()
   const isFavorite = favorites.includes(command.id)
@@ -37,6 +39,7 @@ export default function CommandRow({
       <command.icon />
       <span className="min-w-0 flex-1 truncate">{command.label}</span>
       <div className="ml-auto flex shrink-0 items-center gap-2">
+        {dragHandle}
         <Favorite
           commandId={command.id}
           isFavorite={isFavorite}

--- a/src/components/palette/home.tsx
+++ b/src/components/palette/home.tsx
@@ -15,6 +15,7 @@ import {
   Copy,
   StarOff,
   ChevronRight,
+  GripVertical,
 } from "lucide-react"
 
 import { recentKey } from "@/lib/palette"
@@ -22,7 +23,8 @@ import { viewRouteFor } from "@/lib/views"
 
 import type { Command, RecentItem } from "@/types/palette"
 
-import { useFavoritePages, useFavoriteRoutes } from "@/hooks/use-favorites"
+import { useFavorites } from "@/hooks/use-favorites"
+import { useListReorder } from "@/hooks/use-list-reorder"
 
 import RecentRow from "./recent-row"
 import CommandRow from "./command-row"
@@ -43,6 +45,7 @@ export interface HomeProps {
   onOpenNew: () => void
   onCopyAccountId: () => void
   onToggleFavoritePage: () => void
+  onReorderFavorites: (from: number, to: number) => void
   onCommandSelect: (command: Command) => void
   onRecentSelect: (item: RecentItem) => void
 }
@@ -63,16 +66,20 @@ export default function Home({
   onOpenNew,
   onCopyAccountId,
   onToggleFavoritePage,
+  onReorderFavorites,
   onCommandSelect,
   onRecentSelect,
 }: HomeProps) {
   const pathname = useLocation({ select: (location) => location.pathname })
-  const favoritePages = useFavoritePages()
-  const favoriteRouteIds = useFavoriteRoutes()
+  const favorites = useFavorites()
   const currentRoute = viewRouteFor(pathname)
-  const isPageFavorited =
-    favoritePages.some((page) => page.path === pathname) ||
-    (currentRoute != null && favoriteRouteIds.includes(currentRoute.to))
+  const isPageFavorited = favorites.some((favorite) =>
+    favorite.kind === "page"
+      ? favorite.path === pathname
+      : currentRoute != null && favorite.to === currentRoute.to,
+  )
+
+  const favoritesReorder = useListReorder(onReorderFavorites)
 
   const isTyping = filterText.trim().length > 0
   const showFindEnterHint = selectedValue === "action:find"
@@ -153,13 +160,27 @@ export default function Home({
       {favoriteCommands.length > 0 && (
         <CommandGroup heading="Favorites">
           {favoriteCommands.map((command) => (
-            <CommandRow
-              key={command.id}
-              value={`favorite:${command.id}`}
-              command={command}
-              selectedValue={selectedValue}
-              onSelect={() => onCommandSelect(command)}
-            />
+            <div key={command.id} data-reorder-item>
+              <CommandRow
+                value={`favorite:${command.id}`}
+                command={command}
+                selectedValue={selectedValue}
+                onSelect={() => {
+                  if (!favoritesReorder.isDragging()) onCommandSelect(command)
+                }}
+                dragHandle={
+                  !isTyping && (
+                    <button
+                      type="button"
+                      className="inline-flex size-5 shrink-0 cursor-grab touch-none items-center justify-center text-content-subdued opacity-0 group-hover/palette-row:opacity-100 group-data-[selected=true]/palette-row:opacity-100 active:cursor-grabbing pointer-coarse:opacity-100"
+                      {...favoritesReorder.handleProps}
+                    >
+                      <GripVertical className="size-4! text-current" />
+                    </button>
+                  )
+                }
+              />
+            </div>
           ))}
         </CommandGroup>
       )}

--- a/src/components/palette/menu.tsx
+++ b/src/components/palette/menu.tsx
@@ -48,11 +48,13 @@ import type { AnyResource } from "@/types/api"
 import { useCloud } from "@/hooks/use-cloud"
 import { useResourceNavigate } from "@/hooks/use-resource-navigate"
 import {
+  useFavorites,
   useFavoriteCommands,
-  useFavoritePages,
   toggleFavoritePage,
   toggleFavoriteRoute,
+  reorderFavoriteCommands,
 } from "@/hooks/use-favorites"
+import { reorderSubset } from "@/hooks/use-list-reorder"
 
 import * as keygen from "@/keygen"
 
@@ -118,7 +120,7 @@ export default function Menu({ open, onOpenChange }: MenuProps): ReactElement {
     [commands],
   )
 
-  const favoritePages = useFavoritePages()
+  const favorites = useFavorites()
   const favoriteIds = useFavoriteCommands()
   const favoriteCommands = useMemo(
     () =>
@@ -304,10 +306,12 @@ export default function Menu({ open, onOpenChange }: MenuProps): ReactElement {
 
   function toggleCurrentPageFavorite() {
     const path = window.location.pathname
-    const page = favoritePages.find((p) => p.path === path)
+    const page = favorites.find(
+      (favorite) => favorite.kind === "page" && favorite.path === path,
+    )
     const route = viewRouteFor(path)
 
-    if (page) {
+    if (page?.kind === "page") {
       toggleFavoritePage(page)
     } else if (route) {
       toggleFavoriteRoute(route.to)
@@ -320,6 +324,17 @@ export default function Menu({ open, onOpenChange }: MenuProps): ReactElement {
     }
 
     close()
+  }
+
+  function reorderPaletteFavorites(from: number, to: number) {
+    reorderFavoriteCommands(
+      reorderSubset(
+        favoriteIds,
+        favoriteCommands.map((command) => command.id),
+        from,
+        to,
+      ),
+    )
   }
 
   function handleResourceSelect(item: AnyResource) {
@@ -526,6 +541,7 @@ export default function Menu({ open, onOpenChange }: MenuProps): ReactElement {
                 selectedValue={selectedValue}
                 recents={recents}
                 favoriteCommands={favoriteCommands}
+                onReorderFavorites={reorderPaletteFavorites}
                 commandsById={commandsById}
                 findCommands={findCommands}
                 filterCommands={filterCommands}

--- a/src/components/sidebar/panel.tsx
+++ b/src/components/sidebar/panel.tsx
@@ -39,13 +39,14 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 
-import { User, Star, StarOff } from "lucide-react"
+import { User, Star, StarOff, GripVertical } from "lucide-react"
 
 import * as keygen from "@/keygen"
 
 import {
-  useFavoritePages,
-  useFavoriteRoutes,
+  favoriteKey,
+  useFavorites,
+  reorderFavorites,
   toggleFavoritePage,
   toggleFavoriteRoute,
 } from "@/hooks/use-favorites"
@@ -54,6 +55,7 @@ import { useMobile } from "@/hooks/use-mobile"
 import { useAppVersion } from "@/hooks/use-app-version"
 import { usePermissions } from "@/hooks/use-permissions"
 import { useEnvironment } from "@/hooks/use-environment"
+import { useListReorder, reorderSubset } from "@/hooks/use-list-reorder"
 
 import { DOCS_API_URL, GITHUB_URL } from "@/lib/url"
 
@@ -103,6 +105,32 @@ function useVisibleViews(): View[] {
   })
 }
 
+function FavoriteReorderItem({
+  onRemove,
+  handleProps,
+  children,
+}: {
+  onRemove: () => void
+  handleProps: React.ComponentProps<typeof SidebarMenuAction>
+  children: React.ReactElement
+}) {
+  return (
+    <SidebarMenuItem data-reorder-item>
+      <SidebarMenuButton asChild>{children}</SidebarMenuButton>
+      <SidebarMenuAction
+        showOnHover
+        className="right-6 cursor-grab touch-none active:cursor-grabbing"
+        {...handleProps}
+      >
+        <GripVertical />
+      </SidebarMenuAction>
+      <SidebarMenuAction showOnHover onClick={onRemove}>
+        <StarOff />
+      </SidebarMenuAction>
+    </SidebarMenuItem>
+  )
+}
+
 export default function SidebarPanel(): React.ReactElement {
   const activeView = useActiveView()
   const visibleViews = useVisibleViews()
@@ -119,8 +147,7 @@ export default function SidebarPanel(): React.ReactElement {
   const accountId = keygen.config.id
   const { open, setOpen } = useSidebar()
   const [paletteOpen, setPaletteOpen] = useState(false)
-  const allFavoritePages = useFavoritePages()
-  const favoriteRouteIds = useFavoriteRoutes()
+  const allFavorites = useFavorites()
 
   const isMobile = useMobile()
   const { isCloud } = useCloud()
@@ -153,18 +180,20 @@ export default function SidebarPanel(): React.ReactElement {
       (route) => isCloud || route.to !== "/$accountId/app/billing",
     ),
   )
-  const favoriteRoutes = favoriteRouteIds.flatMap((to) => {
-    const route = allVisibleRoutes.find((r) => r.to === to)
-    return route ? [route] : []
-  })
-  const favoritePages = allFavoritePages.filter(
-    (page) => page.accountId === accountId,
+  const favorites = allFavorites.filter((favorite) =>
+    favorite.kind === "route"
+      ? allVisibleRoutes.some((route) => route.to === favorite.to)
+      : favorite.accountId === accountId,
   )
-  const hasFavorites = favoriteRoutes.length > 0 || favoritePages.length > 0
+  const hasFavorites = favorites.length > 0
 
   const pathname = useLocation({ select: (location) => location.pathname })
-  const isCurrentPageFavorited = favoritePages.some(
-    (page) => page.path === pathname,
+  const isCurrentPageFavorited = favorites.some(
+    (favorite) => favorite.kind === "page" && favorite.path === pathname,
+  )
+
+  const favoritesReorder = useListReorder((from, to) =>
+    reorderFavorites(reorderSubset(allFavorites, favorites, from, to)),
   )
 
   return (
@@ -342,7 +371,10 @@ export default function SidebarPanel(): React.ReactElement {
                 <>
                   <SidebarGroupLabel>{currentView.label}</SidebarGroupLabel>
                   {visibleRoutes.map((route) => {
-                    const isFavorite = favoriteRouteIds.includes(route.to)
+                    const isFavorite = allFavorites.some(
+                      (favorite) =>
+                        favorite.kind === "route" && favorite.to === route.to,
+                    )
 
                     return (
                       <SidebarMenuItem key={route.to}>
@@ -375,48 +407,46 @@ export default function SidebarPanel(): React.ReactElement {
             <SidebarGroup className="mt-2 pt-0">
               <SidebarMenu>
                 <SidebarGroupLabel>Favorites</SidebarGroupLabel>
-                {favoriteRoutes.map((route) => (
-                  <SidebarMenuItem key={route.to}>
-                    <SidebarMenuButton asChild>
+                {favorites.map((favorite) => {
+                  const { label, linkProps, onRemove } =
+                    favorite.kind === "route"
+                      ? (() => {
+                          const route = allVisibleRoutes.find(
+                            (r) => r.to === favorite.to,
+                          )!
+                          return {
+                            label: route.label,
+                            linkProps: {
+                              ...route,
+                              params: { accountId },
+                              activeOptions: { exact: isCurrentPageFavorited },
+                            },
+                            onRemove: () => toggleFavoriteRoute(favorite.to),
+                          }
+                        })()
+                      : {
+                          label: favorite.label,
+                          linkProps: { to: favorite.path },
+                          onRemove: () => toggleFavoritePage(favorite),
+                        }
+
+                  return (
+                    <FavoriteReorderItem
+                      key={favoriteKey(favorite)}
+                      handleProps={favoritesReorder.handleProps}
+                      onRemove={onRemove}
+                    >
                       <Link
-                        {...route}
-                        params={{ accountId }}
-                        activeOptions={{ exact: isCurrentPageFavorited }}
+                        {...linkProps}
                         activeProps={{
                           className: "bg-background-2 text-content-loud",
                         }}
                       >
-                        {route.label}
+                        <span>{label}</span>
                       </Link>
-                    </SidebarMenuButton>
-                    <SidebarMenuAction
-                      showOnHover
-                      onClick={() => toggleFavoriteRoute(route.to)}
-                    >
-                      <StarOff />
-                    </SidebarMenuAction>
-                  </SidebarMenuItem>
-                ))}
-                {favoritePages.map((page) => (
-                  <SidebarMenuItem key={page.path}>
-                    <SidebarMenuButton asChild>
-                      <Link
-                        to={page.path}
-                        activeProps={{
-                          className: "bg-background-2 text-content-loud",
-                        }}
-                      >
-                        <span>{page.label}</span>
-                      </Link>
-                    </SidebarMenuButton>
-                    <SidebarMenuAction
-                      showOnHover
-                      onClick={() => toggleFavoritePage(page)}
-                    >
-                      <StarOff />
-                    </SidebarMenuAction>
-                  </SidebarMenuItem>
-                ))}
+                    </FavoriteReorderItem>
+                  )
+                })}
               </SidebarMenu>
             </SidebarGroup>
           )}

--- a/src/hooks/use-favorites.ts
+++ b/src/hooks/use-favorites.ts
@@ -8,6 +8,10 @@ export interface FavoritePage {
   accountId: string
 }
 
+export type Favorite =
+  | { kind: "route"; to: string }
+  | ({ kind: "page" } & FavoritePage)
+
 function createFavoritesStore<T>(
   storageKey: string,
   isValid: (value: unknown) => value is T,
@@ -60,10 +64,14 @@ function createFavoritesStore<T>(
     commit(next)
   }
 
+  const reorder = (next: ReadonlyArray<T>): void => {
+    commit(next)
+  }
+
   const useFavorites = (): ReadonlyArray<T> =>
     useSyncExternalStore(subscribe, getSnapshot)
 
-  return { useFavorites, toggle, update }
+  return { useFavorites, toggle, update, reorder }
 }
 
 const isString = (value: unknown): value is string => typeof value === "string"
@@ -78,6 +86,17 @@ const isFavoritePage = (value: unknown): value is FavoritePage => {
   )
 }
 
+const isFavorite = (value: unknown): value is Favorite => {
+  if (typeof value !== "object" || value === null) return false
+  const favorite = value as Partial<Favorite>
+  if (favorite.kind === "route") return typeof favorite.to === "string"
+  if (favorite.kind === "page") return isFavoritePage(value)
+  return false
+}
+
+export const favoriteKey = (favorite: Favorite): string =>
+  favorite.kind === "route" ? `route:${favorite.to}` : `page:${favorite.path}`
+
 const identity = (id: string): string => id
 
 const commandFavorites = createFavoritesStore(
@@ -85,30 +104,30 @@ const commandFavorites = createFavoritesStore(
   isString,
   identity,
 )
-const routeFavorites = createFavoritesStore(
-  "keygen.route.favorites.v1",
-  isString,
-  identity,
-)
-const pageFavorites = createFavoritesStore(
-  "keygen.page.favorites.v1",
-  isFavoritePage,
-  (page) => page.path,
+const favorites = createFavoritesStore(
+  "keygen.favorites.v2",
+  isFavorite,
+  favoriteKey,
 )
 
 export const useFavoriteCommands = commandFavorites.useFavorites
 export const toggleFavoriteCommand = commandFavorites.toggle
+export const reorderFavoriteCommands = commandFavorites.reorder
 
-export const useFavoriteRoutes = routeFavorites.useFavorites
-export const toggleFavoriteRoute = routeFavorites.toggle
+export const useFavorites = favorites.useFavorites
+export const reorderFavorites = favorites.reorder
 
-export const useFavoritePages = pageFavorites.useFavorites
-export const toggleFavoritePage = pageFavorites.toggle
+export const toggleFavoriteRoute = (to: string): void =>
+  favorites.toggle({ kind: "route", to })
+
+export const toggleFavoritePage = (page: FavoritePage): void =>
+  favorites.toggle({ kind: "page", ...page })
 
 export function useSyncFavoritePageLabel(label?: string | null): void {
   useEffect(() => {
     if (!label) return
-    pageFavorites.update({
+    favorites.update({
+      kind: "page",
       path: window.location.pathname,
       label,
       accountId: keygen.config.id,

--- a/src/hooks/use-list-reorder.ts
+++ b/src/hooks/use-list-reorder.ts
@@ -1,0 +1,115 @@
+import { useRef } from "react"
+
+interface ActiveDrag {
+  pointerId: number
+  startY: number
+  from: number
+  target: number
+  moved: boolean
+  rows: HTMLElement[]
+  stride: number
+}
+
+function moveItem<T>(items: ReadonlyArray<T>, from: number, to: number): T[] {
+  const next = [...items]
+  const [moved] = next.splice(from, 1)
+  next.splice(to, 0, moved)
+  return next
+}
+
+export function reorderSubset<T>(
+  all: ReadonlyArray<T>,
+  subset: ReadonlyArray<T>,
+  from: number,
+  to: number,
+): T[] {
+  const queue = moveItem(subset, from, to)
+  const visible = new Set(subset)
+  return all.map((item) => (visible.has(item) ? queue.shift()! : item))
+}
+
+export function useListReorder(onReorder: (from: number, to: number) => void) {
+  const dragRef = useRef<ActiveDrag | null>(null)
+
+  const settle = (commit: boolean) => {
+    const drag = dragRef.current
+    if (!drag) return
+    dragRef.current = null
+    for (const row of drag.rows) {
+      row.style.transform = ""
+      row.style.transition = ""
+      row.style.zIndex = ""
+      row.style.position = ""
+    }
+    if (commit && drag.moved && drag.target !== drag.from) {
+      onReorder(drag.from, drag.target)
+    }
+  }
+
+  const handleProps = {
+    onPointerDown: (event: React.PointerEvent<HTMLElement>) => {
+      if (event.button !== 0 || !event.isPrimary) return
+      const item = event.currentTarget.closest<HTMLElement>(
+        "[data-reorder-item]",
+      )
+      const list = item?.parentElement
+      if (!item || !list) return
+      const rows = Array.from(
+        list.querySelectorAll<HTMLElement>(":scope > [data-reorder-item]"),
+      )
+      if (rows.length < 2) return
+      event.preventDefault()
+      event.currentTarget.setPointerCapture(event.pointerId)
+      const from = rows.indexOf(item)
+      dragRef.current = {
+        pointerId: event.pointerId,
+        startY: event.clientY,
+        from,
+        target: from,
+        moved: false,
+        rows,
+        stride:
+          rows[1].getBoundingClientRect().top -
+          rows[0].getBoundingClientRect().top,
+      }
+    },
+    onPointerMove: (event: React.PointerEvent<HTMLElement>) => {
+      const drag = dragRef.current
+      if (!drag || event.pointerId !== drag.pointerId) return
+      const offset = event.clientY - drag.startY
+      if (!drag.moved && Math.abs(offset) < 3) return
+      drag.moved = true
+      drag.target = Math.min(
+        drag.rows.length - 1,
+        Math.max(0, drag.from + Math.round(offset / drag.stride)),
+      )
+      const dragged = drag.rows[drag.from]
+      dragged.style.transform = `translateY(${offset}px)`
+      dragged.style.zIndex = "10"
+      dragged.style.position = "relative"
+      drag.rows.forEach((row, i) => {
+        if (i === drag.from) return
+        const shift =
+          i > drag.from && i <= drag.target
+            ? -drag.stride
+            : i < drag.from && i >= drag.target
+              ? drag.stride
+              : 0
+        row.style.transition = "transform 150ms"
+        row.style.transform = shift ? `translateY(${shift}px)` : ""
+      })
+    },
+    onPointerUp: () => settle(true),
+    onPointerCancel: () => settle(false),
+    onClick: (event: React.MouseEvent<HTMLElement>) => {
+      event.stopPropagation()
+    },
+    onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => {
+      if (event.key === "Enter" || event.key === " ") event.stopPropagation()
+    },
+  }
+
+  const isDragging = () => dragRef.current?.moved ?? false
+
+  return { handleProps, isDragging }
+}


### PR DESCRIPTION
Follow-up to #349. Allows users to re-order their favorites in both the sidebar and the command palette.

<img width="400" src="https://github.com/user-attachments/assets/871f0276-2745-4923-b288-12e358653cbb" />