### PR TITLE
fix: remove tooltip delay override on rail nav icons

### DIFF
--- a/src/components/sidebar/panel.tsx
+++ b/src/components/sidebar/panel.tsx
@@ -232,7 +232,7 @@ export default function SidebarPanel(): React.ReactElement {
         >
           <RailGroup className="flex flex-col items-center">
             {visibleViews.map((view) => (
-              <Tooltip key={view.id} delayDuration={300}>
+              <Tooltip key={view.id}>
                 <TooltipTrigger asChild>
                   <Button
                     variant="rail"


### PR DESCRIPTION
Fixes #341 

## Problem
Tooltips on the main rail nav icons had a noticeable delay before appearing, since the `Tooltip` for each rail icon explicitly set `delayDuration={300}` — overriding the app's default `TooltipProvider delayDuration={0}`. Every other tooltip in the app already opens instantly; this was the one exception.

## Fix
Removed the `delayDuration={300}` override in `src/components/sidebar/panel.tsx` so the rail nav tooltips inherit the app-wide 0ms default, matching the rest of the UI.

https://github.com/user-attachments/assets/48aa8abb-e4b0-4970-a589-2bc1a59c8dde

