### PR TITLE
Add CSV export to license expiration heatmap

### DIFF
--- a/src/components/analytics/license-expiration-heatmap.tsx
+++ b/src/components/analytics/license-expiration-heatmap.tsx
@@ -20,12 +20,12 @@ import { Skeleton } from "@/components/ui/skeleton"
 
 import * as keygen from "@/keygen"
 
-import { cn } from "@/lib/utils"
 import {
   toDisplayRow,
   getTemperatureColor,
   buildExpirationHeatmap,
 } from "@/lib/analytics"
+import { cn } from "@/lib/utils"
 import { truncator } from "@/lib/truncate"
 
 import { License } from "@/types/licenses"
@@ -33,6 +33,7 @@ import { ExpirationHeatmapEntry } from "@/types/analytics"
 
 import {
   useExpirationsHeatmap,
+  useExportExpiringLicenses,
   useLicensesExpiringOn,
 } from "@/queries/analytics"
 
@@ -94,6 +95,18 @@ export default function LicenseExpirationHeatmap({
     () => buildExpirationHeatmap(cells, { start, end }),
     [cells, start, end],
   )
+
+  const exportLicenses = useExportExpiringLicenses()
+
+  const handleExport = () => {
+    const exportStart = format(new Date(), "yyyy-MM-dd")
+    const exportEnd = format(addDays(new Date(), rangeDays - 1), "yyyy-MM-dd")
+
+    exportLicenses.mutate({
+      before: `${exportEnd}T23:59:59.999Z`,
+      filename: `licenses-expiring-${exportStart}-to-${exportEnd}.csv`,
+    })
+  }
 
   const [expanded, setExpanded] = useState(false)
 
@@ -196,17 +209,28 @@ export default function LicenseExpirationHeatmap({
       title="License expirations"
       className="rounded-md md:w-full"
       action={
-        <GoToButton
-          path={`/$accountId/app/licenses`}
-          params={{
-            accountId: keygen.config.id,
-          }}
-          search={{
-            expires: { within: expirationWindow },
-          }}
-          label="View all"
-          className="[&_.group:hover_svg]:text-primary [&_button]:text-content-normal [&_button]:hover:text-content-loud [&_svg]:text-content-normal"
-        />
+        <div className="flex items-center gap-3">
+          <Button
+            variant="link"
+            size="link"
+            onClick={handleExport}
+            disabled={exportLicenses.isPending}
+            className="text-content-normal hover:text-content-loud"
+          >
+            {exportLicenses.isPending ? "Exporting…" : "Export CSV"}
+          </Button>
+          <GoToButton
+            path={`/$accountId/app/licenses`}
+            params={{
+              accountId: keygen.config.id,
+            }}
+            search={{
+              expires: { within: expirationWindow },
+            }}
+            label="View all"
+            className="[&_.group:hover_svg]:text-primary [&_button]:text-content-normal [&_button]:hover:text-content-loud [&_svg]:text-content-normal"
+          />
+        </div>
       }
     >
       {!enabled || isLoading ? (

--- a/src/components/analytics/license-expiration-heatmap.tsx
+++ b/src/components/analytics/license-expiration-heatmap.tsx
@@ -12,11 +12,16 @@ import {
   startOfMonth,
   getDaysInMonth,
 } from "date-fns"
-import { ChevronLeft, ChevronRight } from "lucide-react"
+import { ChevronLeft, ChevronRight, EllipsisVertical } from "lucide-react"
 
-import * as Skeletons from "@/components/skeletons"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 
 import * as keygen from "@/keygen"
 
@@ -41,6 +46,7 @@ import { useMobile } from "@/hooks/use-mobile"
 import { useCursorFollowTooltip } from "@/hooks/use-cursor-follow-tooltip"
 
 import * as Motion from "@/components/motion"
+import * as Skeletons from "@/components/skeletons"
 import GoToButton from "@/components/go-to-button"
 import CursorTooltip from "@/components/cursor-tooltip"
 import Card from "./card"
@@ -210,15 +216,6 @@ export default function LicenseExpirationHeatmap({
       className="rounded-md md:w-full"
       action={
         <div className="flex items-center gap-3">
-          <Button
-            variant="link"
-            size="link"
-            onClick={handleExport}
-            disabled={exportLicenses.isPending}
-            className="text-content-normal hover:text-content-loud"
-          >
-            {exportLicenses.isPending ? "Exporting…" : "Export CSV"}
-          </Button>
           <GoToButton
             path={`/$accountId/app/licenses`}
             params={{
@@ -230,6 +227,22 @@ export default function LicenseExpirationHeatmap({
             label="View all"
             className="[&_.group:hover_svg]:text-primary [&_button]:text-content-normal [&_button]:hover:text-content-loud [&_svg]:text-content-normal"
           />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="link"
+                variant="ghost"
+                className="rounded-sm px-1 text-content-subdued hover:text-content-loud"
+              >
+                <EllipsisVertical className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={handleExport}>
+                Export as CSV
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       }
     >

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,0 +1,59 @@
+import { License } from "@/types/licenses"
+
+const QUOTED_CHARS = /[",\n\r]/
+const FORMULA_PREFIX = /^[=+\-@\t\r]/
+
+function toCsvCell(value: string | null | undefined): string {
+  if (value == null || value === "") {
+    return ""
+  }
+
+  const guarded = FORMULA_PREFIX.test(value) ? `'${value}` : value
+  if (QUOTED_CHARS.test(guarded)) {
+    return `"${guarded.replace(/"/g, '""')}"`
+  }
+
+  return guarded
+}
+
+export function toCsv(
+  headers: readonly string[],
+  rows: readonly (string | null | undefined)[][],
+): string {
+  return [headers, ...rows]
+    .map((row) => row.map(toCsvCell).join(","))
+    .join("\r\n")
+}
+
+const LICENSE_COLUMNS: readonly (readonly [
+  string,
+  (license: License) => string | null,
+])[] = [
+  ["id", (license) => license.id],
+  ["name", (license) => license.attributes.name],
+  ["key", (license) => license.attributes.key],
+  ["status", (license) => license.attributes.status],
+  ["policy", (license) => license.relationships.policy?.data?.id ?? null],
+  ["product", (license) => license.relationships.product?.data?.id ?? null],
+  ["owner", (license) => license.relationships.owner?.data?.id ?? null],
+  ["expiry", (license) => license.attributes.expiry],
+  ["created", (license) => license.attributes.created],
+  [
+    "metadata",
+    (license) =>
+      Object.keys(license.attributes.metadata).length
+        ? JSON.stringify(license.attributes.metadata)
+        : null,
+  ],
+]
+
+export function licensesToCsv(licenses: readonly License[]): string {
+  const sorted = [...licenses].sort((a, b) =>
+    (a.attributes.expiry ?? "").localeCompare(b.attributes.expiry ?? ""),
+  )
+
+  return toCsv(
+    LICENSE_COLUMNS.map(([header]) => header),
+    sorted.map((license) => LICENSE_COLUMNS.map(([, value]) => value(license))),
+  )
+}

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,3 +1,5 @@
+const UTF8_BOM = "\uFEFF"
+
 export function downloadBlob(
   content: string,
   filename: string,
@@ -14,4 +16,8 @@ export function downloadBlob(
   document.body.removeChild(link)
 
   setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
+export function downloadCsv(content: string, filename: string) {
+  downloadBlob(`${UTF8_BOM}${content}`, filename, "text/csv;charset=utf-8")
 }

--- a/src/queries/analytics.ts
+++ b/src/queries/analytics.ts
@@ -1,9 +1,15 @@
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useMutation } from "@tanstack/react-query"
 
 import { useEnvironment } from "@/hooks/use-environment"
+import { cursorFromLink } from "@/hooks/use-cursors"
+
+import { licensesToCsv } from "@/lib/csv"
+import { downloadCsv } from "@/lib/download"
+import { toast } from "@/lib/toast"
 
 import { APIError } from "@/types/api"
 import { DateRangeOptions } from "@/types/analytics"
+import { License } from "@/types/licenses"
 
 import * as keygen from "@/keygen"
 
@@ -220,6 +226,58 @@ export function useLeaderboard(
     enabled: enabled ?? true,
     retry: false,
   })
+}
+
+const EXPORT_PAGE_SIZE = 100
+
+export function useExportExpiringLicenses() {
+  const { code } = useEnvironment()
+
+  return useMutation<License[], APIError, { before: string; filename: string }>(
+    {
+      mutationFn: async ({ before }) => {
+        const licenses: License[] = []
+        let cursor: string | null = null
+
+        do {
+          const response = await keygen.licenses.list({
+            pageSize: EXPORT_PAGE_SIZE,
+            pageCursor: cursor,
+            filters: { expires: { before } },
+            environment: code,
+          })
+
+          if (response.errors) {
+            throw new APIError(response.errors[0])
+          }
+
+          licenses.push(...(response.data ?? []))
+          cursor = cursorFromLink(response.links?.next)
+        } while (cursor)
+
+        return licenses
+      },
+      onSuccess: (licenses, { filename }) => {
+        if (!licenses.length) {
+          toast({
+            message: "No licenses expiring in this range",
+            variant: "warning",
+          })
+          return
+        }
+
+        downloadCsv(licensesToCsv(licenses), filename)
+
+        toast({
+          message: `Exported ${licenses.length} ${licenses.length === 1 ? "license" : "licenses"}`,
+          variant: "success",
+        })
+      },
+      onError: () => {
+        toast({ message: "Failed to export licenses", variant: "error" })
+      },
+    },
+  )
 }
 
 export function useLicensesExpiringOn(


### PR DESCRIPTION
Closes #348. Adds an actions dropdown button to the license expiration heatmap with (currently) a single option to export expiring licenses as a CSV.

<img width="700" src="https://github.com/user-attachments/assets/cb7db8a9-0fcc-4562-88a2-0c431c10d2bc" />
<img width="700" src="https://github.com/user-attachments/assets/fc99f591-9d69-4efe-8963-fb98637258fe" />
